### PR TITLE
ENG-18020: System test error: [TaskManager] TASK: java.lang.IllegalArgumentException

### DIFF
--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -1868,9 +1868,10 @@ public final class TaskManager {
          */
         void setDynamicThreadCount(int threadCount) {
             if (m_dynamicThreadCount) {
-                if (log.isTraceEnabled()) {
-                    log.trace("MANAGER: Updating dynamic thread count to " + threadCount + " on " + m_name);
-                }
+//                if (log.isTraceEnabled()) {
+//                    log.trace("MANAGER: Updating dynamic thread count to " + threadCount + " on " + m_name);
+//                }
+                log.warn("MANAGER: Updating dynamic thread count to " + threadCount + " on " + m_name);
                 setCorePoolSize(threadCount);
             }
         }

--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -1879,6 +1879,7 @@ public final class TaskManager {
             if (threadCount != m_rawExecutor.getCorePoolSize()) {
                 // In JDK>=9, setCorePoolSize(poolSize) requires the poolSize <= MaximumPoolSize
                 // and setMaximumPoolSize(poolSize) requires the poolSize >= CorePoolSize.
+                // note: the order of the statements is important.
                 if (m_rawExecutor.getMaximumPoolSize() >= threadCount) {
                     m_rawExecutor.setCorePoolSize(threadCount);
                     m_rawExecutor.setMaximumPoolSize(Math.max(threadCount, 1));

--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -1878,6 +1878,7 @@ public final class TaskManager {
 
         private void setCorePoolSize(int threadCount) {
             if (threadCount != m_rawExecutor.getCorePoolSize()) {
+                log.warn("MANAGER: Setting CorePoolSize to " + threadCount + " on " + m_name);
                 m_rawExecutor.setCorePoolSize(threadCount);
                 m_rawExecutor.setMaximumPoolSize(Math.max(threadCount, 1));
             }

--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -1878,9 +1878,9 @@ public final class TaskManager {
 
         private void setCorePoolSize(int threadCount) {
             if (threadCount != m_rawExecutor.getCorePoolSize()) {
-                log.warn("MANAGER: Setting CorePoolSize to " + threadCount + " on " + m_name);
-                m_rawExecutor.setCorePoolSize(threadCount);
+                log.warn("MANAGER: Setting CorePoolSize to " + threadCount + " on " + m_name + " max size: " + m_rawExecutor.getMaximumPoolSize());
                 m_rawExecutor.setMaximumPoolSize(Math.max(threadCount, 1));
+                m_rawExecutor.setCorePoolSize(threadCount);
             }
         }
     }


### PR DESCRIPTION
This is because we try to set a CorePoolSize that is larger than the maximum pool size.
In Java 8 this is allowed but in Java >= 9, this will throw a java.lang.IllegalArgumentException. See the discussion [here](https://bugs.openjdk.java.net/browse/JDK-7153400). The system test is running in Java 11 and hit the exception(I am surprised). 

Fix all places including `TaskManager`  that uses `setCorePoolSize`.