### PR TITLE
ENG-18200: Update statistic columns

### DIFF
--- a/src/frontend/org/voltdb/task/TaskStatsSource.java
+++ b/src/frontend/org/voltdb/task/TaskStatsSource.java
@@ -43,10 +43,11 @@ public class TaskStatsSource extends StatsSource {
     private static final String PREFIX_SCHEDULER = "SCHEDULER_";
     private static final String PREFIX_PROCEDURE = "PROCEDURE_";
 
-    private static final Collection<ColumnInfo> s_columns = ImmutableList.of(new ColumnInfo("NAME", VoltType.STRING),
+    private static final Collection<ColumnInfo> s_columns = ImmutableList.of(
+            new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltSystemProcedure.CTYPE_ID),
+            new ColumnInfo("TASK_NAME", VoltType.STRING),
             new ColumnInfo("STATE", VoltType.STRING),
             new ColumnInfo("SCOPE", VoltType.STRING),
-            new ColumnInfo(VoltSystemProcedure.CNAME_PARTITION_ID, VoltSystemProcedure.CTYPE_ID),
             new ColumnInfo(PREFIX_SCHEDULER + "INVOCATIONS", VoltType.BIGINT),
             new ColumnInfo(PREFIX_SCHEDULER + "TOTAL_EXECUTION", VoltType.BIGINT),
             new ColumnInfo(PREFIX_SCHEDULER + "MIN_EXECUTION", VoltType.BIGINT),
@@ -67,6 +68,8 @@ public class TaskStatsSource extends StatsSource {
             new ColumnInfo(PREFIX_PROCEDURE + "MAX_WAIT_TIME", VoltType.BIGINT),
             new ColumnInfo(PREFIX_PROCEDURE + "AVG_WAIT_TIME", VoltType.BIGINT),
             new ColumnInfo(PREFIX_PROCEDURE + "FAILURES", VoltType.BIGINT));
+
+    private static final int s_sharedSubSelectorColumnCount = 7;
 
     // Metadata to basically select a subset of columns from the full stats
     private static List<ColumnAs> s_schedulersConvert;
@@ -131,37 +134,31 @@ public class TaskStatsSource extends StatsSource {
 
     private static List<ColumnAs> getSchedulersConverter(VoltTable source) {
         if (s_schedulersConvert == null) {
-            s_schedulersConvert = initializeConverter(source, PREFIX_SCHEDULER, PREFIX_PROCEDURE);
+            s_schedulersConvert = initializeConverter(source, PREFIX_SCHEDULER);
         }
         return s_schedulersConvert;
     }
 
     private static List<ColumnAs> getProceduresConverter(VoltTable source) {
         if (s_procedursConvert == null) {
-            s_procedursConvert = initializeConverter(source, PREFIX_PROCEDURE, PREFIX_SCHEDULER);
+            s_procedursConvert = initializeConverter(source, PREFIX_PROCEDURE);
         }
         return s_procedursConvert;
     }
 
     /**
-     * @param source       {@link VoltTable} which will be the source of the stats
-     * @param prefixRemove If a column has this prefix the column will be kept but the prefix will be removed from the
-     *                     name
-     * @param prefixSkip   If a column has this prefix it will be skipped
+     * @param source     {@link VoltTable} which will be the source of the stats
+     * @param prefixKeep If a column has this prefix it will be kept in the converted table
      * @return {@link List} of {@link ColumnAs} for selecting out desired stats
      */
-    private static List<ColumnAs> initializeConverter(VoltTable source, String prefixRemove, String prefixSkip) {
+    private static List<ColumnAs> initializeConverter(VoltTable source, String prefixKeep) {
         ImmutableList.Builder<ColumnAs> builder = ImmutableList.<ColumnAs>builder();
 
         for (int i = 0; i < source.getColumnCount(); ++i) {
             String columnName = source.getColumnName(i);
-            if (columnName.startsWith(prefixSkip)) {
-                continue;
+            if (i < s_sharedSubSelectorColumnCount || columnName.startsWith(prefixKeep)) {
+                builder.add(new ColumnAs(source, i, columnName));
             }
-            if (columnName.startsWith(prefixRemove)) {
-                columnName = columnName.substring(prefixRemove.length());
-            }
-            builder.add(new ColumnAs(source, i, columnName));
         }
 
         return builder.build();
@@ -209,10 +206,10 @@ public class TaskStatsSource extends StatsSource {
         int column = 3;
 
         // Header state info
+        rowValues[column++] = m_partitionId;
         rowValues[column++] = m_name;
         rowValues[column++] = m_state;
         rowValues[column++] = m_scope.name();
-        rowValues[column++] = m_partitionId;
 
         // Scheduler stats
         column = m_schedulerStats.pupulateStats(rowValues, column);

--- a/tests/frontend/org/voltdb/task/TestTaskManager.java
+++ b/tests/frontend/org/voltdb/task/TestTaskManager.java
@@ -422,7 +422,7 @@ public class TestTaskManager {
         VoltTable table = getScheduleStats();
         Map<String, Long> invocationCounts = new HashMap<>();
         while (table.advanceRow()) {
-            invocationCounts.put(table.getString("NAME"), table.getLong("SCHEDULER_INVOCATIONS"));
+            invocationCounts.put(table.getString("TASK_NAME"), table.getLong("SCHEDULER_INVOCATIONS"));
         }
 
         // No schedules should restart since class and deps did not change
@@ -431,7 +431,7 @@ public class TestTaskManager {
 
         table = getScheduleStats();
         while (table.advanceRow()) {
-            String scheduleName = table.getString("NAME");
+            String scheduleName = table.getString("TASK_NAME");
             long currentCount = table.getLong("SCHEDULER_INVOCATIONS");
             assertTrue("Count decreased for " + scheduleName,
                     invocationCounts.put(scheduleName, currentCount) < currentCount);
@@ -445,7 +445,7 @@ public class TestTaskManager {
 
         table = getScheduleStats();
         while (table.advanceRow()) {
-            String scheduleName = table.getString("NAME");
+            String scheduleName = table.getString("TASK_NAME");
             long currentCount = table.getLong("SCHEDULER_INVOCATIONS");
             long previousCount = invocationCounts.put(scheduleName, currentCount);
             if (scheduleName.equals("TestActionScheduler")) {
@@ -468,7 +468,7 @@ public class TestTaskManager {
 
         table = getScheduleStats();
         while (table.advanceRow()) {
-            String scheduleName = table.getString("NAME");
+            String scheduleName = table.getString("TASK_NAME");
             long currentCount = table.getLong("SCHEDULER_INVOCATIONS");
             long previousCount = invocationCounts.put(scheduleName, currentCount);
             assertTrue("Count increased for " + scheduleName + " from " + previousCount + " to " + currentCount,

--- a/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
+++ b/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
@@ -147,7 +147,7 @@ public class TestTasksEnd2End extends LocalClustersTestBase {
         table = getTaskStats(client);
         assertEquals(3, table.getRowCount());
         while (table.advanceRow()) {
-            String scheduleName = table.getString("NAME");
+            String scheduleName = table.getString("TASK_NAME");
             int id = -1;
             if (schedule1.equalsIgnoreCase(scheduleName)) {
                 id = 1;


### PR DESCRIPTION
In order to be more consistent with other statistics rename the NAME column
TASK_NAME and move PARTITION_ID to be before TASK_NAME.

Also, do not trim the prefix from the subselelected columns when performing a
sub selection.