### PR TITLE
Massive refactories on EE index

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -188,7 +188,7 @@ std::string NValue::debug() const {
     return buffer.str();
 }
 
-inline char const* NValue::getObject_withoutNull(int32_t& lengthOut) const {
+char const* NValue::getObject_withoutNull(int32_t& lengthOut) const {
     if (getSourceInlined()) {
         const char* storage = *reinterpret_cast<const char* const*>(m_data);
         lengthOut = storage[0]; // one-byte length prefix for inline

--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -151,14 +151,15 @@ std::string NValue::debug() const {
         case ValueType::tVARCHAR:
           ptr = getObject_withoutNull(length);
           out_val = std::string(ptr, length);
-          buffer << "[" << length << "]";
-          buffer << "\"" << out_val << "\"[@" << static_cast<const void*>(ptr) << "]";
+          buffer << "[" << length << "]"
+              << "\"" << out_val << "\"[@" << static_cast<const void*>(ptr) << "]"
+              << (getSourceInlined() ? "inlined" : "not inlined");
           break;
         case ValueType::tVARBINARY:
           ptr = getObject_withoutNull(length);
           out_val = std::string(ptr, length);
-          buffer << "[" << length << "]";
-          buffer << "-bin[@" << static_cast<const void*>(ptr) << "]";
+          buffer << "[" << length << "]"
+              << "-bin[@" << static_cast<const void*>(ptr) << "]";
           break;
         case ValueType::tDECIMAL:
           buffer << createStringFromDecimal();

--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -152,14 +152,14 @@ std::string NValue::debug() const {
           ptr = getObject_withoutNull(length);
           out_val = std::string(ptr, length);
           buffer << "[" << length << "]"
-              << "\"" << out_val << "\"[@" << static_cast<const void*>(ptr) << "]"
+              << "\"" << out_val << "\"[*" << static_cast<const void*>(ptr) << "]"
               << (getSourceInlined() ? "inlined" : "not inlined");
           break;
         case ValueType::tVARBINARY:
           ptr = getObject_withoutNull(length);
           out_val = std::string(ptr, length);
           buffer << "[" << length << "]"
-              << "-bin[@" << static_cast<const void*>(ptr) << "]";
+              << "-bin[*" << static_cast<const void*>(ptr) << "]";
           break;
         case ValueType::tDECIMAL:
           buffer << createStringFromDecimal();

--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -195,9 +195,6 @@ inline char const* NValue::getObject_withoutNull(int32_t& lengthOut) const {
         return storage + SHORT_OBJECT_LENGTHLENGTH; // skip prefix.
     } else {
         char const* retVal = getObjectPointer()->getObject(lengthOut);
-//        cout << "[" << lengthOut << "]"
-//            << "\"" << string(retVal, lengthOut) << "\"[@" << static_cast<const void*>(retVal) << "]"
-//            << endl;
         vassert(lengthOut >= 0);
         return retVal;
     }

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -666,9 +666,6 @@ class NValue {
 
     static inline int32_t getCharLength(const char *valueChars, const size_t length) {
         printf("getCharLength(): %p\n", valueChars);
-        if (valueChars - StringRef::EMPTY_STRING == 0x4) {             // hack: hack!!
-            return 0;
-        }
         // very efficient code to count characters in UTF string and ASCII string
         int32_t j = 0;
         size_t i = length;
@@ -723,7 +720,7 @@ class NValue {
         if (isNull()) {
             return 0;
         }
-        vassert( ! getSourceInlined());
+        vassert(! getSourceInlined());
         const StringRef* sref = getObjectPointer();
         return sref->getAllocatedSizeInPersistentStorage();
     }
@@ -894,7 +891,7 @@ private:
     }
 
     const StringRef* getObjectPointer() const {
-       return *reinterpret_cast<const StringRef* const*>(m_data);
+       return *reinterpret_cast<StringRef const*const*>(m_data);
     }
 
     StringRef* getObjectPointer() {
@@ -909,17 +906,7 @@ private:
         }
     }
 
-    const char* getObject_withoutNull(int32_t& lengthOut) const {
-        if (getSourceInlined()) {
-            const char* storage = *reinterpret_cast<const char* const*>(m_data);
-            lengthOut = storage[0]; // one-byte length prefix for inline
-            return storage + SHORT_OBJECT_LENGTHLENGTH; // skip prefix.
-        } else {
-           char const* retVal = getObjectPointer()->getObject(lengthOut);
-           vassert(lengthOut >= 0);
-           return retVal;
-        }
-    }
+    const char* getObject_withoutNull(int32_t& lengthOut) const;
 
     // getters
     const int8_t& getTinyInt() const {
@@ -1711,9 +1698,6 @@ private:
 //        printf("Calling validVarcharSize(?, %lu, %d): %s\n", length, maxLength,
 //                StackTrace::stringStackTrace(". ").c_str());
 
-        if (valueChars - StringRef::EMPTY_STRING == 0x4) {     // Hack! hack!
-            return true;
-        }
         int32_t min_continuation_bytes = static_cast<int32_t>(length) - maxLength;
         if (min_continuation_bytes <= 0) {
             return true;
@@ -2789,9 +2773,6 @@ inline NValue NValue::initFromTupleStorage(const void *storage, ValueType type, 
                     retval.setNullObjectPointer();
                 } else {
                     retval.setObjectPointer(sref);
-                    if (sref->getObjectLength() > 800) {
-                        printf("!!!! %p : %p ~~ %p\n", sref, &retval, StringRef::EMPTY_STRING);
-                    }
                 }
                 break;
             }

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -665,7 +665,6 @@ class NValue {
     static int64_t parseTimestampString(const std::string &txt);
 
     static inline int32_t getCharLength(const char *valueChars, const size_t length) {
-        printf("getCharLength(): %p\n", valueChars);
         // very efficient code to count characters in UTF string and ASCII string
         int32_t j = 0;
         size_t i = length;
@@ -1695,9 +1694,6 @@ private:
     }
 
     static inline bool validVarcharSize(const char *valueChars, size_t length, int32_t maxLength) {
-//        printf("Calling validVarcharSize(?, %lu, %d): %s\n", length, maxLength,
-//                StackTrace::stringStackTrace(". ").c_str());
-
         int32_t min_continuation_bytes = static_cast<int32_t>(length) - maxLength;
         if (min_continuation_bytes <= 0) {
             return true;
@@ -1756,7 +1752,6 @@ private:
                          msg, SQLException::TYPE_VAR_LENGTH_MISMATCH);
                 }
              } else if (!validVarcharSize(ptr, objLength, maxLength)) {
-                 printf("!!!! Too late ????\n");
                 const int32_t charLength = getCharLength(ptr, objLength);
                 char msg[1024];
                 std::string inputValue;

--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -55,7 +55,6 @@ const char* StringRef::getObject(int32_t& lengthOut) const {
 
 int32_t StringRef::getAllocatedSizeInPersistentStorage() const {
     // The CompactingPool allocated a chunk of this size for storage.
-    printf("getAllocatdSizeInPersistentStorage(): '%s'\n", m_stringPtr); fflush(stdout);
     int32_t const alloc_size =
         ThreadLocalPool::getAllocationSizeForRelocatable(asSizedObject(m_stringPtr));
     //cout << "Pool allocation size: " << alloc_size << endl;
@@ -115,7 +114,7 @@ StringRef* StringRef::create(int32_t sz, const char* source, Pool* tempPool) {
     if (tempPool) {
         result = new (tempPool->allocate(sizeof(StringRef)+sizeof(ThreadLocalPool::Sized) + sz))
             StringRef(tempPool, sz);
-    } else if (sz > 0) {
+    } else {
 #ifdef MEMCHECK
         result = new StringRef(sz);
 #else

--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -125,9 +125,6 @@ StringRef* StringRef::create(int32_t sz, const char* source, Pool* tempPool) {
     if (source && sz > 0) {
         ::memcpy(result->getObjectValue(), source, sz);
     }
-//    if (sz == 0) {
-//        printf("Empty string (1) at %p\n", result);
-//    }
     return result;
 }
 
@@ -140,17 +137,11 @@ StringRef* StringRef::create(int32_t sz, const char* source, LargeTempTableBlock
     if (source && sz > 0) {
         ::memcpy(result->getObjectValue(), source, sz);
     }
-//    if (sz == 0) {
-//        printf("Empty string (2) at %p\n", result);
-//    }
     return result;
 }
 
 void StringRef::relocate(std::ptrdiff_t offset) {
     m_stringPtr += offset;
-//    if (getObjectLength() == 0) {
-//        printf("Relocating empty string %p -> %p\n", m_stringPtr - offset, m_stringPtr);
-//    }
 }
 
 // The destroy method keeps this from getting run on temporary strings.

--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -125,6 +125,9 @@ StringRef* StringRef::create(int32_t sz, const char* source, Pool* tempPool) {
     if (source && sz > 0) {
         ::memcpy(result->getObjectValue(), source, sz);
     }
+//    if (sz == 0) {
+//        printf("Empty string (1) at %p\n", result);
+//    }
     return result;
 }
 
@@ -134,15 +137,20 @@ StringRef* StringRef::create(int32_t sz, const char* source, LargeTempTableBlock
     result = new (lttBlock->allocate(sizeof(StringRef)+sizeof(ThreadLocalPool::Sized) + sz))
         StringRef(nullptr, sz);
 
-    if (source) {
+    if (source && sz > 0) {
         ::memcpy(result->getObjectValue(), source, sz);
     }
+//    if (sz == 0) {
+//        printf("Empty string (2) at %p\n", result);
+//    }
     return result;
-
 }
 
 void StringRef::relocate(std::ptrdiff_t offset) {
     m_stringPtr += offset;
+//    if (getObjectLength() == 0) {
+//        printf("Relocating empty string %p -> %p\n", m_stringPtr - offset, m_stringPtr);
+//    }
 }
 
 // The destroy method keeps this from getting run on temporary strings.

--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -25,20 +25,25 @@
 using namespace voltdb;
 
 inline ThreadLocalPool::Sized* asSizedObject(char* stringPtr) {
-    printf("asSizedObject(%p); empty string(%p)\n", stringPtr, StringRef::EMPTY_STRING);
+   /*printf("asSizedObject(%p); empty string(%p) : %s\n",
+           stringPtr, StringRef::EMPTY_STRING, StackTrace::stringStackTrace("/ ").c_str());*/
    return reinterpret_cast<ThreadLocalPool::Sized*>(stringPtr);
 }
 
 char* StringRef::getObjectValue() {
-   return asSizedObject(m_stringPtr)->m_data;
+    return m_stringPtr == EMPTY_STRING ?
+        const_cast<char*>(EMPTY_STRING) :
+        asSizedObject(m_stringPtr)->m_data;
 }
 
 const char* StringRef::getObjectValue() const {
-   return asSizedObject(m_stringPtr)->m_data;
+    return m_stringPtr == EMPTY_STRING ?
+        EMPTY_STRING : asSizedObject(m_stringPtr)->m_data;
 }
 
 int32_t StringRef::getObjectLength() const {
-   return asSizedObject(m_stringPtr)->m_size;
+   return m_stringPtr == EMPTY_STRING ? 0 :
+       asSizedObject(m_stringPtr)->m_size;
 }
 
 const char* StringRef::getObject(int32_t& lengthOut) const {

--- a/src/ee/common/StringRef.h
+++ b/src/ee/common/StringRef.h
@@ -40,7 +40,6 @@ class StringRef {
 
     char* m_stringPtr;
 public:
-    static char const* EMPTY_STRING;
     // Only called from destroy and only for persistent strings.
     ~StringRef();
 

--- a/src/ee/common/StringRef.h
+++ b/src/ee/common/StringRef.h
@@ -34,14 +34,16 @@ class StringRef {
     StringRef(int32_t size);
     // Signature used internally for temporary strings
     StringRef(Pool* tempPool, int32_t size);
-    // Only called from destroy and only for persistent strings.
-    ~StringRef();
 
     // Only called from destroy and only for persistent strings.
     void operator delete(void* object);
 
     char* m_stringPtr;
 public:
+    static char const* EMPTY_STRING;
+    // Only called from destroy and only for persistent strings.
+    ~StringRef();
+
     /// Utility method to extract the amount of memory that was
     /// used by non-inline storage for this string/varbinary.
     /// Includes the size of the pooled StringRef object,

--- a/src/ee/common/StringRef.h
+++ b/src/ee/common/StringRef.h
@@ -39,9 +39,9 @@ class StringRef {
     void operator delete(void* object);
 
     char* m_stringPtr;
-public:
     // Only called from destroy and only for persistent strings.
     ~StringRef();
+public:
 
     /// Utility method to extract the amount of memory that was
     /// used by non-inline storage for this string/varbinary.

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -46,7 +46,6 @@ std::mutex ThreadLocalPool::s_sharedMemoryMutex;
 ThreadLocalPool::PartitionBucketMap_t ThreadLocalPool::s_allocations;
 #endif
 
-ThreadLocalPool::Sized const ThreadLocalPool::EMPTY_STRING(0);
 ThreadLocalPool::ThreadLocalPool() {
     if (m_key == nullptr) {
         m_allocated = new size_t(0);

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -46,6 +46,7 @@ std::mutex ThreadLocalPool::s_sharedMemoryMutex;
 ThreadLocalPool::PartitionBucketMap_t ThreadLocalPool::s_allocations;
 #endif
 
+ThreadLocalPool::Sized const ThreadLocalPool::EMPTY_STRING(0);
 ThreadLocalPool::ThreadLocalPool() {
     if (m_key == nullptr) {
         m_allocated = new size_t(0);

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -96,6 +96,7 @@ public:
         char m_data[0];
         Sized(int32_t requested_size) : m_size(requested_size) { }
     };
+    static Sized const EMPTY_STRING;
 
     // This needs to be >= the VoltType.MAX_VALUE_LENGTH defined in java, currently 1048576.
     // The rationale for making it any larger would be to allow calculating wider "temp"

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -96,7 +96,6 @@ public:
         char m_data[0];
         Sized(int32_t requested_size) : m_size(requested_size) { }
     };
-    static Sized const EMPTY_STRING;
 
     // This needs to be >= the VoltType.MAX_VALUE_LENGTH defined in java, currently 1048576.
     // The rationale for making it any larger would be to allow calculating wider "temp"

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -43,7 +43,6 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <cstdlib>
 #include <sstream>
 #include "common/tabletuple.h"
 

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -319,11 +319,14 @@ void TableTuple::serializeTo(SerializeOutput &output, const HiddenColumnFilter *
         }
     }
     // write the length of the tuple
-    output.writeIntAt(start, static_cast<int32_t>(output.position() - start - sizeof(int32_t)));
+    output.writeIntAt(start, output.position() - start - sizeof(int32_t));
 }
 
 bool TableTuple::equalsNoSchemaCheck(const TableTuple &other,
         const HiddenColumnFilter *hiddenColumnFilter) const {
+//    if (address() == other.address()) {
+//        return true;
+//    }
     for (int ii = 0; ii < m_schema->columnCount(); ii++) {
         const NValue lhs = getNValue(ii);
         const NValue rhs = other.getNValue(ii);

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -518,9 +518,6 @@ size_t TableTuple::maxExportSerializedColumnSizeCommon(int colIndex, bool isHidd
 
 bool TableTuple::equalsNoSchemaCheck(const TableTuple &other,
         const HiddenColumnFilter *hiddenColumnFilter) const {
-//    if (address() == other.address()) {
-//        return true;
-//    }
     for (int ii = 0; ii < m_schema->columnCount(); ii++) {
         const NValue lhs = getNValue(ii);
         const NValue rhs = other.getNValue(ii);

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -96,4 +96,318 @@ std::string TableTuple::debugNoHeader() const {
     return debug("");
 }
 
+/**
+ * Release to the heap any memory allocated for any uninlined columns.
+ */
+void TableTuple::freeObjectColumns() const {
+    const uint16_t unlinlinedColumnCount = m_schema->getUninlinedObjectColumnCount();
+    std::vector<char*> oldObjects;
+    for (int ii = 0; ii < unlinlinedColumnCount; ii++) {
+        int idx = m_schema->getUninlinedObjectColumnInfoIndex(ii);
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(idx);
+        char** dataPtr = reinterpret_cast<char**>(getWritableDataPtr(columnInfo));
+        oldObjects.push_back(*dataPtr);
+    }
+    NValue::freeObjectsFromTupleStorage(oldObjects);
+}
+
+/*
+ * With a persistent update the copy should only do an allocation for
+ * a string if the source and destination pointers are different.
+ */
+void TableTuple::copyForPersistentUpdate(const TableTuple &source,
+        std::vector<char*> &oldObjects, std::vector<char*> &newObjects) {
+    vassert(m_schema);
+    vassert(m_schema->equals(source.m_schema));
+    const int columnCount = m_schema->columnCount();
+    const uint16_t uninlineableObjectColumnCount = m_schema->getUninlinedObjectColumnCount();
+    /*
+     * The source and target tuple have the same policy WRT to
+     * inlining strings because a TableTuple used for updating a
+     * persistent table uses the same schema as the persistent table.
+     */
+    if (uninlineableObjectColumnCount > 0) {
+        uint16_t uninlineableObjectColumnIndex = 0;
+        uint16_t nextUninlineableObjectColumnInfoIndex = m_schema->getUninlinedObjectColumnInfoIndex(0);
+        /*
+         * Copy each column doing an allocation for string
+         * copies. Compare the source and target pointer to see if it
+         * is changed in this update. If it is changed then free the
+         * old string and copy/allocate the new one from the source.
+         */
+        for (uint16_t ii = 0; ii < columnCount; ii++) {
+            if (ii == nextUninlineableObjectColumnInfoIndex) {
+                const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(ii);
+                char *       *mPtr = reinterpret_cast<char**>(getWritableDataPtr(columnInfo));
+                const TupleSchema::ColumnInfo *sourceColumnInfo = source.getSchema()->getColumnInfo(ii);
+                char * const *oPtr = reinterpret_cast<char* const*>(source.getDataPtr(sourceColumnInfo));
+                if (*mPtr != *oPtr) {
+                    // Make a copy of the input string. Don't want to delete the old string
+                    // because it's either from the temp pool or persistently referenced elsewhere.
+                    oldObjects.push_back(*mPtr);
+                    // TODO: Here, it's known that the column is an object type, and yet
+                    // setNValueAllocateForObjectCopies is called to figure this all out again.
+                    setNValueAllocateForObjectCopies(ii, source.getNValue(ii));
+                    // Yes, uses the same old pointer as two statements ago to get a new value. Neat.
+                    newObjects.push_back(*mPtr);
+                }
+                uninlineableObjectColumnIndex++;
+                if (uninlineableObjectColumnIndex < uninlineableObjectColumnCount) {
+                    nextUninlineableObjectColumnInfoIndex =
+                      m_schema->getUninlinedObjectColumnInfoIndex(uninlineableObjectColumnIndex);
+                } else {
+                    // This is completely optional -- the value from here on has to be one that can't
+                    // be reached by incrementing from the current value.
+                    // Zero works, but then again so does the current value.
+                    nextUninlineableObjectColumnInfoIndex = 0;
+                }
+            } else {
+                // TODO: Here, it's known that the column value is some kind of scalar or inline, yet
+                // setNValueAllocateForObjectCopies is called to figure this all out again.
+                // This seriously complicated function is going to boil down to an incremental
+                // memcpy of a few more bytes of the tuple.
+                // Solution? It would likely be faster even for object-heavy tuples to work in three passes:
+                // 1) collect up all the "changed object pointer" offsets.
+                // 2) do the same wholesale tuple memcpy as in the no-objects "else" clause, below,
+                // 3) replace the object pointer at each "changed object pointer offset"
+                //    with a pointer to an object copy of its new referent.
+                setNValueAllocateForObjectCopies(ii, source.getNValue(ii));
+            }
+        }
+
+        // Copy any hidden columns that follow normal visible ones.
+        if (m_schema->hiddenColumnCount() > 0) {
+            // If we ever add support for uninlined hidden columns,
+            // we'll need to do update this code.
+            vassert(m_schema->getUninlinedObjectHiddenColumnCount() == 0);
+            ::memcpy(m_data + TUPLE_HEADER_SIZE + m_schema->offsetOfHiddenColumns(),
+                     source.m_data + TUPLE_HEADER_SIZE + m_schema->offsetOfHiddenColumns(),
+                     m_schema->lengthOfAllHiddenColumns());
+        }
+
+        // This obscure assignment is propagating the tuple flags rather than leaving it to the caller.
+        // TODO: It would be easier for the caller to simply set the values it wants upon return.
+        m_data[0] = source.m_data[0];
+    } else {
+        // copy the tuple flags and the data (all inline/scalars)
+        ::memcpy(m_data, source.m_data, m_schema->tupleLength() + TUPLE_HEADER_SIZE);
+    }
+}
+
+void TableTuple::deserializeFrom(SerializeInputBE& tupleIn, Pool* dataPool,
+        const LoadTableCaller &caller) {
+    vassert(m_schema);
+    vassert(m_data);
+
+    const int32_t columnCount  = m_schema->columnCount();
+    const int32_t hiddenColumnCount  = m_schema->hiddenColumnCount();
+    tupleIn.readInt();
+
+    // ENG-14346, we may throw SQLException because of a too-wide VARCHAR column.
+    // In some systems, the uninitialized StringRef* is not NULL, which may result in
+    // unexpected errors during cleanup.
+    // This can only happen in the loadTable path, because we check the value length
+    // in Java for the normal transaction path.
+    // We explicitly initialize the StringRefs for those non-inlined columns here to
+    // prevent any surprises.
+    uint16_t nonInlinedColCount = m_schema->getUninlinedObjectColumnCount();
+    for (uint16_t i = 0; i < nonInlinedColCount; i++) {
+        uint16_t idx = m_schema->getUninlinedObjectColumnInfoIndex(i);
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(idx);
+        char *dataPtr = getWritableDataPtr(columnInfo);
+        *reinterpret_cast<StringRef**>(dataPtr) = NULL;
+    }
+
+    for (int j = 0; j < columnCount; ++j) {
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(j);
+
+        /**
+         * Hack hack. deserializeFrom is only called when we serialize
+         * and deserialize tables. The serialization format for
+         * Strings/Objects in a serialized table happens to have the
+         * same in memory representation as the Strings/Objects in a
+         * tabletuple. The goal here is to wrap the serialized
+         * representation of the value in an NValue and then serialize
+         * that into the tuple from the NValue. This makes it possible
+         * to push more value specific functionality out of
+         * TableTuple. The memory allocation will be performed when
+         * serializing to tuple storage.
+         */
+        char *dataPtr = getWritableDataPtr(columnInfo);
+        NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(),
+                columnInfo->inlined, static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
+    }
+
+    for (int j = 0; j < hiddenColumnCount; ++j) {
+        const TupleSchema::HiddenColumnInfo *columnInfo = m_schema->getHiddenColumnInfo(j);
+
+        if (caller.useDefaultValue(columnInfo->columnType)) {
+            VOLT_DEBUG("Using default value for caller %d and hidden column %d",
+                    caller.getId(), columnInfo->columnType);
+            setHiddenNValue(columnInfo, HiddenColumn::getDefaultValue(columnInfo->columnType));
+        } else { // tupleIn may not have hidden column
+            if (!tupleIn.hasRemaining()) {
+                throwSerializableEEException(
+                        "TableTuple::deserializeFrom table tuple doesn't have enough space to deserialize the hidden column "
+                        "(index=%d) hidden column count=%d\n", j, m_schema->hiddenColumnCount());
+            }
+            char *dataPtr = getWritableDataPtr(columnInfo);
+            NValue::deserializeFrom(tupleIn, dataPool, dataPtr, columnInfo->getVoltType(), false, -1, false);
+        }
+    }
+}
+
+
+void TableTuple::deserializeFromDR(SerializeInputLE &tupleIn,  Pool *dataPool) {
+    vassert(m_schema);
+    vassert(m_data);
+    const int32_t columnCount  = m_schema->columnCount();
+    int nullMaskLength = ((columnCount + 7) & -8) >> 3;
+    const uint8_t *nullArray = reinterpret_cast<const uint8_t*>(tupleIn.getRawPointer(nullMaskLength));
+
+    for (int j = 0; j < columnCount; j++) {
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(j);
+
+        const uint32_t index = j >> 3;
+        const uint32_t bit = j % 8;
+        const uint8_t mask = (uint8_t) (0x80u >> bit);
+        const bool isNull = (nullArray[index] & mask);
+
+        if (isNull) {
+            NValue value = NValue::getNullValue(columnInfo->getVoltType());
+            setNValue(j, value);
+        } else {
+            char *dataPtr = getWritableDataPtr(columnInfo);
+            NValue::deserializeFrom<TUPLE_SERIALIZATION_DR, BYTE_ORDER_LITTLE_ENDIAN>(
+                    tupleIn, dataPool, dataPtr,
+                    columnInfo->getVoltType(), columnInfo->inlined,
+                    static_cast<int32_t>(columnInfo->length), columnInfo->inBytes);
+        }
+    }
+
+    int32_t hiddenColumnCount = m_schema->hiddenColumnCount();
+
+    for (int i = 0; i < hiddenColumnCount; i++) {
+        const TupleSchema::HiddenColumnInfo * hiddenColumnInfo = m_schema->getHiddenColumnInfo(i);
+        if (hiddenColumnInfo->columnType == HiddenColumn::MIGRATE_TXN) {
+            // Set the hidden column for persistent table to null
+            NValue value = NValue::getNullValue(hiddenColumnInfo->getVoltType());
+            setHiddenNValue(i, value);
+        } else {
+            char *dataPtr = getWritableDataPtr(hiddenColumnInfo);
+            NValue::deserializeFrom<TUPLE_SERIALIZATION_DR, BYTE_ORDER_LITTLE_ENDIAN>(
+                    tupleIn, dataPool, dataPtr, hiddenColumnInfo->getVoltType(), false, -1, false);
+        }
+    }
+}
+
+void TableTuple::serializeTo(SerializeOutput &output, const HiddenColumnFilter *filter) const {
+    size_t start = output.reserveBytes(4);
+
+    for (int j = 0; j < m_schema->columnCount(); ++j) {
+        //int fieldStart = output.position();
+        NValue value = getNValue(j);
+        value.serializeTo(output);
+    }
+
+    if (filter) {
+        for (int j = 0; j < m_schema->hiddenColumnCount(); ++j) {
+            if (filter->include(j)) {
+                NValue value = getHiddenNValue(j);
+                value.serializeTo(output);
+            }
+        }
+    }
+    // write the length of the tuple
+    output.writeIntAt(start, static_cast<int32_t>(output.position() - start - sizeof(int32_t)));
+}
+
+bool TableTuple::equalsNoSchemaCheck(const TableTuple &other,
+        const HiddenColumnFilter *hiddenColumnFilter) const {
+    for (int ii = 0; ii < m_schema->columnCount(); ii++) {
+        const NValue lhs = getNValue(ii);
+        const NValue rhs = other.getNValue(ii);
+        if (lhs.op_notEquals(rhs).isTrue()) {
+            return false;
+        }
+    }
+    if (hiddenColumnFilter != nullptr) {
+        for (int ii = 0; ii < m_schema->hiddenColumnCount(); ii++) {
+            if (hiddenColumnFilter->include(ii)) {
+                const NValue lhs = getHiddenNValue(ii);
+                const NValue rhs = other.getHiddenNValue(ii);
+                if (lhs.op_notEquals(rhs).isTrue()) {
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+void TableTuple::setAllNulls() {
+    vassert(m_schema);
+    vassert(m_data);
+
+    for (int ii = 0; ii < m_schema->columnCount(); ++ii) {
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(ii);
+        NValue value = NValue::getNullValue(columnInfo->getVoltType());
+        setNValue(columnInfo, value, false);
+    }
+
+    for (int jj = 0; jj < m_schema->hiddenColumnCount(); ++jj) {
+        const TupleSchema::HiddenColumnInfo *hiddenColumnInfo = m_schema->getHiddenColumnInfo(jj);
+        NValue value = NValue::getNullValue(hiddenColumnInfo->getVoltType());
+        setHiddenNValue(hiddenColumnInfo, value);
+    }
+}
+
+void TableTuple::relocateNonInlinedFields(std::ptrdiff_t offset) {
+    uint16_t nonInlinedColCount = m_schema->getUninlinedObjectColumnCount();
+    for (uint16_t i = 0; i < nonInlinedColCount; i++) {
+        uint16_t idx = m_schema->getUninlinedObjectColumnInfoIndex(i);
+        const TupleSchema::ColumnInfo *columnInfo = m_schema->getColumnInfo(idx);
+        vassert(isVariableLengthType(columnInfo->getVoltType()) && !columnInfo->inlined);
+
+        char **dataPtr = reinterpret_cast<char**>(getWritableDataPtr(columnInfo));
+        if (*dataPtr != nullptr) {
+            (*dataPtr) += offset;
+            NValue value = getNValue(idx);
+            value.relocateNonInlined(offset);
+        }
+    }
+}
+
+int TableTuple::compare(const TableTuple &other) const {
+    const int columnCount = m_schema->columnCount();
+    int diff;
+    for (int ii = 0; ii < columnCount; ii++) {
+        const NValue lhs = getNValue(ii);
+        const NValue rhs = other.getNValue(ii);
+        diff = lhs.compare(rhs);
+        if (diff) {
+            return diff;
+        }
+    }
+    return VALUE_COMPARE_EQUAL;
+}
+
+/**
+ * Compare two tuples. Null value in the rhs tuple will be treated as maximum.
+ */
+int TableTuple::compareNullAsMax(const TableTuple &other) const {
+    const int columnCount = m_schema->columnCount();
+    assert(columnCount == other.m_schema->columnCount());
+    int diff;
+    for (int ii = 0; ii < columnCount; ii++) {
+        const NValue& lhs = getNValue(ii);
+        const NValue& rhs = other.getNValue(ii);
+        diff = lhs.compareNullAsMax(rhs);
+        if (diff) {
+            return diff;
+        }
+    }
+    return VALUE_COMPARE_EQUAL;
+}
+
 }

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -128,13 +128,8 @@ public:
      * backing store
      */
     inline void move(void *address) {
-#ifndef  NDEBUG
-        if (m_schema == NULL && address != NULL) {
-            StackTrace::printStackTrace();
-        }
-#endif
-        vassert(m_schema != NULL || address == NULL);
-        m_data = reinterpret_cast<char*> (address);
+        vassert(m_schema != nullptr || address == nullptr);
+        m_data = reinterpret_cast<char*>(address);
     }
 
     inline void moveNoHeader(void *address) {

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -285,6 +285,7 @@ public:
                 bytes += getNValue(idx).getAllocationSizeForObjectInTempStorage();
             }
         }
+//        printf("getNonInlinedMemorySizeForTempTable() -> %lu\n", bytes);
         return bytes;
     }
 

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -459,11 +459,11 @@ int VoltDBEngine::executePlanFragments(
                 drBufferChange += drReplicatedStreamBufferChange- DRTupleStream::BEGIN_RECORD_SIZE;
             }
         }
-        m_resultOutput.writeIntAt(m_startOfResultBuffer + 1, static_cast<int32_t> (drBufferChange));
+        m_resultOutput.writeIntAt(m_startOfResultBuffer + 1, drBufferChange);
         VOLT_DEBUG("executePlanFragments : hasDRBinaryLog %d, drBufferChange %d", hasDRBinaryLog,
                    static_cast<int32_t> (drBufferChange));
         m_resultOutput.writeIntAt(m_startOfResultBuffer + 5,
-                static_cast<int32_t>(m_resultOutput.position() - m_startOfResultBuffer) -
+                m_resultOutput.position() - m_startOfResultBuffer -
                 sizeof(int32_t) - sizeof(int32_t) - sizeof(int8_t));
 
     }
@@ -2440,7 +2440,7 @@ int VoltDBEngine::getStats(int selector, int locators[], int numLocators,
     if (resultTable != NULL) {
         resultTable->serializeTo(m_resultOutput);
         m_resultOutput.writeIntAt(lengthPosition,
-                static_cast<int32_t>(m_resultOutput.size() - sizeof(int32_t)));
+                m_resultOutput.size() - sizeof(int32_t));
         return 1;
     } else {
         return 0;

--- a/src/ee/indexes/CompactingHashMultiMapIndex.h
+++ b/src/ee/indexes/CompactingHashMultiMapIndex.h
@@ -68,19 +68,78 @@ class CompactingHashMultiMapIndex : public TableIndex {
     // comparison stuff
     KeyEqualityChecker m_eq;
 
-
     ~CompactingHashMultiMapIndex() {};
 
     static MapIterator& castToIter(IndexCursor& cursor) {
         return *reinterpret_cast<MapIterator*> (cursor.m_keyIter);
     }
 
-    void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) {
+    TableIndex* cloneEmptyNonCountingTreeIndex() const override {
+        throwFatalException("Primary key index discovered to be non-unique.");
+    }
+
+    void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
+    }
+
+    bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
+    }
+
+    void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
+    }
+
+    void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+    }
+
+    bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+    }
+
+    void moveToBeforePriorEntry(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
+    }
+
+    void moveToPriorEntry(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
+    }
+
+    void moveToEnd(bool begin, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
+    }
+
+    TableTuple nextValue(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
+    }
+
+    bool advanceToNextKey(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
+    }
+
+    TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const override {
+        throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
+    }
+
+    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
+    }
+
+    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
+    }
+
+    bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
+    }
+
+    void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
         ++m_inserts;
         m_entries.insert(setKeyFromTuple(tuple), tuple->address());
     }
 
-    bool deleteEntryDo(const TableTuple *tuple) {
+    bool deleteEntryDo(const TableTuple *tuple) override {
         ++m_deletes;
         MapIterator iter = findTuple(*tuple);
         if (iter.isEnd()) {
@@ -93,7 +152,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
     /**
      * Update in place an index entry with a new tuple address
      */
-    bool replaceEntryNoKeyChangeDo(const TableTuple &destinationTuple, const TableTuple &originalTuple) {
+    bool replaceEntryNoKeyChangeDo(const TableTuple &destinationTuple, const TableTuple &originalTuple) override {
         vassert(originalTuple.address() != destinationTuple.address());
 
         // full delete and insert for certain key types
@@ -116,19 +175,19 @@ class CompactingHashMultiMapIndex : public TableIndex {
         }
     }
 
-    bool keyUsesNonInlinedMemory() const {
+    bool keyUsesNonInlinedMemory() const override {
         return KeyType::keyUsesNonInlinedMemory();
     }
 
-    bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const {
+    bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const override {
         return ! m_eq(setKeyFromTuple(lhs), setKeyFromTuple(rhs));
     }
 
-    bool existsDo(const TableTuple *persistentTuple) const {
+    bool existsDo(const TableTuple *persistentTuple) const override {
         return ! findTuple(*persistentTuple).isEnd();
     }
 
-    bool moveToKey(const TableTuple *searchKey, IndexCursor& cursor) const {
+    bool moveToKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findKey(searchKey);
         if (mapIter.isEnd()) {
@@ -140,7 +199,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
         }
     }
 
-    bool moveToKeyByTuple(const TableTuple *persistentTuple, IndexCursor &cursor) const {
+    bool moveToKeyByTuple(const TableTuple *persistentTuple, IndexCursor &cursor) const override {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findTuple(*persistentTuple);
         if (mapIter.isEnd()) {
@@ -152,7 +211,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
         }
    }
 
-    TableTuple nextValueAtKey(IndexCursor& cursor) const {
+    TableTuple nextValueAtKey(IndexCursor& cursor) const override {
         if (cursor.m_match.isNullTuple()) {
             return cursor.m_match;
         }
@@ -168,19 +227,19 @@ class CompactingHashMultiMapIndex : public TableIndex {
         return retval;
     }
 
-    bool hasKey(const TableTuple *searchKey) const {
+    bool hasKey(const TableTuple *searchKey) const override {
         return ! findKey(searchKey).isEnd();
     }
 
-    size_t getSize() const {
+    size_t getSize() const override {
         return m_entries.size();
     }
 
-    int64_t getMemoryEstimate() const {
+    int64_t getMemoryEstimate() const override {
         return m_entries.bytesAllocated();
     }
 
-    std::string getTypeName() const {
+    std::string getTypeName() const override {
         return "CompactingHashMultiMapIndex";
     }
 

--- a/src/ee/indexes/CompactingHashMultiMapIndex.h
+++ b/src/ee/indexes/CompactingHashMultiMapIndex.h
@@ -128,12 +128,14 @@ class CompactingHashMultiMapIndex : public TableIndex {
         return {};
     }
 
-    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper,
+            IndexCursor& cursor) const override {
         notImplemented("getCounterGET");
         return {};
     }
 
-    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper,
+            IndexCursor& cursor) const override {
         notImplemented("getCounterLET");
         return {};
     }
@@ -166,10 +168,10 @@ class CompactingHashMultiMapIndex : public TableIndex {
 
         // full delete and insert for certain key types
         if (KeyType::keyDependsOnTupleAddress()) {
-            if ( ! CompactingHashMultiMapIndex::deleteEntry(&originalTuple)) {
+            if (! deleteEntry(&originalTuple)) {
                 return false;
             } else {
-                CompactingHashMultiMapIndex::addEntry(&destinationTuple, nullptr);
+                addEntry(&destinationTuple, nullptr);
                 return true;
             }
         }
@@ -212,7 +214,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findTuple(*persistentTuple);
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
@@ -229,7 +231,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
         MapIterator &mapIter = castToIter(cursor);
         mapIter.moveNext();
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
         }

--- a/src/ee/indexes/CompactingHashMultiMapIndex.h
+++ b/src/ee/indexes/CompactingHashMultiMapIndex.h
@@ -75,63 +75,72 @@ class CompactingHashMultiMapIndex : public TableIndex {
     }
 
     TableIndex* cloneEmptyNonCountingTreeIndex() const override {
-        throwFatalException("Primary key index discovered to be non-unique.");
+        notImplemented("cloneEmptyNonCountingTreeIndex");
+        return {};
     }
 
     void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
+        notImplemented("moveToKeyOrGreater");
     }
 
     bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
+        notImplemented("moveToGreaterThanKey");
+        return {};
     }
 
     void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
+        notImplemented("moveToLessThanKey");
     }
 
     void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+        notImplemented("moveToKeyOrLess");
     }
 
     bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+        notImplemented("moveToCoveringCell");
+        return {};
     }
 
     void moveToBeforePriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
+        notImplemented("moveToBeforePriorEntry");
     }
 
     void moveToPriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
+        notImplemented("moveToPriorEntry");
     }
 
     void moveToEnd(bool begin, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
+        notImplemented("moveToEnd");
     }
 
     TableTuple nextValue(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
+        notImplemented("nextValue");
+        return {};
     }
 
     bool advanceToNextKey(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
+        notImplemented("advanceToNextKey");
+        return {};
     }
 
     TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const override {
-        throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
+        notImplemented("uniqueMatchingTuple");
+        return {};
     }
 
     int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
+        notImplemented("getCounterGET");
+        return {};
     }
 
     int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
+        notImplemented("getCounterLET");
+        return {};
     }
 
     bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
+        notImplemented("moveToRankTuple");
+        return {};
     }
 
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
@@ -239,7 +248,7 @@ class CompactingHashMultiMapIndex : public TableIndex {
         return m_entries.bytesAllocated();
     }
 
-    std::string getTypeName() const override {
+    char const* getTypeName() const override {
         return "CompactingHashMultiMapIndex";
     }
 

--- a/src/ee/indexes/CompactingHashUniqueIndex.h
+++ b/src/ee/indexes/CompactingHashUniqueIndex.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef COMPACTINGHASHUNIQUEINDEX_H_
-#define COMPACTINGHASHUNIQUEINDEX_H_
+#pragma once
 
 #include <iostream>
 #include <common/debuglog.h>
@@ -59,17 +58,20 @@ namespace voltdb {
  * @see TableIndex
  */
 template<typename KeyType>
-class CompactingHashUniqueIndex : public TableIndex
-{
-    typedef typename KeyType::KeyEqualityChecker KeyEqualityChecker;
-    typedef typename KeyType::KeyHasher KeyHasher;
-    typedef CompactingHashTable<KeyType, const void*, KeyHasher, KeyEqualityChecker> MapType;
-    typedef typename MapType::iterator MapIterator;
+class CompactingHashUniqueIndex : public TableIndex {
+    using KeyEqualityChecker = typename KeyType::KeyEqualityChecker;
+    using KeyHasher = typename KeyType::KeyHasher;
+    using MapType = CompactingHashTable<KeyType, const void*, KeyHasher, KeyEqualityChecker>;
+    using MapIterator = typename MapType::iterator;
+
+    MapType m_entries;
+    // comparison stuff
+    KeyEqualityChecker m_eq;
 
     ~CompactingHashUniqueIndex() {};
 
     static MapIterator& castToIter(IndexCursor& cursor) {
-        return *reinterpret_cast<MapIterator*> (cursor.m_keyIter);
+        return *reinterpret_cast<MapIterator*>(cursor.m_keyIter);
     }
 
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) {
@@ -88,37 +90,37 @@ class CompactingHashUniqueIndex : public TableIndex
     /**
      * Update in place an index entry with a new tuple address
      */
-    bool replaceEntryNoKeyChangeDo(const TableTuple &destinationTuple, const TableTuple &originalTuple)
-    {
+    bool replaceEntryNoKeyChangeDo(const TableTuple &destinationTuple, const TableTuple &originalTuple) {
         vassert(originalTuple.address() != destinationTuple.address());
 
         // full delete and insert for certain key types
         if (KeyType::keyDependsOnTupleAddress()) {
-            if ( ! CompactingHashUniqueIndex::deleteEntry(&originalTuple)) {
+            if (! CompactingHashUniqueIndex::deleteEntry(&originalTuple)) {
                 return false;
+            } else {
+                TableTuple conflict(destinationTuple.getSchema());
+                CompactingHashUniqueIndex::addEntry(&destinationTuple, &conflict);
+                return conflict.isNullTuple();
             }
-            TableTuple conflict(destinationTuple.getSchema());
-            CompactingHashUniqueIndex::addEntry(&destinationTuple, &conflict);
-            return conflict.isNullTuple();
         }
 
         MapIterator mapiter = findTuple(originalTuple);
         if (mapiter.isEnd()) {
             return false;
+        } else {
+            mapiter.setValue(destinationTuple.address());
+            m_updates++;
+            return true;
         }
-        mapiter.setValue(destinationTuple.address());
-        m_updates++;
-        return true;
     }
 
     bool keyUsesNonInlinedMemory() const { return KeyType::keyUsesNonInlinedMemory(); }
 
     bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const {
-        return !(m_eq(setKeyFromTuple(lhs), setKeyFromTuple(rhs)));
+        return ! m_eq(setKeyFromTuple(lhs), setKeyFromTuple(rhs));
     }
 
-    bool existsDo(const TableTuple *persistentTuple) const
-    {
+    bool existsDo(const TableTuple *persistentTuple) const {
         return ! findTuple(*persistentTuple).isEnd();
     }
 
@@ -127,26 +129,25 @@ class CompactingHashUniqueIndex : public TableIndex
         mapIter = findKey(searchKey);
 
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
+        } else {
+            cursor.m_match.move(const_cast<void*>(mapIter.value()));
+            return true;
         }
-        cursor.m_match.move(const_cast<void*>(mapIter.value()));
-
-        return true;
     }
 
-    bool moveToKeyByTuple(const TableTuple *persistentTuple, IndexCursor &cursor) const
-    {
+    bool moveToKeyByTuple(const TableTuple *persistentTuple, IndexCursor &cursor) const {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findTuple(*persistentTuple);
 
         if (mapIter.isEnd()) {
             cursor.m_match.move(NULL);
             return false;
+        } else {
+            cursor.m_match.move(const_cast<void*>(mapIter.value()));
+            return true;
         }
-        cursor.m_match.move(const_cast<void*>(mapIter.value()));
-
-        return true;
     }
 
     TableTuple nextValueAtKey(IndexCursor& cursor) const {
@@ -155,8 +156,7 @@ class CompactingHashUniqueIndex : public TableIndex
         return retval;
     }
 
-    TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const
-    {
+    TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const {
         TableTuple retval(getTupleSchema());
         const MapIterator keyIter = findTuple(searchTuple);
         if ( ! keyIter.isEnd()) {
@@ -169,50 +169,42 @@ class CompactingHashUniqueIndex : public TableIndex
         return ! findKey(searchKey).isEnd();
     }
 
-    size_t getSize() const { return m_entries.size(); }
+    size_t getSize() const {
+        return m_entries.size();
+    }
 
-    int64_t getMemoryEstimate() const
-    {
+    int64_t getMemoryEstimate() const {
         return m_entries.bytesAllocated();
     }
 
-    std::string getTypeName() const { return "CompactingHashUniqueIndex"; };
+    std::string getTypeName() const {
+        return "CompactingHashUniqueIndex";
+    }
 
-    TableIndex *cloneEmptyNonCountingTreeIndex() const
-    {
-        return new CompactingTreeUniqueIndex<NormalKeyValuePair<KeyType, void const *>, false >(TupleSchema::createTupleSchema(getKeySchema()), m_scheme);
+    TableIndex *cloneEmptyNonCountingTreeIndex() const {
+        return new CompactingTreeUniqueIndex<NormalKeyValuePair<KeyType, void const *>, false>(
+                TupleSchema::createTupleSchema(getKeySchema()), m_scheme);
     }
 
     // Non-virtual (so "really-private") helper methods.
-    MapIterator findKey(const TableTuple *searchKey) const
-    {
+    MapIterator findKey(const TableTuple *searchKey) const {
         return m_entries.find(KeyType(searchKey));
     }
 
-    MapIterator findTuple(const TableTuple &originalTuple) const
-    {
+    MapIterator findTuple(const TableTuple &originalTuple) const {
         return m_entries.find(setKeyFromTuple(&originalTuple));
     }
 
-    const KeyType setKeyFromTuple(const TableTuple *tuple) const
-    {
+    const KeyType setKeyFromTuple(const TableTuple *tuple) const {
         KeyType result(tuple, m_scheme.columnIndices, m_scheme.indexedExpressions, m_keySchema);
         return result;
     }
-
-    MapType m_entries;
-
-    // comparison stuff
-   KeyEqualityChecker m_eq;
-
 public:
     CompactingHashUniqueIndex(const TupleSchema *keySchema, const TableIndexScheme &scheme) :
         TableIndex(keySchema, scheme),
         m_entries(true, KeyHasher(keySchema), KeyEqualityChecker(keySchema)),
-        m_eq(keySchema)
-    {}
+        m_eq(keySchema) {}
 };
 
 }
 
-#endif // COMPACTINGHASHUNIQUEINDEX_H_

--- a/src/ee/indexes/CompactingHashUniqueIndex.h
+++ b/src/ee/indexes/CompactingHashUniqueIndex.h
@@ -118,12 +118,14 @@ class CompactingHashUniqueIndex : public TableIndex {
         return {};
     }
 
-    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper,
+            IndexCursor& cursor) const override {
         notImplemented("getCounterGET");
         return {};
     }
 
-    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper,
+            IndexCursor& cursor) const override {
         notImplemented("getCounterLET");
         return {};
     }
@@ -135,8 +137,8 @@ class CompactingHashUniqueIndex : public TableIndex {
 
     void addEntryDo(const TableTuple* tuple, TableTuple* conflictTuple) override {
         ++m_inserts;
-        const void* const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
-        if (conflictEntry != NULL && conflictTuple != NULL) {
+        auto const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
+        if (conflictEntry != nullptr && conflictTuple != nullptr) {
             conflictTuple->move(const_cast<void*>(*conflictEntry));
         }
     }
@@ -149,16 +151,17 @@ class CompactingHashUniqueIndex : public TableIndex {
     /**
      * Update in place an index entry with a new tuple address
      */
-    bool replaceEntryNoKeyChangeDo(const TableTuple& destinationTuple, const TableTuple& originalTuple) override {
+    bool replaceEntryNoKeyChangeDo(const TableTuple& destinationTuple,
+            const TableTuple& originalTuple) override {
         vassert(originalTuple.address() != destinationTuple.address());
 
         // full delete and insert for certain key types
         if (KeyType::keyDependsOnTupleAddress()) {
-            if (! CompactingHashUniqueIndex::deleteEntry(&originalTuple)) {
+            if (! deleteEntry(&originalTuple)) {
                 return false;
             } else {
                 TableTuple conflict(destinationTuple.getSchema());
-                CompactingHashUniqueIndex::addEntry(&destinationTuple, &conflict);
+                addEntry(&destinationTuple, &conflict);
                 return conflict.isNullTuple();
             }
         }
@@ -203,7 +206,7 @@ class CompactingHashUniqueIndex : public TableIndex {
         mapIter = findTuple(*persistentTuple);
 
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
@@ -213,7 +216,7 @@ class CompactingHashUniqueIndex : public TableIndex {
 
     TableTuple nextValueAtKey(IndexCursor& cursor) const override {
         TableTuple retval = cursor.m_match;
-        cursor.m_match.move(NULL);
+        cursor.m_match.move(nullptr);
         return retval;
     }
 
@@ -261,7 +264,8 @@ class CompactingHashUniqueIndex : public TableIndex {
     }
 public:
     CompactingHashUniqueIndex(const TupleSchema *keySchema, const TableIndexScheme &scheme) :
-        TableIndex(keySchema, scheme), m_entries(true, KeyHasher(keySchema), KeyEqualityChecker(keySchema)),
+        TableIndex(keySchema, scheme),
+        m_entries(true, KeyHasher(keySchema), KeyEqualityChecker(keySchema)),
         m_eq(keySchema) {}
 };
 

--- a/src/ee/indexes/CompactingHashUniqueIndex.h
+++ b/src/ee/indexes/CompactingHashUniqueIndex.h
@@ -74,7 +74,59 @@ class CompactingHashUniqueIndex : public TableIndex {
         return *reinterpret_cast<MapIterator*>(cursor.m_keyIter);
     }
 
-    void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) {
+    void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
+    }
+
+    bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
+    }
+
+    void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
+    }
+
+    void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+    }
+
+    bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+    }
+
+    void moveToBeforePriorEntry(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
+    }
+
+    void moveToPriorEntry(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
+    }
+
+    void moveToEnd(bool begin, IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
+    }
+
+    TableTuple nextValue(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
+    }
+
+    bool advanceToNextKey(IndexCursor& cursor) const override {
+        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
+    }
+
+    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
+    }
+
+    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
+    }
+
+    bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const override {
+        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
+    }
+
+    void addEntryDo(const TableTuple* tuple, TableTuple* conflictTuple) override {
         ++m_inserts;
         const void* const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
         if (conflictEntry != NULL && conflictTuple != NULL) {
@@ -82,7 +134,7 @@ class CompactingHashUniqueIndex : public TableIndex {
         }
     }
 
-    bool deleteEntryDo(const TableTuple *tuple) {
+    bool deleteEntryDo(const TableTuple* tuple) override {
         ++m_deletes;
         return m_entries.erase(setKeyFromTuple(tuple));
     }
@@ -90,7 +142,7 @@ class CompactingHashUniqueIndex : public TableIndex {
     /**
      * Update in place an index entry with a new tuple address
      */
-    bool replaceEntryNoKeyChangeDo(const TableTuple &destinationTuple, const TableTuple &originalTuple) {
+    bool replaceEntryNoKeyChangeDo(const TableTuple& destinationTuple, const TableTuple& originalTuple) override {
         vassert(originalTuple.address() != destinationTuple.address());
 
         // full delete and insert for certain key types
@@ -114,17 +166,19 @@ class CompactingHashUniqueIndex : public TableIndex {
         }
     }
 
-    bool keyUsesNonInlinedMemory() const { return KeyType::keyUsesNonInlinedMemory(); }
+    bool keyUsesNonInlinedMemory() const override {
+        return KeyType::keyUsesNonInlinedMemory();
+    }
 
-    bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const {
+    bool checkForIndexChangeDo(const TableTuple* lhs, const TableTuple* rhs) const override {
         return ! m_eq(setKeyFromTuple(lhs), setKeyFromTuple(rhs));
     }
 
-    bool existsDo(const TableTuple *persistentTuple) const {
+    bool existsDo(const TableTuple *persistentTuple) const override {
         return ! findTuple(*persistentTuple).isEnd();
     }
 
-    bool moveToKey(const TableTuple *searchKey, IndexCursor& cursor) const {
+    bool moveToKey(const TableTuple* searchKey, IndexCursor &cursor) const override {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findKey(searchKey);
 
@@ -137,7 +191,7 @@ class CompactingHashUniqueIndex : public TableIndex {
         }
     }
 
-    bool moveToKeyByTuple(const TableTuple *persistentTuple, IndexCursor &cursor) const {
+    bool moveToKeyByTuple(const TableTuple* persistentTuple, IndexCursor& cursor) const override {
         MapIterator &mapIter = castToIter(cursor);
         mapIter = findTuple(*persistentTuple);
 
@@ -150,13 +204,13 @@ class CompactingHashUniqueIndex : public TableIndex {
         }
     }
 
-    TableTuple nextValueAtKey(IndexCursor& cursor) const {
+    TableTuple nextValueAtKey(IndexCursor& cursor) const override {
         TableTuple retval = cursor.m_match;
         cursor.m_match.move(NULL);
         return retval;
     }
 
-    TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const {
+    TableTuple uniqueMatchingTuple(const TableTuple& searchTuple) const override {
         TableTuple retval(getTupleSchema());
         const MapIterator keyIter = findTuple(searchTuple);
         if ( ! keyIter.isEnd()) {
@@ -165,23 +219,23 @@ class CompactingHashUniqueIndex : public TableIndex {
         return retval;
     }
 
-    bool hasKey(const TableTuple *searchKey) const {
+    bool hasKey(const TableTuple* searchKey) const override {
         return ! findKey(searchKey).isEnd();
     }
 
-    size_t getSize() const {
+    size_t getSize() const override {
         return m_entries.size();
     }
 
-    int64_t getMemoryEstimate() const {
+    int64_t getMemoryEstimate() const override {
         return m_entries.bytesAllocated();
     }
 
-    std::string getTypeName() const {
+    std::string getTypeName() const override {
         return "CompactingHashUniqueIndex";
     }
 
-    TableIndex *cloneEmptyNonCountingTreeIndex() const {
+    TableIndex* cloneEmptyNonCountingTreeIndex() const override {
         return new CompactingTreeUniqueIndex<NormalKeyValuePair<KeyType, void const *>, false>(
                 TupleSchema::createTupleSchema(getKeySchema()), m_scheme);
     }
@@ -196,13 +250,11 @@ class CompactingHashUniqueIndex : public TableIndex {
     }
 
     const KeyType setKeyFromTuple(const TableTuple *tuple) const {
-        KeyType result(tuple, m_scheme.columnIndices, m_scheme.indexedExpressions, m_keySchema);
-        return result;
+        return KeyType(tuple, m_scheme.columnIndices, m_scheme.indexedExpressions, m_keySchema);
     }
 public:
     CompactingHashUniqueIndex(const TupleSchema *keySchema, const TableIndexScheme &scheme) :
-        TableIndex(keySchema, scheme),
-        m_entries(true, KeyHasher(keySchema), KeyEqualityChecker(keySchema)),
+        TableIndex(keySchema, scheme), m_entries(true, KeyHasher(keySchema), KeyEqualityChecker(keySchema)),
         m_eq(keySchema) {}
 };
 

--- a/src/ee/indexes/CompactingHashUniqueIndex.h
+++ b/src/ee/indexes/CompactingHashUniqueIndex.h
@@ -75,55 +75,62 @@ class CompactingHashUniqueIndex : public TableIndex {
     }
 
     void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
+        notImplemented("moveToKeyOrGreater");
     }
 
     bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
+        notImplemented("moveToGreaterThanKey");
+        return {};
     }
 
     void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
+        notImplemented("moveToLessThanKey");
     }
 
     void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+        notImplemented("moveToKeyOrLess");
     }
 
     bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+        notImplemented("moveToCoveringCell");
+        return {};
     }
 
     void moveToBeforePriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
+        notImplemented("moveToBeforePriorEntry");
     }
 
     void moveToPriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
+        notImplemented("moveToPriorEntry");
     }
 
     void moveToEnd(bool begin, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
+        notImplemented("moveToEnd");
     }
 
     TableTuple nextValue(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
+        notImplemented("nextValue");
+        return {};
     }
 
     bool advanceToNextKey(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
+        notImplemented("advanceToNextKey");
+        return {};
     }
 
     int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
+        notImplemented("getCounterGET");
+        return {};
     }
 
     int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
+        notImplemented("getCounterLET");
+        return {};
     }
 
     bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
+        notImplemented("moveToRankTuple");
+        return {};
     }
 
     void addEntryDo(const TableTuple* tuple, TableTuple* conflictTuple) override {
@@ -231,7 +238,7 @@ class CompactingHashUniqueIndex : public TableIndex {
         return m_entries.bytesAllocated();
     }
 
-    std::string getTypeName() const override {
+    char const* getTypeName() const override {
         return "CompactingHashUniqueIndex";
     }
 

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -106,6 +106,8 @@ class CompactingTreeMultiMapIndex : public TableIndex {
         if (iter.isEnd()) {
             return false;
         } else {
+            printf("Deleting tuple %s: found\n", tuple->debug().c_str());
+            fflush(stdout);
             return m_entries.erase(iter);
         }
     }

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -81,15 +81,18 @@ class CompactingTreeMultiMapIndex : public TableIndex {
     }
 
     TableIndex* cloneEmptyNonCountingTreeIndex() const override {
-        throwFatalException("Primary key index discovered to be non-unique.");
+        notImplemented("cloneEmptyNonCountingTreeIndex");
+        return {};
     }
 
     bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+        notImplemented("moveToCoveringCell");
+        return {};
     }
 
     TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const override {
-        throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
+        notImplemented("uniqueMatchingTuple");
+        return {};
     }
 
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
@@ -416,7 +419,7 @@ class CompactingTreeMultiMapIndex : public TableIndex {
         return (ret);
     }
 
-    std::string getTypeName() const override {
+    char const* getTypeName() const override {
         return "CompactingTreeMultiMapIndex";
     }
 

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -106,8 +106,6 @@ class CompactingTreeMultiMapIndex : public TableIndex {
         if (iter.isEnd()) {
             return false;
         } else {
-            printf("Deleting tuple %s: found\n", tuple->debug().c_str());
-            fflush(stdout);
             return m_entries.erase(iter);
         }
     }

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -280,7 +280,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
         return retval;
     }
 
-    TableTuple nextValueAtKey(IndexCursor& cursor) const {
+    TableTuple nextValueAtKey(IndexCursor& cursor) const override {
         TableTuple retval = cursor.m_match;
         cursor.m_match.move(NULL);
         return retval;

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -83,25 +83,14 @@ class CompactingTreeUniqueIndex : public TableIndex {
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
         ++m_inserts;
         auto const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
-        bool moved = false;
         if (conflictEntry != nullptr && conflictTuple != nullptr) {
             conflictTuple->move(const_cast<void*>(*conflictEntry));
-            moved = true;
         }
-        printf("&& Added tuple %s : %s :: %s\n", tuple->debug().c_str(), moved ? "moved" : "not moved",
-                debug().c_str());
-        fflush(stdout);
     }
 
     bool deleteEntryDo(const TableTuple *tuple) override {
         ++m_deletes;
-        printf("&& Deleting tuple %s from index %s\n", tuple->debug().c_str(),
-                debug().c_str());
-        fflush(stdout);
-        bool retcode = m_entries.erase(setKeyFromTuple(tuple));
-        printf("&&! Deleted tuple %s: %s\n", tuple->debug().c_str(), retcode ? "Found" : "Not Found");
-        fflush(stdout);
-        return retcode;
+        return m_entries.erase(setKeyFromTuple(tuple));
     }
 
     /**

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -101,11 +101,11 @@ class CompactingTreeUniqueIndex : public TableIndex {
 
         // full delete and insert for certain key types
         if (KeyType::keyDependsOnTupleAddress()) {
-            if (! CompactingTreeUniqueIndex::deleteEntry(&originalTuple)) {
+            if (! deleteEntry(&originalTuple)) {
                 return false;
             } else {
                 TableTuple conflict(destinationTuple.getSchema());
-                CompactingTreeUniqueIndex::addEntry(&destinationTuple, &conflict);
+                addEntry(&destinationTuple, &conflict);
                 return conflict.isNullTuple();
             }
         }
@@ -138,7 +138,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
         mapIter = findKey(searchKey);
 
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
@@ -152,7 +152,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
         mapIter = findTuple(*persistentTuple);
 
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
@@ -282,7 +282,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
 
     TableTuple nextValueAtKey(IndexCursor& cursor) const override {
         TableTuple retval = cursor.m_match;
-        cursor.m_match.move(NULL);
+        cursor.m_match.move(nullptr);
         return retval;
     }
 
@@ -295,7 +295,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
             mapIter.movePrev();
         }
         if (mapIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapIter.value()));
@@ -361,7 +361,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
         auto &mapConstIter = castToIter(cursor);
         mapConstIter = m_entries.findRank(denseRank);
         if (mapConstIter.isEnd()) {
-            cursor.m_match.move(NULL);
+            cursor.m_match.move(nullptr);
             return false;
         } else {
             cursor.m_match.move(const_cast<void*>(mapConstIter.value()));

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -76,7 +76,8 @@ class CompactingTreeUniqueIndex : public TableIndex {
     }
 
     bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
+        notImplemented("moveToCoveringCell");
+        return {};
     }
 
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
@@ -389,7 +390,7 @@ class CompactingTreeUniqueIndex : public TableIndex {
         return buffer.str();
     }
 
-    std::string getTypeName() const override {
+    char const* getTypeName() const override {
         return "CompactingTreeUniqueIndex";
     };
 

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -90,7 +90,8 @@ class CompactingTreeUniqueIndex : public TableIndex {
 
     bool deleteEntryDo(const TableTuple *tuple) override {
         ++m_deletes;
-        return m_entries.erase(setKeyFromTuple(tuple));
+        bool result = m_entries.erase(setKeyFromTuple(tuple));
+        return result;
     }
 
     /**

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -82,15 +82,26 @@ class CompactingTreeUniqueIndex : public TableIndex {
 
     void addEntryDo(const TableTuple *tuple, TableTuple *conflictTuple) override {
         ++m_inserts;
-        const void* const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
-        if (conflictEntry != NULL && conflictTuple != NULL) {
+        auto const* conflictEntry = m_entries.insert(setKeyFromTuple(tuple), tuple->address());
+        bool moved = false;
+        if (conflictEntry != nullptr && conflictTuple != nullptr) {
             conflictTuple->move(const_cast<void*>(*conflictEntry));
+            moved = true;
         }
+        printf("&& Added tuple %s : %s :: %s\n", tuple->debug().c_str(), moved ? "moved" : "not moved",
+                debug().c_str());
+        fflush(stdout);
     }
 
     bool deleteEntryDo(const TableTuple *tuple) override {
         ++m_deletes;
-        return m_entries.erase(setKeyFromTuple(tuple));
+        printf("&& Deleting tuple %s from index %s\n", tuple->debug().c_str(),
+                debug().c_str());
+        fflush(stdout);
+        bool retcode = m_entries.erase(setKeyFromTuple(tuple));
+        printf("&&! Deleted tuple %s: %s\n", tuple->debug().c_str(), retcode ? "Found" : "Not Found");
+        fflush(stdout);
+        return retcode;
     }
 
     /**

--- a/src/ee/indexes/CoveringCellIndex.h
+++ b/src/ee/indexes/CoveringCellIndex.h
@@ -99,66 +99,71 @@ private:
         throwFatalException("Primary key index discovered to be non-unique.");
     }
 
-    void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
+    void moveToKeyOrGreater(const TableTuple*, IndexCursor&) const override {
+        notImplemented("moveToKeyOrGreater");
     }
 
-    bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
+    bool moveToGreaterThanKey(const TableTuple*, IndexCursor&) const override {
+        notImplemented("moveToGreaterThanKey");
+        return false;
     }
 
-    void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
+    void moveToLessThanKey(const TableTuple*, IndexCursor&) const override {
+        notImplemented("moveToLessThanKey");
     }
 
-    void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
+    void moveToKeyOrLess(TableTuple*, IndexCursor&) const override {
+        notImplemented("moveToKeyOrLess");
     }
 
-    void moveToBeforePriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
+    void moveToBeforePriorEntry(IndexCursor&) const override {
+        notImplemented("moveToBeforePriorEntry");
     }
 
-    void moveToPriorEntry(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
+    void moveToPriorEntry(IndexCursor&) const override {
+        notImplemented("moveToPriorEntry");
     }
 
-    void moveToEnd(bool begin, IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
+    void moveToEnd(bool, IndexCursor&) const override {
+        notImplemented("moveToEnd");
     }
 
-    TableTuple nextValue(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
+    TableTuple nextValue(IndexCursor&) const override {
+        notImplemented("nextValue");
+        return {};
     }
 
-    bool advanceToNextKey(IndexCursor& cursor) const override {
-        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
+    bool advanceToNextKey(IndexCursor&) const override {
+        notImplemented("advanceToNextKey");
+        return {};
     }
 
-    TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const override {
-        throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
+    TableTuple uniqueMatchingTuple(const TableTuple &) const override {
+        notImplemented("uniqueMatchingTuple");
+        return {};
     }
 
-    int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
+    int64_t getCounterGET(const TableTuple*, bool, IndexCursor&) const override {
+        notImplemented("getCounterGET");
+        return {};
     }
 
-    int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
+    int64_t getCounterLET(const TableTuple*, bool, IndexCursor&) const override {
+        notImplemented("getCounterLET");
+        return {};
     }
 
-    bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const override {
-        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
+    bool moveToRankTuple(int64_t, bool, IndexCursor&) const override {
+        notImplemented("moveToRankTuple");
+        return {};
     }
 public:
     /**
      * This constructor is the same as for the other index types.
      */
     CoveringCellIndex(const TupleSchema *keySchema, const TableIndexScheme &scheme) :
-        TableIndex(keySchema, scheme)
-        , m_cellEntries(false, CellKeyComparator(keySchema))
-        , m_tupleEntries(true, TupleKeyComparator(nullptr))
-        , m_columnIndex(scheme.columnIndices[0]) {
+        TableIndex(keySchema, scheme), m_cellEntries(false, CellKeyComparator(keySchema)),
+        m_tupleEntries(true, TupleKeyComparator(nullptr)), m_columnIndex(scheme.columnIndices[0]) {
         vassert(scheme.columnIndices.size() == 1);
     }
 
@@ -207,7 +212,7 @@ public:
     /**
      * The name of this type of index
      */
-    std::string getTypeName() const override {
+    char const* getTypeName() const override {
         return "CoveringCellIndex";
     }
 

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -40,50 +40,37 @@ class IndexStats : public StatsSource {
     int64_t m_lastTupleCount = 0;
     int64_t m_lastMemEstimate = 0;
 
-    static std::array<std::tuple<std::string, ValueType, int32_t, bool, bool>, 7> const BASE_SCHEMA;
+    static std::array<schema_tuple_type, 7> const BASE_SCHEMA;
 protected:
     /**
      * Update the stats tuple with the latest statistics available to this StatsSource.
      */
-    virtual void updateStatsTuple(TableTuple *tuple);
-
-    /**
-     * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
-     * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
-     * contributing to the end of the list.
-     */
-    std::vector<std::string> generateStatsColumnNames() const override;
+    virtual void updateStatsTuple(TableTuple *tuple) override;
 
     /**
      * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
      * end of a list.
      */
-    void populateSchema(std::vector<ValueType> &types,
-            std::vector<int32_t> &columnLengths,
-            std::vector<bool> &allowNull,
-            std::vector<bool> &inBytes) override;
+    schema_type populateSchema() override;
 public:
     /**
      * Static method to generate the column names for the tables which
      * contain index stats.
      */
-    static std::vector<std::string> generateIndexStatsColumnNames();
+    static std::vector<std::string> generateStatsColumnNames();
 
     /**
      * Static method to generate the remaining schema information for
      * the tables which contain index stats.
      */
-    static void populateIndexStatsSchema(std::vector<ValueType>& types,
-                                         std::vector<int32_t>& columnLengths,
-                                         std::vector<bool>& allowNull,
-                                         std::vector<bool>& inBytes);
+    static schema_type populateIndexStatsSchema();
 
     static TempTable* generateEmptyIndexStatsTable();
 
     /*
      * Constructor caches reference to the table that will be generating the statistics
      */
-    IndexStats(voltdb::TableIndex* index);
+    IndexStats(TableIndex* index);
 
     ~IndexStats();
 

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -15,8 +15,7 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef INDEXSTATS_H_
-#define INDEXSTATS_H_
+#pragma once
 
 #include "stats/StatsSource.h"
 
@@ -29,6 +28,38 @@ class TempTable;
  * StatsSource extension for tables.
  */
 class IndexStats : public StatsSource {
+    /**
+     * Index whose stats are being collected.
+     */
+    TableIndex* m_index;
+    NValue m_indexName;
+    NValue m_indexType;
+
+    int8_t m_isUnique = 0;
+    int8_t m_isCountable = 0;
+    int64_t m_lastTupleCount = 0;
+    int64_t m_lastMemEstimate = 0;
+protected:
+    /**
+     * Update the stats tuple with the latest statistics available to this StatsSource.
+     */
+    virtual void updateStatsTuple(TableTuple *tuple);
+
+    /**
+     * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
+     * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
+     * contributing to the end of the list.
+     */
+    virtual std::vector<std::string> generateStatsColumnNames() const;
+
+    /**
+     * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
+     * end of a list.
+     */
+    virtual void populateSchema(std::vector<ValueType> &types,
+            std::vector<int32_t> &columnLengths,
+            std::vector<bool> &allowNull,
+            std::vector<bool> &inBytes);
 public:
     /**
      * Static method to generate the column names for the tables which
@@ -40,7 +71,7 @@ public:
      * Static method to generate the remaining schema information for
      * the tables which contain index stats.
      */
-    static void populateIndexStatsSchema(std::vector<voltdb::ValueType>& types,
+    static void populateIndexStatsSchema(std::vector<ValueType>& types,
                                          std::vector<int32_t>& columnLengths,
                                          std::vector<bool>& allowNull,
                                          std::vector<bool>& inBytes);
@@ -60,47 +91,10 @@ public:
      * @parameter name Name of this set of statistics
      * @parameter tableName Name of the indexed table
      */
-    void configure(std::string name, std::string tableName);
+    void configure(std::string const& name, std::string const& tableName);
 
-    void rename(std::string name);
-
-protected:
-
-    /**
-     * Update the stats tuple with the latest statistics available to this StatsSource.
-     */
-    virtual void updateStatsTuple(TableTuple *tuple);
-
-    /**
-     * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
-     * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
-     * contributing to the end of the list.
-     */
-    virtual std::vector<std::string> generateStatsColumnNames();
-
-    /**
-     * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
-     * end of a list.
-     */
-    virtual void populateSchema(std::vector<voltdb::ValueType> &types, std::vector<int32_t> &columnLengths,
-            std::vector<bool> &allowNull, std::vector<bool> &inBytes);
-
-private:
-    /**
-     * Index whose stats are being collected.
-     */
-    voltdb::TableIndex *m_index;
-
-    voltdb::NValue m_indexName;
-    voltdb::NValue m_indexType;
-
-    int8_t m_isUnique;
-    int8_t m_isCountable;
-
-    int64_t m_lastTupleCount;
-    int64_t m_lastMemEstimate;
+    void rename(std::string const& name);
 };
 
 }
 
-#endif /* INDEXSTATS_H_ */

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -16,7 +16,7 @@
  */
 
 #pragma once
-
+#include <array>
 #include "stats/StatsSource.h"
 
 namespace voltdb {
@@ -39,6 +39,8 @@ class IndexStats : public StatsSource {
     int8_t m_isCountable = 0;
     int64_t m_lastTupleCount = 0;
     int64_t m_lastMemEstimate = 0;
+
+    static std::array<std::tuple<std::string, ValueType, int32_t, bool, bool>, 7> const BASE_SCHEMA;
 protected:
     /**
      * Update the stats tuple with the latest statistics available to this StatsSource.
@@ -50,16 +52,16 @@ protected:
      * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
      * contributing to the end of the list.
      */
-    virtual std::vector<std::string> generateStatsColumnNames() const;
+    std::vector<std::string> generateStatsColumnNames() const override;
 
     /**
      * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
      * end of a list.
      */
-    virtual void populateSchema(std::vector<ValueType> &types,
+    void populateSchema(std::vector<ValueType> &types,
             std::vector<int32_t> &columnLengths,
             std::vector<bool> &allowNull,
-            std::vector<bool> &inBytes);
+            std::vector<bool> &inBytes) override;
 public:
     /**
      * Static method to generate the column names for the tables which

--- a/src/ee/indexes/indexkey.h
+++ b/src/ee/indexes/indexkey.h
@@ -112,7 +112,7 @@ inline uint64_t convertSignedValueToUnsignedValue<INT64_MAX, int64_t, uint64_t>(
     return retval;
 }
 
-template <std::size_t> struct IntsEqualityChecker;
+template <std::size_t> class IntsEqualityChecker;
 template <std::size_t> struct IntsComparator;
 template <std::size_t> struct IntsHasher;
 
@@ -196,7 +196,6 @@ struct IntsKey {
         int keyOffset = 0;
         int intraKeyOffset = static_cast<int>(sizeof(uint64_t) - 1);
         const int columnCount = keySchema->columnCount();
-        uint64_t keyValue;
         for (int ii = 0; ii < columnCount; ii++) {
             switch(keySchema->columnType(ii)) {
                 case voltdb::ValueType::tBIGINT:
@@ -376,9 +375,9 @@ struct IntsHasher {
     }
 };
 
-template <std::size_t> struct GenericEqualityChecker;
-template <std::size_t> struct GenericComparator;
-template <std::size_t> struct GenericHasher;
+template <std::size_t> class GenericEqualityChecker;
+template <std::size_t> class GenericComparator;
+template <std::size_t> class GenericHasher;
 
 /**
  * Key object for indexes of mixed types.
@@ -563,7 +562,7 @@ public:
  * Required by CompactingMap keyed by GenericKey<>
  */
 template <std::size_t keySize>
-struct GenericComparator {
+class GenericComparator {
 protected:
     const TupleSchema *m_keySchema;
 public:

--- a/src/ee/indexes/tableindex.cpp
+++ b/src/ee/indexes/tableindex.cpp
@@ -76,7 +76,7 @@ TableIndexScheme::TableIndexScheme(
       expressionsAsText(a_expressionsAsText),
       predicateAsText(a_predicateAsText),
       tupleSchema(a_tupleSchema) {
-        if (predicate != NULL) {
+        if (predicate != nullptr) {
             // Collect predicate column indicies
             ExpressionUtil::extractTupleValuesColumnIdx(a_predicate, allColumnIndices);
         }
@@ -90,8 +90,8 @@ void TableIndexScheme::setMigrate() {
    if (predicate == nullptr) {
       predicate = hiddenColumnExpr;
    } else {
-      predicate = ExpressionUtil::conjunctionFactory(ExpressionType::EXPRESSION_TYPE_CONJUNCTION_AND,
-            hiddenColumnExpr, predicate);
+      predicate = ExpressionUtil::conjunctionFactory(
+              ExpressionType::EXPRESSION_TYPE_CONJUNCTION_AND, hiddenColumnExpr, predicate);
    }
    // NOTE: we are not updating JSON expressions for the predicate, which
    // involves work on rapidjson (that we may deprecate soon), and serialization
@@ -102,21 +102,14 @@ void TableIndexScheme::setMigrate() {
       // INTEGER type).
       allColumnIndices.emplace_back(hiddenColumnIndex);
    }
-
 }
 
 TableIndex::TableIndex(const TupleSchema *keySchema, const TableIndexScheme &scheme) :
-    m_scheme(scheme),
-    m_keySchema(keySchema),
+    m_scheme(scheme), m_keySchema(keySchema),
     m_id(TableCatalogDelegate::getIndexIdString(scheme)),
 
     // initialize all the counters to zero
-    m_inserts(0),
-    m_deletes(0),
-    m_updates(0),
-
-    m_stats(this)
-{}
+    m_inserts(0), m_deletes(0), m_updates(0), m_stats(this) {}
 
 TableIndex::~TableIndex()
 {

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -204,6 +204,11 @@ protected:
                                          const TableTuple &originalTuple) = 0;
     virtual bool existsDo(const TableTuple* values) const = 0;
     virtual bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const = 0;
+
+    void notImplemented(char const* method) const {
+        throwFatalException("Invoked method %s on %s which has no implementation",
+                method, getTypeName());
+    }
 private:
     // This should always/only be required for unique key indexes used for primary keys.
     virtual TableIndex *cloneEmptyNonCountingTreeIndex() const = 0;
@@ -361,17 +366,17 @@ public:
      * We might have to make a different class in future for maximizing
      * performance of UniqueIndex.
      */
-    inline bool isUniqueIndex() const {
+    bool isUniqueIndex() const {
         return m_scheme.unique;
     }
     /**
      * Same as isUniqueIndex...
      */
-    inline bool isCountableIndex() const {
+    bool isCountableIndex() const {
         return m_scheme.countable;
     }
 
-    inline bool isMigratingIndex() const {
+    bool isMigratingIndex() const {
        return m_scheme.migrating;
     }
 
@@ -478,7 +483,7 @@ public:
     }
 
     virtual std::string debug() const;
-    virtual std::string getTypeName() const = 0;
+    virtual char const* getTypeName() const = 0;
 
     virtual void ensureCapacity(uint32_t capacity) {}
 

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -138,8 +138,7 @@ struct TableIndexScheme {
 
 struct IndexCursor {
 public:
-    IndexCursor(const TupleSchema * schema) :
-        m_forward(true), m_match(schema) {
+    IndexCursor(const TupleSchema* schema) : m_match(schema) {
         memset(m_keyIter, 0, sizeof(m_keyIter));
         memset(m_keyEndIter, 0, sizeof(m_keyEndIter));
     }
@@ -147,7 +146,7 @@ public:
     ~IndexCursor() {}
 
     // iteration stuff
-    bool m_forward;  // for tree index ONLY
+    bool m_forward = true;  // for tree index ONLY
     TableTuple m_match;
     char m_keyIter[16];
     char m_keyEndIter[16]; // for multiple tree index ONLY
@@ -190,9 +189,9 @@ protected:
     const std::string m_id;
 
     // counters
-    int m_inserts;
-    int m_deletes;
-    int m_updates;
+    int m_inserts = 0;
+    int m_deletes = 0;
+    int m_updates = 0;
 
     // stats
     IndexStats m_stats;
@@ -464,7 +463,7 @@ public:
         return m_scheme.name;
     }
 
-    void rename(std::string name) {
+    void rename(std::string const& name) {
         if (m_scheme.name.compare(name) != 0) {
             m_scheme.name = name;
             IndexStats *stats = getIndexStats();

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -206,9 +206,7 @@ protected:
     virtual bool checkForIndexChangeDo(const TableTuple *lhs, const TableTuple *rhs) const = 0;
 private:
     // This should always/only be required for unique key indexes used for primary keys.
-    virtual TableIndex *cloneEmptyNonCountingTreeIndex() const {
-        throwFatalException("Primary key index discovered to be non-unique or missing a cloneEmptyTreeIndex implementation.");
-    }
+    virtual TableIndex *cloneEmptyNonCountingTreeIndex() const = 0;
 
     ThreadLocalPool m_tlPool;
 public:
@@ -281,9 +279,7 @@ public:
      *      data, but chosen values for this index.  So, searchKey has
      *      to contain values in this index's entry order.
      */
-    virtual void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrGreater which has no implementation");
-    };
+    virtual void moveToKeyOrGreater(const TableTuple *searchKey, IndexCursor& cursor) const = 0;
 
     /**
      * This method moves to the first tuple greater than given key.
@@ -293,30 +289,18 @@ public:
      *      data, but chosen values for this index.  So, searchKey has
      *      to contain values in this index's entry order.
      */
-    virtual bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToGreaterThanKey which has no implementation");
-    };
+    virtual bool moveToGreaterThanKey(const TableTuple *searchKey, IndexCursor& cursor) const = 0;
 
-    virtual void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToLessThanKey which has no implementation");
-    };
+    virtual void moveToLessThanKey(const TableTuple *searchKey, IndexCursor& cursor) const = 0;
 
     // move the cursor to the first tuple less than or equal to the given key.
-    virtual void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) {
-        throwFatalException("Invoked TableIndex virtual method moveToKeyOrLess which has no implementation");
-    };
+    virtual void moveToKeyOrLess(TableTuple *searchKey, IndexCursor& cursor) const = 0;
 
-    virtual bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToCoveringCell which has no implementation");
-    }
+    virtual bool moveToCoveringCell(const TableTuple* searchKey, IndexCursor &cursor) const = 0;
 
-    virtual void moveToBeforePriorEntry(IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToBeforePriorEntry which has no implementation");
-    }
+    virtual void moveToBeforePriorEntry(IndexCursor& cursor) const = 0;
 
-    virtual void moveToPriorEntry(IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToPriorEntry which has no implementation");
-    }
+    virtual void moveToPriorEntry(IndexCursor& cursor) const = 0;
 
     /**
      * This method moves to the beginning or the end of the indexes.
@@ -324,9 +308,7 @@ public:
      *
      * @see begin true to move to the beginning, false to the end.
      */
-    virtual void moveToEnd(bool begin, IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method moveToEnd which has no implementation");
-    }
+    virtual void moveToEnd(bool begin, IndexCursor& cursor) const = 0;
 
     /**
      * sets the tuple to point the entry found by
@@ -336,9 +318,7 @@ public:
      * @return true if any entry to return, false if reached the end
      * of this index.
      */
-    virtual TableTuple nextValue(IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method nextValue which has no implementation");
-    };
+    virtual TableTuple nextValue(IndexCursor& cursor) const = 0;
 
     /**
      * sets the tuple to point the entry found by moveToKey().  calls
@@ -363,16 +343,12 @@ public:
      *
      * @return true if any entry to return, false if not.
      */
-    virtual bool advanceToNextKey(IndexCursor& cursor) const {
-        throwFatalException("Invoked TableIndex virtual method advanceToNextKey which has no implementation");
-    };
+    virtual bool advanceToNextKey(IndexCursor& cursor) const = 0;
 
     /** retrieves from a primary key index the persistent tuple
      *  matching the given temp tuple.  The tuple's schema should be
      *  the table's schema, not the index's key schema.  */
-    virtual TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const {
-        throwFatalException("Invoked TableIndex virtual method uniqueMatchingTuple which has no use on a non-unique index");
-    };
+    virtual TableTuple uniqueMatchingTuple(const TableTuple &searchTuple) const = 0;
 
     /**
      * @return true if lhs is different from rhs in this index, which
@@ -419,9 +395,8 @@ public:
      * @Return great than rank value as "m_entries.size() + 1"  for given
      * searchKey that is larger than all keys.
      */
-    virtual int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterGET which has no implementation");
-    }
+    virtual int64_t getCounterGET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const = 0;
+
     /**
      * This function only supports countable tree index. It returns the counter value
      * equal or less than the serarchKey. It will return the rank with the searchKey
@@ -433,9 +408,7 @@ public:
      * @Return less than rank value as "m_entries.size()"  for given
      * searchKey that is larger than all keys.
      */
-    virtual int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const {
-        throwFatalException("Invoked non-countable TableIndex virtual method getCounterLET which has no implementation");
-    }
+    virtual int64_t getCounterLET(const TableTuple *searchKey, bool isUpper, IndexCursor& cursor) const = 0;
 
     // dense rank value tuple look up
 
@@ -451,9 +424,7 @@ public:
      * @param cursor IndexCursor object
      * @return true if it finds tuple with the dense rank value, otherwise false
      */
-    virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const {
-        throwFatalException("Invoked non-countable TableIndex virtual method moveToRankTuple which has no implementation");
-    }
+    virtual bool moveToRankTuple(int64_t denseRank, bool forward, IndexCursor& cursor) const = 0;
 
     virtual size_t getSize() const = 0;
 

--- a/src/ee/indexes/tableindexfactory.cpp
+++ b/src/ee/indexes/tableindexfactory.cpp
@@ -92,7 +92,7 @@ class TableIndexPicker {
         } else if (m_intsOnly) {
             // The IntsKey size parameter ((KeySize-1)/8 + 1) is calculated to be
             // the number of 8-byte uint64's required to store KeySize packed bytes.
-            return getInstanceForKeyType<IntsKey<(KeySize-1)/8 + 1> >();
+            return getInstanceForKeyType<IntsKey<(KeySize-1)/8 + 1>>();
         }
         // Generic Key
         if (m_type == HASH_TABLE_INDEX) {
@@ -107,18 +107,18 @@ class TableIndexPicker {
         // That's exactly what the GenericPersistentKey subtype of GenericKey does. This incurs extra overhead
         // for object copying and freeing, so is only enabled as needed.
         if (m_inlinesOrColumnsOnly) {
-            return getInstanceForKeyType<GenericKey<KeySize> >();
+            return getInstanceForKeyType<GenericKey<KeySize>>();
         } else {
-            return getInstanceForKeyType<GenericPersistentKey<KeySize> >();
+            return getInstanceForKeyType<GenericPersistentKey<KeySize>>();
         }
     }
 
     template <int ColCount>
     TableIndex *getInstanceForHashedGenericColumns() const {
         if (m_scheme.unique) {
-            return new CompactingHashUniqueIndex<GenericKey<ColCount> >(m_keySchema, m_scheme);
+            return new CompactingHashUniqueIndex<GenericKey<ColCount>>(m_keySchema, m_scheme);
         } else {
-            return new CompactingHashMultiMapIndex<GenericKey<ColCount> >(m_keySchema, m_scheme);
+            return new CompactingHashMultiMapIndex<GenericKey<ColCount>>(m_keySchema, m_scheme);
         }
     }
 
@@ -176,12 +176,12 @@ public:
 
         if (m_scheme.unique) {
             if (m_scheme.countable) {
-                return new CompactingTreeUniqueIndex<NormalKeyValuePair<TupleKey>, true >(m_keySchema, m_scheme);
+                return new CompactingTreeUniqueIndex<NormalKeyValuePair<TupleKey>, true>(m_keySchema, m_scheme);
             } else {
                 return new CompactingTreeUniqueIndex<NormalKeyValuePair<TupleKey>, false>(m_keySchema, m_scheme);
             }
         } else if (m_scheme.countable) {
-            return new CompactingTreeMultiMapIndex<PointerKeyValuePair<TupleKey>, true >(m_keySchema, m_scheme);
+            return new CompactingTreeMultiMapIndex<PointerKeyValuePair<TupleKey>, true>(m_keySchema, m_scheme);
         } else {
             return new CompactingTreeMultiMapIndex<PointerKeyValuePair<TupleKey>, false>(m_keySchema, m_scheme);
         }

--- a/src/ee/indexes/tableindexfactory.h
+++ b/src/ee/indexes/tableindexfactory.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef TABLEINDEXFACTORY_H_
-#define TABLEINDEXFACTORY_H_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -63,4 +62,3 @@ public:
 
 }
 
-#endif // TABLEINDEXFACTORY_H_

--- a/src/ee/stats/StatsAgent.h
+++ b/src/ee/stats/StatsAgent.h
@@ -15,8 +15,7 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef STATSAGENT_H_
-#define STATSAGENT_H_
+#pragma once
 
 #include "common/ids.h"
 #include "common/types.h"
@@ -33,11 +32,20 @@ class TempTable;
  * could be extended to include stats about plan fragments and the temp tables connecting them.
  */
 class StatsAgent {
+    /**
+     * Map from a statistics selector to a map of CatalogIds to StatsSources.
+     */
+    std::map<StatisticsSelectorType, std::multimap<CatalogId, StatsSource*>> m_statsCategoryByStatsSelector;
+
+    /**
+     * Temporary tables for aggregating the results of table statistics keyed by type of statistic
+     */
+    std::map<StatisticsSelectorType, TempTable*> m_statsTablesByStatsSelector;
 public:
     /**
      * Do nothing constructor
      */
-    StatsAgent();
+    StatsAgent() = default;
 
     /**
      * Associate the specified StatsSource with the specified CatalogId under the specified StatsSelector
@@ -45,12 +53,12 @@ public:
      * @param catalogId CatalogId of the resource
      * @param statsSource statsSource containing statistics for the resource
      */
-    void registerStatsSource(voltdb::StatisticsSelectorType sst, voltdb::CatalogId catalogId, voltdb::StatsSource* statsSource);
+    void registerStatsSource(StatisticsSelectorType sst, CatalogId catalogId, StatsSource* statsSource);
 
     /**
      * Unassociate all instances of this selector type
      */
-    void unregisterStatsSource(voltdb::StatisticsSelectorType sst, int32_t relativeIndexOfTable = -1);
+    void unregisterStatsSource(StatisticsSelectorType sst, int32_t relativeIndexOfTable = -1);
 
     /**
      * Get statistics for the specified resources
@@ -60,26 +68,14 @@ public:
      * @param now Timestamp to return with each row
      */
     TempTable* getStats(
-            voltdb::StatisticsSelectorType sst,
+            StatisticsSelectorType sst,
             int64_t m_siteId, int32_t m_partitionId,
-            std::vector<voltdb::CatalogId> catalogIds,
+            std::vector<CatalogId> catalogIds,
             bool interval,
             int64_t now);
 
     ~StatsAgent();
-
-private:
-    /**
-     * Map from a statistics selector to a map of CatalogIds to StatsSources.
-     */
-    std::map<voltdb::StatisticsSelectorType, std::multimap<voltdb::CatalogId, voltdb::StatsSource*> > m_statsCategoryByStatsSelector;
-
-    /**
-     * Temporary tables for aggregating the results of table statistics keyed by type of statistic
-     */
-    std::map<voltdb::StatisticsSelectorType, voltdb::TempTable*> m_statsTablesByStatsSelector;
 };
 
 }
 
-#endif /* STATSAGENT_H_ */

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -41,8 +41,8 @@ StatsSource::schema_type StatsSource::populateBaseSchema() {
         names.emplace_back(get<0>(t));
         types.emplace_back(get<1>(t));
         columnLengths.emplace_back(get<2>(t));
-        allowNull.emplace_back(get<3>(t));
-        inBytes.emplace_back(get<4>(t));
+        allowNull.push_back(get<3>(t));
+        inBytes.push_back(get<4>(t));
     }
     return make_tuple(names, types, columnLengths, allowNull, inBytes);
 }

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -51,7 +51,8 @@ class StatsSource {
     bool m_interval;
     static std::vector<std::string> const STATS_COLUMN_NAMES;
     /**
-     * ValueType, column length, allow nulls, in bytes */
+     * column name, ValueType, column length, allow nulls, in bytes
+     */
     static std::array<std::tuple<ValueType, int32_t, bool, bool>, 5> const BASE_SCHEMA;
 protected:
     /**

--- a/src/ee/storage/ConstraintFailureException.cpp
+++ b/src/ee/storage/ConstraintFailureException.cpp
@@ -66,7 +66,7 @@ void ConstraintFailureException::p_serialize(ReferenceSerializeOutput *output) c
     } else {
         m_table->serializeTupleTo(*output, tuples, 2);
     }
-    output->writeIntAt(tableSizePosition, static_cast<int32_t>(output->position() - tableSizePosition - 4));
+    output->writeIntAt(tableSizePosition, output->position() - tableSizePosition - 4);
 }
 
 ConstraintFailureException::~ConstraintFailureException() throw () {

--- a/src/ee/storage/PersistentTableStats.cpp
+++ b/src/ee/storage/PersistentTableStats.cpp
@@ -16,20 +16,7 @@
  */
 #include "storage/PersistentTableStats.h"
 #include "storage/persistenttable.h"
-#include "common/executorcontext.hpp"
-#include "execution/VoltDBEngine.h"
-#include <vector>
-#include <string>
 
 namespace voltdb {
-
-PersistentTableStats::PersistentTableStats(voltdb::PersistentTable* table)
-  : voltdb::TableStats(table)
-{
-}
-
-std::vector<std::string> PersistentTableStats::generateStatsColumnNames() {
-    std::vector<std::string> columnNames = TableStats::generateStatsColumnNames();
-    return columnNames;
-}
+PersistentTableStats::PersistentTableStats(PersistentTable* table) : TableStats(table) {}
 }

--- a/src/ee/storage/PersistentTableStats.h
+++ b/src/ee/storage/PersistentTableStats.h
@@ -15,8 +15,7 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PERSISTENTTABLESTATS_H_
-#define PERSISTENTTABLESTATS_H_
+#pragma once
 
 #include "storage/TableStats.h"
 #include <vector>
@@ -28,13 +27,10 @@ class PersistentTable;
 /**
  * Further specialization of TableStats that currently adds no extra functionality.
  */
-class PersistentTableStats : public voltdb::TableStats {
-  public:
-    PersistentTableStats(voltdb::PersistentTable* table);
-  protected:
-    virtual std::vector<std::string> generateStatsColumnNames();
+class PersistentTableStats : public TableStats {
+    public:
+        PersistentTableStats(PersistentTable* table);
 };
 
 }
 
-#endif /* PERSISTENTTABLESTATS_H_ */

--- a/src/ee/storage/StreamedTableStats.cpp
+++ b/src/ee/storage/StreamedTableStats.cpp
@@ -15,17 +15,8 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "storage/StreamedTableStats.h"
-#include "storage/streamedtable.h"
-#include <vector>
-#include <string>
+#include "storage/persistenttable.h"
 
 namespace voltdb {
-
-StreamedTableStats::StreamedTableStats(voltdb::StreamedTable* table) : voltdb::TableStats(table) {
-}
-
-std::vector<std::string> StreamedTableStats::generateStatsColumnNames() {
-    std::vector<std::string> columnNames = TableStats::generateStatsColumnNames();
-    return columnNames;
-}
+StreamedTableStats::StreamedTableStats(voltdb::StreamedTable* table) : voltdb::TableStats(table) {}
 }

--- a/src/ee/storage/StreamedTableStats.h
+++ b/src/ee/storage/StreamedTableStats.h
@@ -15,8 +15,7 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef STREAMEDTABLESTATS_H_
-#define STREAMEDTABLESTATS_H_
+#pragma once
 
 #include "storage/TableStats.h"
 #include <vector>
@@ -28,13 +27,10 @@ class StreamedTable;
 /**
  * Further specialization of TableStats that currently adds no extra functionality.
  */
-class StreamedTableStats : public voltdb::TableStats {
+class StreamedTableStats : public TableStats {
   public:
-    StreamedTableStats(voltdb::StreamedTable* table);
-  protected:
-    virtual std::vector<std::string> generateStatsColumnNames();
+    StreamedTableStats(StreamedTable* table);
 };
 
 }
 
-#endif /* STREAMEDTABLESTATS_H_ */

--- a/src/ee/storage/TableStats.cpp
+++ b/src/ee/storage/TableStats.cpp
@@ -30,16 +30,24 @@
 using namespace voltdb;
 using namespace std;
 
+array<tuple<string, ValueType, int32_t, bool, bool>, 8> const TableStats::BASE_SCHEMA = {
+    make_tuple("TABLE_NAME", ValueType::tVARCHAR, 4096, false, false),
+    make_tuple("TABLE_TYPE", ValueType::tVARCHAR, 4096, false, false),
+
+    make_tuple("TUPLE_COUNT", ValueType::tBIGINT, NValue::getTupleStorageSize(ValueType::tBIGINT), false, false),
+    make_tuple("TUPLE_ALLOCATED_MEMORY", ValueType::tBIGINT, NValue::getTupleStorageSize(ValueType::tBIGINT), false, false),
+    make_tuple("TUPLE_DATA_MEMORY", ValueType::tBIGINT, NValue::getTupleStorageSize(ValueType::tBIGINT), false, false),
+    make_tuple("STRING_DATA_MEMORY", ValueType::tBIGINT, NValue::getTupleStorageSize(ValueType::tBIGINT), false, false),
+
+    make_tuple("TUPLE_LIMIT", ValueType::tINTEGER, NValue::getTupleStorageSize(ValueType::tINTEGER), false, false),
+    make_tuple("PERCENT_FULL", ValueType::tINTEGER, NValue::getTupleStorageSize(ValueType::tINTEGER), false, false)
+};
+
 vector<string> TableStats::generateTableStatsColumnNames() {
     vector<string> columnNames = StatsSource::generateBaseStatsColumnNames();
-    columnNames.push_back("TABLE_NAME");
-    columnNames.push_back("TABLE_TYPE");
-    columnNames.push_back("TUPLE_COUNT");
-    columnNames.push_back("TUPLE_ALLOCATED_MEMORY");
-    columnNames.push_back("TUPLE_DATA_MEMORY");
-    columnNames.push_back("STRING_DATA_MEMORY");
-    columnNames.push_back("TUPLE_LIMIT");
-    columnNames.push_back("PERCENT_FULL");
+    for (auto const& t : BASE_SCHEMA) {
+        columnNames.emplace_back(get<0>(t));
+    }
     return columnNames;
 }
 
@@ -48,45 +56,12 @@ vector<string> TableStats::generateTableStatsColumnNames() {
 void TableStats::populateTableStatsSchema(vector<ValueType> &types, vector<int32_t> &columnLengths, vector<bool> &allowNull,
         vector<bool> &inBytes) {
     StatsSource::populateBaseSchema(types, columnLengths, allowNull, inBytes);
-    types.push_back(ValueType::tVARCHAR);
-    columnLengths.push_back(4096);
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tVARCHAR);
-    columnLengths.push_back(4096);
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tBIGINT);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tBIGINT));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tBIGINT);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tBIGINT));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tBIGINT);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tBIGINT));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tBIGINT);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tBIGINT));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tINTEGER);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tINTEGER));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
-
-    types.push_back(ValueType::tINTEGER);
-    columnLengths.push_back(NValue::getTupleStorageSize(ValueType::tINTEGER));
-    allowNull.push_back(false);
-    inBytes.push_back(false);
+    for (auto const& t : BASE_SCHEMA) {
+        types.emplace_back(get<1>(t));
+        columnLengths.emplace_back(get<2>(t));
+        allowNull.emplace_back(get<3>(t));
+        inBytes.emplace_back(get<4>(t));
+    }
 }
 
 TempTable* TableStats::generateEmptyTableStatsTable() {
@@ -99,7 +74,7 @@ TempTable* TableStats::generateEmptyTableStatsTable() {
     TableStats::populateTableStatsSchema(columnTypes, columnLengths, columnAllowNull, columnInBytes);
     TupleSchema *schema = TupleSchema::createTupleSchema(columnTypes, columnLengths,
             columnAllowNull, columnInBytes);
-    return TableFactory::buildTempTable(name, schema, columnNames, NULL);
+    return TableFactory::buildTempTable(name, schema, columnNames, nullptr);
 }
 
 /*
@@ -193,7 +168,7 @@ void TableStats::populateSchema(vector<ValueType>& types,
         vector<int32_t>& columnLengths,
         vector<bool>& allowNull,
         vector<bool>& inBytes) {
-    TableStats::populateTableStatsSchema(types, columnLengths, allowNull, inBytes);
+    populateTableStatsSchema(types, columnLengths, allowNull, inBytes);
 }
 
 TableStats::~TableStats() {

--- a/src/ee/storage/TableStats.h
+++ b/src/ee/storage/TableStats.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <array>
 #include "stats/StatsSource.h"
 
 namespace voltdb {
@@ -37,6 +38,8 @@ class TableStats : public StatsSource {
     int64_t m_lastAllocatedTupleMemory = 0;
     int64_t m_lastOccupiedTupleMemory = 0;
     int64_t m_lastStringDataMemory = 0;
+
+    static std::array<std::tuple<std::string, ValueType, int32_t, bool, bool>, 8> const BASE_SCHEMA;
 public:
     /**
      * Static method to generate the column names for the tables which
@@ -70,29 +73,28 @@ public:
      * @parameter name Name of this set of statistics
      */
     void configure(std::string const& name);
-
 protected:
 
     /**
      * Update the stats tuple with the latest statistics available to this StatsSource.
      */
-    virtual void updateStatsTuple(TableTuple *tuple);
+    void updateStatsTuple(TableTuple *tuple) override;
 
     /**
      * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
      * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
      * contributing to the end of the list.
      */
-    virtual std::vector<std::string> generateStatsColumnNames() const;
+    std::vector<std::string> generateStatsColumnNames() const override;
 
     /**
      * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
      * end of a list.
      */
-    virtual void populateSchema(std::vector<ValueType>& types,
+    void populateSchema(std::vector<ValueType>& types,
             std::vector<int32_t>& columnLengths,
             std::vector<bool>& allowNull,
-            std::vector<bool>& inBytes);
+            std::vector<bool>& inBytes) override;
 };
 
 }

--- a/src/ee/storage/TableStats.h
+++ b/src/ee/storage/TableStats.h
@@ -39,22 +39,19 @@ class TableStats : public StatsSource {
     int64_t m_lastOccupiedTupleMemory = 0;
     int64_t m_lastStringDataMemory = 0;
 
-    static std::array<std::tuple<std::string, ValueType, int32_t, bool, bool>, 8> const BASE_SCHEMA;
-public:
+    static std::array<schema_tuple_type, 8> const BASE_SCHEMA;
     /**
      * Static method to generate the column names for the tables which
      * contain persistent table stats.
      */
-    static std::vector<std::string> generateTableStatsColumnNames();
+    static std::vector<std::string> generateStatsColumnNames();
+public:
 
     /**
      * Static method to generate the remaining schema information for
      * the tables which contain persistent table stats.
      */
-    static void populateTableStatsSchema(std::vector<ValueType>& types,
-            std::vector<int32_t>& columnLengths,
-            std::vector<bool>& allowNull,
-            std::vector<bool>& inBytes);
+    static schema_type populateTableStatsSchema();
 
     /**
      * Return an empty TableStats table
@@ -81,20 +78,10 @@ protected:
     void updateStatsTuple(TableTuple *tuple) override;
 
     /**
-     * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
-     * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
-     * contributing to the end of the list.
-     */
-    std::vector<std::string> generateStatsColumnNames() const override;
-
-    /**
      * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
      * end of a list.
      */
-    void populateSchema(std::vector<ValueType>& types,
-            std::vector<int32_t>& columnLengths,
-            std::vector<bool>& allowNull,
-            std::vector<bool>& inBytes) override;
+    schema_type populateSchema() override;
 };
 
 }

--- a/src/ee/storage/TableStats.h
+++ b/src/ee/storage/TableStats.h
@@ -28,6 +28,15 @@ class TempTable;
  * StatsSource extension for tables.
  */
 class TableStats : public StatsSource {
+    /**
+     * Table whose stats are being collected.
+     */
+    Table* m_table;
+    NValue m_tableType;
+    int64_t m_lastTupleCount = 0;
+    int64_t m_lastAllocatedTupleMemory = 0;
+    int64_t m_lastOccupiedTupleMemory = 0;
+    int64_t m_lastStringDataMemory = 0;
 public:
     /**
      * Static method to generate the column names for the tables which
@@ -39,8 +48,10 @@ public:
      * Static method to generate the remaining schema information for
      * the tables which contain persistent table stats.
      */
-    static void populateTableStatsSchema(std::vector<voltdb::ValueType>& types, std::vector<int32_t>& columnLengths,
-            std::vector<bool>& allowNull, std::vector<bool>& inBytes);
+    static void populateTableStatsSchema(std::vector<ValueType>& types,
+            std::vector<int32_t>& columnLengths,
+            std::vector<bool>& allowNull,
+            std::vector<bool>& inBytes);
 
     /**
      * Return an empty TableStats table
@@ -50,7 +61,8 @@ public:
     /*
      * Constructor caches reference to the table that will be generating the statistics
      */
-    TableStats(voltdb::Table* table);
+    TableStats(Table* table);
+    ~TableStats();
 
     /**
      * Configure a StatsSource superclass for a set of statistics. Since this class is only used in the EE it can be assumed that
@@ -64,36 +76,23 @@ protected:
     /**
      * Update the stats tuple with the latest statistics available to this StatsSource.
      */
-    virtual void updateStatsTuple(voltdb::TableTuple *tuple);
+    virtual void updateStatsTuple(TableTuple *tuple);
 
     /**
      * Generates the list of column names that will be in the statTable_. Derived classes must override this method and call
      * the parent class's version to obtain the list of columns contributed by ancestors and then append the columns they will be
      * contributing to the end of the list.
      */
-    virtual std::vector<std::string> generateStatsColumnNames();
+    virtual std::vector<std::string> generateStatsColumnNames() const;
 
     /**
      * Same pattern as generateStatsColumnNames except the return value is used as an offset into the tuple schema instead of appending to
      * end of a list.
      */
-    virtual void populateSchema(std::vector<voltdb::ValueType> &types, std::vector<int32_t> &columnLengths,
-            std::vector<bool> &allowNull, std::vector<bool> &inBytes);
-
-    ~TableStats();
-
-private:
-    /**
-     * Table whose stats are being collected.
-     */
-    voltdb::Table* m_table;
-
-    voltdb::NValue m_tableType;
-
-    int64_t m_lastTupleCount;
-    int64_t m_lastAllocatedTupleMemory;
-    int64_t m_lastOccupiedTupleMemory;
-    int64_t m_lastStringDataMemory;
+    virtual void populateSchema(std::vector<ValueType>& types,
+            std::vector<int32_t>& columnLengths,
+            std::vector<bool>& allowNull,
+            std::vector<bool>& inBytes);
 };
 
 }

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -393,7 +393,7 @@ public:
     std::vector<MaterializedViewTriggerForWrite*>& views() { return m_views; }
 
     TableTuple& copyIntoTempTuple(TableTuple& source) {
-        vassert(m_tempTuple.m_data);
+        vassert(m_tempTuple.address());
         m_tempTuple.copy(source);
         return m_tempTuple;
     }

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -64,9 +64,7 @@ using std::string;
 namespace voltdb {
 
 Table::Table(int tableAllocationTargetSize) :
-    m_tableAllocationTargetSize(tableAllocationTargetSize)
-{
-}
+    m_tableAllocationTargetSize(tableAllocationTargetSize) { }
 
 Table::~Table() {
     // not all tables are reference counted but this should be invariant
@@ -401,26 +399,18 @@ void Table::serializeTupleTo(SerializeOutput &serialOutput, voltdb::TableTuple *
 bool Table::equals(voltdb::Table *other) {
     if (columnCount() != other->columnCount()) {
         return false;
-    }
-
-    if (activeTupleCount() != other->activeTupleCount()) {
+    } else if (activeTupleCount() != other->activeTupleCount()) {
         return false;
-    }
-
-    if (databaseId() != other->databaseId()) {
+    } else if (databaseId() != other->databaseId()) {
         return false;
-    }
-
-    if (name() != other->name()) {
+    } else if (name() != other->name()) {
         return false;
-    }
-
-    if (tableType() != other->tableType()) {
+    } else if (tableType() != other->tableType()) {
         return false;
     }
 
     const voltdb::TupleSchema *otherSchema = other->schema();
-    if ( ! m_schema->equals(otherSchema)) {
+    if (! m_schema->equals(otherSchema)) {
         return false;
     }
 
@@ -429,11 +419,9 @@ bool Table::equals(voltdb::Table *other) {
     voltdb::TableTuple firstTuple(m_schema);
     voltdb::TableTuple secondTuple(otherSchema);
     while (firstTI.next(firstTuple)) {
-        if ( ! secondTI.next(secondTuple)) {
+        if (! secondTI.next(secondTuple)) {
             return false;
-        }
-
-        if ( ! firstTuple.equals(secondTuple)) {
+        } else if (! firstTuple.equals(secondTuple)) {
             return false;
         }
     }
@@ -457,12 +445,11 @@ void Table::loadTuplesFromNoHeader(SerializeInputBE &serialInput,
 
         target.deserializeFrom(serialInput, stringPool, LoadTableCaller::get(LoadTableCaller::INTERNAL));
 
-        processLoadedTuple(target, NULL, serializedTupleCount, tupleCountPosition);
+        processLoadedTuple(target, nullptr, serializedTupleCount, tupleCountPosition);
     }
 }
 
-void Table::loadTuplesFrom(SerializeInputBE &serialInput,
-                           Pool *stringPool) {
+void Table::loadTuplesFrom(SerializeInputBE &serialInput, Pool *stringPool) {
     /*
      * directly receives a VoltTable buffer.
      * [00 01]   [02 03]   [04 .. 0x]

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -393,7 +393,7 @@ void Table::serializeTupleTo(SerializeOutput &serialOutput, voltdb::TableTuple *
         tuples[ii].serializeTo(serialOutput);
     }
 
-    serialOutput.writeIntAt(pos, static_cast<int32_t>(serialOutput.position() - pos - sizeof(int32_t)));
+    serialOutput.writeIntAt(pos, serialOutput.position() - pos - sizeof(int32_t));
 }
 
 bool Table::equals(voltdb::Table *other) {

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -49,8 +49,8 @@ template <typename Key, typename Data = const void*>
 class NormalKeyValuePair : public std::pair<Key, Data> {
     using super = std::pair<Key, Data>;
 public:
-    NormalKeyValuePair() {}
-    NormalKeyValuePair(const Key &key, const Data &value) : std::pair<Key, Data>(key, value) {}
+    NormalKeyValuePair() = default;
+    NormalKeyValuePair(const Key &key, const Data &value) : super(key, value) {}
 
     const Key& getKey() const {
         return super::first;
@@ -218,7 +218,9 @@ public:
     ~CompactingMap();
 
     // TODO: remove this. But two eecheck depend on this.
-    bool insert(std::pair<Key, Data> value) { return (insert(value.first, value.second) == NULL); };
+    bool insert(std::pair<Key, Data> value) {
+        return insert(value.first, value.second) == NULL;
+    };
     // A syntactically convenient analog to CompactingHashTable's insert function
     const Data *insert(const Key &key, const Data &data);
     bool erase(const Key &key);
@@ -402,7 +404,7 @@ CompactingMap<KeyValuePair, Compare, hasRank>::insert(const Key &key, const Data
     }
     m_count++;
     vassert(m_allocator.count() == m_count);
-    return NULL;
+    return nullptr;
 }
 
 template<typename KeyValuePair, typename Compare, bool hasRank>


### PR DESCRIPTION
An unordered list of some of these changes/reasons:
 - Move a few long methods from NValue.hpp to NValue.cpp, to help reduce debug cycle on them.
 - Changed method signatures or local argument types to be better descriptive (more restricting)
 - Made a few private methods of `TableTuple` public, to eliminate all `friend`s (being public is better than having friends!)
 - Removed redundant `inline` keywords, `voltdb::` namespace qualifiers, casts, methods that does exactly the same thing as some other methods, etc.
 - Improved design of `TableIndex` class to make it more abstract (making more virtual methods pure)
 - Used newer static initialization for *Stats
 - In debug build, added `TableTuple*` member to `GenericKey` template to keep track of original table tuple it points to, to help debugging index updates.

----
Follow up:
See commented assertion check in L416, indexkey.h. This could potentially cause some big trouble (data corruption).