### PR TITLE
ENG-17091 The right fix

### DIFF
--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -24,8 +24,6 @@
 
 using namespace voltdb;
 
-char const* empty_string = "";
-
 inline ThreadLocalPool::Sized* asSizedObject(char* stringPtr) {
    return reinterpret_cast<ThreadLocalPool::Sized*>(stringPtr);
 }
@@ -44,19 +42,15 @@ int32_t StringRef::getObjectLength() const {
 
 const char* StringRef::getObject(int32_t& lengthOut) const {
     /*/ enable to debug
-    std::cout << this << " DEBUG: getting [" << asSizedObject(m_stringPtr)->m_size << "]"
-              << std::string(asSizedObject(m_stringPtr)->m_data,
-                             asSizedObject(m_stringPtr)->m_size)
-              << std::endl;
+      std::cout << this << " DEBUG: getting [" << asSizedObject(m_stringPtr)->m_size << "]"
+      << std::string(asSizedObject(m_stringPtr)->m_data,
+      asSizedObject(m_stringPtr)->m_size)
+      << std::endl;
     // */
     auto const* sized = asSizedObject(m_stringPtr);
     lengthOut = sized->m_size;
-    if (lengthOut > 0) {
-        return sized->m_data;
-    } else {
-        lengthOut = 0;
-        return empty_string;
-    }
+    vassert(lengthOut >= 0);
+    return sized->m_data;
 }
 
 int32_t StringRef::getAllocatedSizeInPersistentStorage() const {


### PR DESCRIPTION
When fixing ENG-15734 at commit
ae2dc9e9f1511130f54b3be1ef0c63a298eddd67,
I accidentally introduced this stupid error, by adding unnecessary
partial-index check condition into a branch of persistent table update
tuple step;

And then fixed in the wrong way at
0ef6fc6a7bebd8e8cd5ef8eb24b8286ab60b3057 by introducing empty string as
a special instance of StringRef object, that partially masked the
original reproducer when running on a single host.

The reason that adding this additional check fails the reproducer is that it skips the first UPDATE statement when the tuple gets updated, so the old index tuple that should get updated together now points to recycled data (Yes, recycled in C++!), and de-referencing StringRef from garbage simply gives garbage back.