### PR TITLE
ENG-18058: disabling exporter target causes UAC timeout

### DIFF
--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
@@ -263,10 +263,12 @@ public class LoopbackExportClient extends ExportClientBase {
             }
             int firstFieldOffset = m_skipInternals ? INTERNAL_FIELD_COUNT : 0;
             LoopbackCallback cb = m_ctx.createCallback(bix);
-            if (!m_invoker.callProcedure(m_user, false,
+            if (m_invoker.callProcedure(m_user, false,
                     BatchTimeoutOverrideType.NO_TIMEOUT,
                     cb, false, m_shouldContinue, m_procedure,
                     Arrays.copyOfRange(rd.values, firstFieldOffset, rd.values.length))) {
+                m_ctx.m_outstandingTransactions.getAndIncrement();
+            } else {
                 LOG.error("failed to Invoke procedure: " + m_procedure);
             }
 

--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
@@ -64,7 +64,6 @@ import au.com.bytecode.opencsv_voltpatches.CSVWriter;
 public class LoopbackExportClient extends ExportClientBase {
 
     private static final ExportClientLogger LOG = new ExportClientLogger();
-    private static final int ACQUIRE_WAIT_TIME_MS = 5_000;
 
     private String m_procedure;
     private String m_failureLog;

--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
@@ -223,7 +223,7 @@ public class LoopbackExportClient extends ExportClientBase {
             }
             m_restarted = !m_ctx.m_rq.isEmpty();
 
-            if (m_restarted) {
+            if (m_restarted && !m_isShutDown) { // if shut down, the GuestProcessor will always re-process the block when it's up
                 m_failed = new BitSet(m_ctx.recs);
                 m_resubmit = new BitSet(m_ctx.recs);
 
@@ -272,7 +272,6 @@ public class LoopbackExportClient extends ExportClientBase {
                 ++m_ctx.invokes;
             } else {
                 LOG.error("failed to Invoke procedure: " + m_procedure);
-                m_ctx.m_done.release();
             }
 
             return true;

--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
@@ -206,9 +206,6 @@ public class LoopbackExportClient extends ExportClientBase {
 
         @Override
         public void onBlockCompletion(ExportRow row) throws RestartBlockException {
-            if (m_isShutDown) { // if shut down, the GuestProcessor will always re-process the block when it's up
-                return;
-            }
             synchronized (this) {
                 if (m_ctx.m_outstandingTransactions.get() > 0 && !m_isShutDown) {
                     try {
@@ -217,6 +214,9 @@ public class LoopbackExportClient extends ExportClientBase {
                         throw new LoopbackExportException("failed to wait for block callback", e);
                     }
                 }
+            }
+            if (m_isShutDown) { // if shut down, the GuestProcessor will always re-process the block when it's up
+                return;
             }
             m_restarted = !m_ctx.m_rq.isEmpty();
 


### PR DESCRIPTION
The timeout is due to a deadlock in the `LoopbackExportClient.onBlockCompletion`.

`LoopbackExportClient` has a loop back mechanism that calls an insert procedure to insert the processed row back to the Volt stream. It also maintains a Semaphore that is released in the insertion procedures' callbacks.  The `onBlockCompletion` will block until all Semaphore is released and then check for the ClientResponse status. 
The problem is UAC is an MP transaction that will block all the loopback insertions that are queued after the UAC. Therefore we have:
```text
UAC  ----> wait for LoopbackExportClient.onBlockCompletion to shutdown the GuestProcessor.
LoopbackExportClient.onBlockCompletion ---> wait for the insertion callbacks that are blocked by UAC
```