### PR TITLE
ENG-18013: Only start tasks when all hosts are ready

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1520,7 +1520,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 VoltDB.crashLocalVoltDB(e.getMessage(), true, e);
             }
 
-            m_taskManager = new TaskManager(m_clientInterface, getStatsAgent(), m_myHostId);
+            m_taskManager = new TaskManager(m_clientInterface, getStatsAgent(), m_myHostId,
+                    m_config.m_startAction == StartAction.JOIN);
             m_globalServiceElector.registerService(() -> m_taskManager.promoteToLeader(m_catalogContext));
 
             // DR overflow directory

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -2692,50 +2692,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         + m_config.m_pathToDeployment, false, null);
             }
 
-            /*
-             * Check for invalid deployment file settings (enterprise-only) in the community edition.
-             * Trick here is to print out all applicable problems and then stop, rather than stopping
-             * after the first one is found.
-             */
-            if (!m_config.m_isEnterprise) {
-                boolean shutdownDeployment = false;
-                boolean shutdownAction = false;
-
-                // check license features for community version
-                if ((deployment.getCommandlog() != null) && (deployment.getCommandlog().isEnabled())) {
-                    consoleLog.error("Command logging is not supported " +
-                            "in the community edition of VoltDB.");
-                    shutdownDeployment = true;
-                }
-                if (deployment.getDr() != null && deployment.getDr().getRole() != DrRoleType.NONE) {
-                    consoleLog.warn("Database Replication is not supported " +
-                            "in the community edition of VoltDB.");
-                }
-                // check the start action for the community edition
-                if (m_config.m_startAction == StartAction.JOIN) {
-                    consoleLog.error("Start action \"" + m_config.m_startAction.getClass().getSimpleName() +
-                            "\" is not supported in the community edition of VoltDB.");
-                    shutdownAction = true;
-                }
-
-                // if the process needs to stop, try to be helpful
-                if (shutdownAction || shutdownDeployment) {
-                    String msg = "This process will exit. Please run VoltDB with ";
-                    if (shutdownDeployment) {
-                        msg += "a deployment file compatible with the community edition";
-                    }
-                    if (shutdownDeployment && shutdownAction) {
-                        msg += " and ";
-                    }
-
-                    if (shutdownAction && !shutdownDeployment) {
-                        msg += "the CREATE start action";
-                    }
-                    msg += ".";
-
-                    VoltDB.crashLocalVoltDB(msg, false, null);
-                }
-            }
+            checkForEnterpriseFeatures(deployment, true);
 
             // note the heart beats are specified in seconds in xml, but ms internally
             HeartbeatType hbt = deployment.getHeartbeat();
@@ -2919,45 +2876,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             } else {
                 config.m_hostCount = deployment.getCluster().getHostcount();
             }
-            /*
-             * Check for invalid deployment file settings (enterprise-only) in the community edition.
-             * Trick here is to print out all applicable problems and then stop, rather than stopping
-             * after the first one is found.
-             */
-            if (!config.m_isEnterprise) {
-                boolean shutdownDeployment = false;
-                boolean shutdownAction = false;
 
-                // check license features for community version
-                if ((deployment.getCommandlog() != null) && (deployment.getCommandlog().isEnabled())) {
-                    consoleLog.error("Command logging is not supported " +
-                            "in the community edition of VoltDB.");
-                    shutdownDeployment = true;
-                }
-                if (m_config.m_startAction == StartAction.JOIN) {
-                    consoleLog.error("Start action \"" + m_config.m_startAction.getClass().getSimpleName() +
-                            "\" is not supported in the community edition of VoltDB.");
-                    shutdownAction = true;
-                }
-
-                // if the process needs to stop, try to be helpful
-                if (shutdownAction || shutdownDeployment) {
-                    String msg = "This process will exit. Please run VoltDB with ";
-                    if (shutdownDeployment) {
-                        msg += "a deployment file compatible with the community edition";
-                    }
-                    if (shutdownDeployment && shutdownAction) {
-                        msg += " and ";
-                    }
-
-                    if (shutdownAction && !shutdownDeployment) {
-                        msg += "the CREATE start action";
-                    }
-                    msg += ".";
-
-                    VoltDB.crashLocalVoltDB(msg, false, null);
-                }
-            }
+            checkForEnterpriseFeatures(deployment, false);
             return new ReadDeploymentResults(deploymentBytes, deployment);
         } catch (Exception e) {
             /*
@@ -2967,6 +2887,50 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             consoleLog.fatal(e.getMessage());
             VoltDB.crashLocalVoltDB(e.getMessage());
             return null;
+        }
+    }
+
+    /**
+     * Check for invalid deployment file settings (enterprise-only) in the community edition. Trick here is to print out
+     * all applicable problems and then stop, rather than stopping after the first one is found.
+     */
+    private void checkForEnterpriseFeatures(DeploymentType deployment, boolean checkForDr) {
+        if (!m_config.m_isEnterprise) {
+            boolean shutdownDeployment = false;
+            boolean shutdownAction = false;
+
+            // check license features for community version
+            if ((deployment.getCommandlog() != null) && (deployment.getCommandlog().isEnabled())) {
+                consoleLog.error("Command logging is not supported in the community edition of VoltDB.");
+                shutdownDeployment = true;
+            }
+            if (checkForDr && deployment.getDr() != null && deployment.getDr().getRole() != DrRoleType.NONE) {
+                consoleLog.warn("Database Replication is not supported in the community edition of VoltDB.");
+            }
+            // check the start action for the community edition
+            if (m_config.m_startAction == StartAction.JOIN) {
+                consoleLog.error("Start action \"" + m_config.m_startAction.name()
+                        + "\" is not supported in the community edition of VoltDB.");
+                shutdownAction = true;
+            }
+
+            // if the process needs to stop, try to be helpful
+            if (shutdownAction || shutdownDeployment) {
+                String msg = "This process will exit. Please run VoltDB with ";
+                if (shutdownDeployment) {
+                    msg += "a deployment file compatible with the community edition";
+                }
+                if (shutdownDeployment && shutdownAction) {
+                    msg += " and ";
+                }
+
+                if (shutdownAction && !shutdownDeployment) {
+                    msg += "the CREATE start action";
+                }
+                msg += ".";
+
+                VoltDB.crashLocalVoltDB(msg, false, null);
+            }
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -288,13 +288,6 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
     @Override
     public void logTask(TransactionInfoBaseMessage message) throws IOException
     {
-        //TODO: Remove temporary debug for ENG-18013
-        if (message instanceof Iv2InitiateTaskMessage) {
-            Iv2InitiateTaskMessage itm = (Iv2InitiateTaskMessage) message;
-            ELASTICLOG.warn("Received unexpected Iv2InitiateTaskMessage for procedure " + itm.getStoredProcedureName() +
-                    " for partition " + itm.getStoredProcedureInvocation().getPartitionDestination() +
-                    ". isSinglePartition=" + itm.isSinglePartition());
-        }
         assert(!(message instanceof Iv2InitiateTaskMessage));
         if (message instanceof FragmentTaskMessage) {
             if (ELASTICLOG.isTraceEnabled()) {

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -60,7 +60,6 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
             RejoinMessage rm = new RejoinMessage(m_mailbox.getHSId(),
                                                  RejoinMessage.Type.REPLAY_FINISHED);
             m_mailbox.send(m_coordinatorHsId, rm);
-            VoltDB.instance().getTaskManager().siteJoinCompleted(m_partitionId);
         }
     }
 

--- a/src/frontend/org/voltdb/messaging/EnableTasksOnPartitionsMessage.java
+++ b/src/frontend/org/voltdb/messaging/EnableTasksOnPartitionsMessage.java
@@ -1,0 +1,38 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.messaging;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.messaging.VoltMessage;
+
+/**
+ * Message used to indicate that a host participating in an elastic join is now safe to run tasks on partitions
+ */
+public class EnableTasksOnPartitionsMessage extends VoltMessage {
+    @Override
+    protected void initFromBuffer(ByteBuffer buf) throws IOException {
+        assert !buf.hasRemaining();
+    }
+
+    @Override
+    public void flattenToBuffer(ByteBuffer buf) throws IOException {
+        buf.put(VoltDbMessageFactory.START_TASKS_ID);
+    }
+}

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -54,6 +54,7 @@ public class VoltDbMessageFactory extends VoltMessageFactory
     final public static byte DUMP_PLAN_ID = VOLTCORE_MESSAGE_ID_MAX + 28;
     final public static byte Migrate_Partition_Leader_MESSAGE_ID = VOLTCORE_MESSAGE_ID_MAX + 29;
     final public static byte FLUSH_RO_TXN_MESSAGE_ID = VOLTCORE_MESSAGE_ID_MAX + 30;
+    final public static byte START_TASKS_ID = VOLTCORE_MESSAGE_ID_MAX + 31;
 
     /**
      * Overridden by subclasses to create message types unknown by voltcore
@@ -153,6 +154,9 @@ public class VoltDbMessageFactory extends VoltMessageFactory
             break;
         case FLUSH_RO_TXN_MESSAGE_ID:
             message = new MPBacklogFlushMessage();
+            break;
+        case START_TASKS_ID:
+            message = new EnableTasksOnPartitionsMessage();
             break;
         default:
             message = null;

--- a/tests/frontend/org/voltdb/LocalClustersTestBase.java
+++ b/tests/frontend/org/voltdb/LocalClustersTestBase.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -118,6 +119,7 @@ public class LocalClustersTestBase extends JUnit4LocalClusterTest {
     };
 
     private String m_methodName;
+    private boolean m_cleanupAfterTest = false;
 
     private final Set<Long> m_generatedKeys = new HashSet<>();
 
@@ -158,8 +160,19 @@ public class LocalClustersTestBase extends JUnit4LocalClusterTest {
         VoltFile.resetSubrootForThisProcess();
     }
 
+    @After
+    public void optionalCleanUp() {
+        if (m_cleanupAfterTest) {
+            shutdownAllClustersAndClients();
+        }
+    }
+
     public String getMethodName() {
         return m_methodName;
+    }
+
+    protected void cleanupAfterTest() {
+        m_cleanupAfterTest = true;
     }
 
     /**


### PR DESCRIPTION
The current implemenation would mark the host leader for the partition once the
site was ready regardless of whether or not the host was leader for that
partition. Instead send a message from ElasticJoinOperator to all
joining hosts once all joining hosts have completed the streaming
snapshot.