### PR TITLE
refactories on tabletuplefilter

### DIFF
--- a/src/ee/executors/abstractjoinexecutor.h
+++ b/src/ee/executors/abstractjoinexecutor.h
@@ -43,8 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTOREABSTRACTJOINEXECUTOR_H
-#define HSTOREABSTRACTJOINEXECUTOR_H
+#pragma once
 
 #include "common/common.h"
 #include "common/tabletuple.h"
@@ -54,10 +53,9 @@ namespace voltdb {
 
 class AbstractPlanNode;
 class AggregateExecutorBase;
-struct CountingPostfilter;
+class CountingPostfilter;
 class ProgressMonitorProxy;
 class Table;
-class TempTableLimits;
 class VoltDBEngine;
 
 /**
@@ -65,6 +63,10 @@ class VoltDBEngine;
  */
 class AbstractJoinExecutor : public AbstractExecutor {
     protected:
+        JoinType m_joinType;
+        StandAloneTupleStorage m_null_outer_tuple;
+        StandAloneTupleStorage m_null_inner_tuple;
+        AggregateExecutorBase* m_aggExec;
         // Constructor
         AbstractJoinExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node) :
             AbstractExecutor(engine, abstract_node) { }
@@ -75,15 +77,7 @@ class AbstractJoinExecutor : public AbstractExecutor {
 
         // Write tuple to the output table
         void outputTuple(CountingPostfilter& postfilter, TableTuple& join_tuple, ProgressMonitorProxy& pmp);
-
-        JoinType m_joinType;
-
-        StandAloneTupleStorage m_null_outer_tuple;
-        StandAloneTupleStorage m_null_inner_tuple;
-
-        AggregateExecutorBase* m_aggExec;
 };
 
 }
 
-#endif

--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -43,6 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <tuple>
 #include "common/SerializableEEException.h"
 #include "executors/aggregateexecutor.h"
 #include "plannodes/aggregatenode.h"
@@ -579,7 +580,7 @@ inline void AggregateExecutorBase::initCountingPredicate(const NValueArray& para
     auto* inlineLimitNode = dynamic_cast<LimitPlanNode*>(
             m_abstractNode->getInlinePlanNode(PLAN_NODE_TYPE_LIMIT));
     if (inlineLimitNode) {
-        inlineLimitNode->getLimitAndOffsetByReference(params, limit, offset);
+        std::tie(limit, offset) = inlineLimitNode->getLimitAndOffset(params);
     }
     m_postfilter = CountingPostfilter(m_tmpOutputTable, m_postPredicate, limit, offset, parentPostfilter);
 }

--- a/src/ee/executors/executorutil.cpp
+++ b/src/ee/executors/executorutil.cpp
@@ -54,19 +54,6 @@ CountingPostfilter::CountingPostfilter(const AbstractTempTable* table, const Abs
     m_parentPostfilter(parentPostfilter),
     m_limit(limit),
     m_offset(offset),
-    m_tuple_skipped(0),
-    m_under_limit(true)
-{}
-
-
-CountingPostfilter::CountingPostfilter() :
-    m_table(NULL),
-    m_postPredicate(NULL),
-    m_parentPostfilter(NULL),
-    m_limit(NO_LIMIT),
-    m_offset(NO_OFFSET),
-    m_tuple_skipped(0),
-    m_under_limit(false)
-{}
+    m_under_limit(true) {}
 
 }

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -43,6 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <tuple>
 #include "indexscanexecutor.h"
 
 #include "executors/aggregateexecutor.h"
@@ -174,7 +175,7 @@ bool IndexScanExecutor::p_execute(const NValueArray &params) {
     int limit = CountingPostfilter::NO_LIMIT;
     int offset = CountingPostfilter::NO_OFFSET;
     if (limit_node != nullptr) {
-        limit_node->getLimitAndOffsetByReference(params, limit, offset);
+        std::tie(limit, offset) = limit_node->getLimitAndOffset(params);
     }
 
     //

--- a/src/ee/executors/indexscanexecutor.h
+++ b/src/ee/executors/indexscanexecutor.h
@@ -63,7 +63,7 @@ class IndexScanPlanNode;
 class ProjectionPlanNode;
 class AggregateExecutorBase;
 class InsertExecutor;
-struct CountingPostfilter;
+class CountingPostfilter;
 
 class IndexScanExecutor : public AbstractExecutor {
     // Data in this class is arranged roughly in the order it is read for

--- a/src/ee/executors/largeorderbyexecutor.cpp
+++ b/src/ee/executors/largeorderbyexecutor.cpp
@@ -43,6 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <tuple>
 #include "largeorderbyexecutor.h"
 #include "execution/ExecutorVector.h"
 #include "execution/ProgressMonitorProxy.h"
@@ -56,8 +57,7 @@ namespace voltdb {
 
 bool
 LargeOrderByExecutor::p_init(AbstractPlanNode* abstract_node,
-                             const ExecutorVector& executorVector)
-{
+                             const ExecutorVector& executorVector) {
     OrderByPlanNode* node = dynamic_cast<OrderByPlanNode*>(abstract_node);
     vassert(node);
 
@@ -96,7 +96,7 @@ LargeOrderByExecutor::p_execute(const NValueArray &params) {
     int limit = -1;
     int offset = 0;
     if (m_limitPlanNode != NULL) {
-        m_limitPlanNode->getLimitAndOffsetByReference(params, limit, offset);
+        std::tie(limit, offset) = m_limitPlanNode->getLimitAndOffset(params);
     }
 
     inputTable->sort(&pmp,

--- a/src/ee/executors/limitexecutor.cpp
+++ b/src/ee/executors/limitexecutor.cpp
@@ -43,6 +43,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <tuple>
 #include "limitexecutor.h"
 #include "plannodes/limitnode.h"
 #include "storage/temptable.h"
@@ -52,8 +53,7 @@ using namespace voltdb;
 
 bool
 LimitExecutor::p_init(AbstractPlanNode* abstract_node,
-                      const ExecutorVector& executorVector)
-{
+                      const ExecutorVector& executorVector) {
     VOLT_TRACE("init limit Executor");
 
     LimitPlanNode* node = dynamic_cast<LimitPlanNode*>(abstract_node);
@@ -62,8 +62,7 @@ LimitExecutor::p_init(AbstractPlanNode* abstract_node,
     //
     // Skip if we are inline
     //
-    if (!node->isInline())
-    {
+    if (!node->isInline()) {
         //
         // Just copy the table schema of our input table
         //
@@ -95,7 +94,7 @@ bool LimitExecutor::p_execute(const NValueArray &params) {
     int tuple_ctr = 0;
     int limit = -1;
     int offset = -1;
-    node->getLimitAndOffsetByReference(params, limit, offset);
+    std::tie(limit, offset) = node->getLimitAndOffset(params);
 
     if (iterator.advance(tuple, offset) < offset) {
         return true;     // offset beyond table count: empty table

--- a/src/ee/executors/mergejoinexecutor.cpp
+++ b/src/ee/executors/mergejoinexecutor.cpp
@@ -247,7 +247,7 @@ bool MergeJoinExecutor::p_execute(const NValueArray &params) {
     int limit = CountingPostfilter::NO_LIMIT;
     int offset = CountingPostfilter::NO_OFFSET;
     if (limitNode) {
-        limitNode->getLimitAndOffsetByReference(params, limit, offset);
+        tie(limit, offset) = limitNode->getLimitAndOffset(params);
     }
 
     int const outerCols = outerTable->columnCount();

--- a/src/ee/executors/mergereceiveexecutor.cpp
+++ b/src/ee/executors/mergereceiveexecutor.cpp
@@ -240,7 +240,7 @@ bool MergeReceiveExecutor::p_execute(const NValueArray &params) {
     int limit = CountingPostfilter::NO_LIMIT;
     int offset = CountingPostfilter::NO_OFFSET;
     if (m_limit_node != NULL) {
-        m_limit_node->getLimitAndOffsetByReference(params, limit, offset);
+        std::tie(limit, offset) = m_limit_node->getLimitAndOffset(params);
     }
     // Init the postfilter to evaluate LIMIT/OFFSET conditions
     CountingPostfilter postfilter(m_tmpOutputTable, NULL, limit, offset);

--- a/src/ee/executors/mergereceiveexecutor.h
+++ b/src/ee/executors/mergereceiveexecutor.h
@@ -43,16 +43,12 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTOREORDERBYMERGEEXECUTOR_H
-#define HSTOREORDERBYMERGEEXECUTOR_H
+#pragma once
 
 #include "common/common.h"
 #include "common/tabletuple.h"
 #include "common/valuevector.h"
 #include "executors/abstractexecutor.h"
-
-#include <boost/scoped_ptr.hpp>
-
 #include <vector>
 
 namespace voltdb {
@@ -62,7 +58,7 @@ namespace voltdb {
     class LimitPlanNode;
     class AggregateExecutorBase;
     class ProgressMonitorProxy;
-    struct CountingPostfilter;
+    class CountingPostfilter;
 
     /**
      * The optimized replacement for an ORDER BY executor to be used at the coordinator node
@@ -71,6 +67,9 @@ namespace voltdb {
      * specified by the inlined OrderByPlanNode
      */
     class MergeReceiveExecutor : public AbstractExecutor {
+        OrderByPlanNode* m_orderby_node;
+        LimitPlanNode* m_limit_node;
+        AggregateExecutorBase* m_agg_exec;
     public:
         MergeReceiveExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node);
 
@@ -86,14 +85,7 @@ namespace voltdb {
         bool p_init(AbstractPlanNode* abstract_node,
                     const ExecutorVector& executorVector);
         bool p_execute(const NValueArray &params);
-
-    private:
-        OrderByPlanNode* m_orderby_node;
-        LimitPlanNode* m_limit_node;
-
-        AggregateExecutorBase* m_agg_exec;
     };
 
 }
 
-#endif

--- a/src/ee/executors/nestloopexecutor.cpp
+++ b/src/ee/executors/nestloopexecutor.cpp
@@ -135,7 +135,7 @@ bool NestLoopExecutor::p_execute(const NValueArray &params) {
     int limit = CountingPostfilter::NO_LIMIT;
     int offset = CountingPostfilter::NO_OFFSET;
     if (limit_node) {
-        limit_node->getLimitAndOffsetByReference(params, limit, offset);
+        tie(limit, offset) = limit_node->getLimitAndOffset(params);
     }
 
     int outer_cols = outer_table->columnCount();

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -205,7 +205,7 @@ bool NestLoopIndexExecutor::p_execute(const NValueArray &params) {
     int limit = CountingPostfilter::NO_LIMIT;
     int offset = CountingPostfilter::NO_OFFSET;
     if (limit_node) {
-        limit_node->getLimitAndOffsetByReference(params, limit, offset);
+        tie(limit, offset) = limit_node->getLimitAndOffset(params);
     }
     // Init the postfilter
     CountingPostfilter postfilter(m_tmpOutputTable, where_expression, limit, offset);

--- a/src/ee/executors/orderbyexecutor.cpp
+++ b/src/ee/executors/orderbyexecutor.cpp
@@ -95,9 +95,7 @@ OrderByExecutor::p_init(AbstractPlanNode* abstract_node,
     return true;
 }
 
-bool
-OrderByExecutor::p_execute(const NValueArray &params)
-{
+bool OrderByExecutor::p_execute(const NValueArray &params) {
     OrderByPlanNode* node = dynamic_cast<OrderByPlanNode*>(m_abstractNode);
     vassert(node);
     AbstractTempTable* output_table = dynamic_cast<AbstractTempTable*>(node->getOutputTable());
@@ -111,9 +109,8 @@ OrderByExecutor::p_execute(const NValueArray &params)
     //
     int limit = -1;
     int offset = -1;
-    if (limit_node != NULL)
-    {
-        limit_node->getLimitAndOffsetByReference(params, limit, offset);
+    if (limit_node != NULL) {
+        std::tie(limit, offset) = limit_node->getLimitAndOffset(params);
     }
 
     VOLT_TRACE("Running OrderBy '%s'", m_abstractNode->debug().c_str());
@@ -128,8 +125,7 @@ OrderByExecutor::p_execute(const NValueArray &params)
         vector<TableTuple> xs;
         ProgressMonitorProxy pmp(m_engine->getExecutorContext(), this);
         TableIterator iterator = input_table->iterator();
-        while (iterator.next(tuple))
-        {
+        while (iterator.next(tuple)) {
             pmp.countdownProgress();
             vassert(tuple.isActive());
             xs.push_back(tuple);

--- a/src/ee/executors/seqscanexecutor.cpp
+++ b/src/ee/executors/seqscanexecutor.cpp
@@ -200,7 +200,7 @@ bool SeqScanExecutor::p_execute(const NValueArray &params) {
         int limit = CountingPostfilter::NO_LIMIT;
         int offset = CountingPostfilter::NO_OFFSET;
         if (limit_node) {
-            limit_node->getLimitAndOffsetByReference(params, limit, offset);
+            std::tie(limit, offset) = limit_node->getLimitAndOffset(params);
         }
         // Initialize the postfilter
         CountingPostfilter postfilter(m_tmpOutputTable, predicate, limit, offset);

--- a/src/ee/executors/seqscanexecutor.h
+++ b/src/ee/executors/seqscanexecutor.h
@@ -43,49 +43,41 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTORESEQSCANEXECUTOR_H
-#define HSTORESEQSCANEXECUTOR_H
+#pragma once
 
 #include "common/common.h"
 #include "common/valuevector.h"
 #include "executors/abstractexecutor.h"
 #include "execution/VoltDBEngine.h"
 
-namespace voltdb
-{
+namespace voltdb {
     class AggregateExecutorBase;
-    struct CountingPostfilter;
     class InsertExecutor;
 
     class SeqScanExecutor : public AbstractExecutor {
-    public:
-        SeqScanExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node)
-            : AbstractExecutor(engine, abstract_node)
-            , m_aggExec(NULL)
-            , m_insertExec(NULL)
-        {}
-    protected:
-        bool p_init(AbstractPlanNode* abstract_node,
-                    const ExecutorVector& executorVector);
-        bool p_execute(const NValueArray& params);
-
-    private:
-        /**
-         * Output a tuple.  This may send the tuple to an
-         * inline insert or aggregate node, or it may send the
-         * tuple to the output table.
-         */
-        void outputTuple(TableTuple& tuple);
-
         // These are logically local variables to p_execute.
         // But we need to share them between p_execute and
         // outputTuple, so we save them here.  They come out of
         // the plan node anyway, so their lifetime is managed
         // by the plan node.  We don't need to worry about
         // freeing them.
-        AggregateExecutorBase* m_aggExec;
-        InsertExecutor* m_insertExec;
+        AggregateExecutorBase* m_aggExec = nullptr;
+        InsertExecutor* m_insertExec = nullptr;
+
+        /**
+         * Output a tuple.  This may send the tuple to an
+         * inline insert or aggregate node, or it may send the
+         * tuple to the output table.
+         */
+        void outputTuple(TableTuple& tuple);
+    public:
+        SeqScanExecutor(VoltDBEngine *engine, AbstractPlanNode* abstract_node)
+            : AbstractExecutor(engine, abstract_node) {}
+    protected:
+        bool p_init(AbstractPlanNode* abstract_node,
+                    const ExecutorVector& executorVector);
+        bool p_execute(const NValueArray& params);
+
     };
 }
 
-#endif

--- a/src/ee/plannodes/limitnode.h
+++ b/src/ee/plannodes/limitnode.h
@@ -43,55 +43,41 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef HSTORELIMITNODE_H
-#define HSTORELIMITNODE_H
+#pragma once
 
-#include <sstream>
 #include "abstractplannode.h"
 #include "common/debuglog.h"
 #include "common/valuevector.h"
 
 namespace voltdb {
 
-class Table;
-
-/**
- *
- */
 class LimitPlanNode : public AbstractPlanNode {
-public:
-    LimitPlanNode()
-        : limit(-1)
-        , offset(0)
-        , limitParamIdx(-1)
-        , offsetParamIdx(-1)
-        , limitExpression(NULL)
-    {
-    }
-
-    ~LimitPlanNode();
-    PlanNodeType getPlanNodeType() const;
-
-    // evaluate possibly parameterized limit and offsets.
-    void getLimitAndOffsetByReference(const NValueArray &params, int &limit, int &offset);
-
-    std::string debugInfo(const std::string &spacer) const;
-
-private:
     void loadFromJSONObject(PlannerDomValue obj);
-    int limit;
-    int offset;
-    int limitParamIdx;
-    int offsetParamIdx;
+    int limit = -1;
+    int offset = 0;
+    int limitParamIdx = -1;
+    int offsetParamIdx = -1;
 
     /*
      * If the query has limit and offset, the pushed-down limit node will
      * have a limit expression of the sum of the limit parameter and the
      * offset parameter, and offset will be 0
      */
-    AbstractExpression* limitExpression;
+    AbstractExpression* limitExpression = nullptr;
+public:
+    LimitPlanNode() = default;
+    ~LimitPlanNode() {
+        delete limitExpression;
+    }
+    PlanNodeType getPlanNodeType() const {
+        return PLAN_NODE_TYPE_LIMIT;
+    }
+
+    // evaluate possibly parameterized limit and offsets.
+    std::tuple<int, int> getLimitAndOffset(const NValueArray &params);
+
+    std::string debugInfo(const std::string &spacer) const;
 };
 
 }
 
-#endif

--- a/src/ee/storage/tabletuplefilter.h
+++ b/src/ee/storage/tabletuplefilter.h
@@ -43,12 +43,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef VOLTDB_TABLETUPLEFILTER_H
-#define VOLTDB_TABLETUPLEFILTER_H
+#pragma once
 
 #include "common/tabletuple.h"
 
-#include <boost/unordered_map.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
 #include <vector>
@@ -56,14 +54,60 @@
 
 namespace voltdb {
 
+class TableTupleFilter;
+/**
+ * Non-const TableTupleFilter Iterator. Implements FORWARD ITERATOR Concept.
+ * Iterates over the tuples that have a certain value set in
+ * underline TableTupleFilter.
+ *
+ * Parameter MARKER specifies the value to look for. Only tuples that have
+ * their value set to MARKER will be iterated over
+ */
+template<int8_t Marker, typename ValueType>
+class TableTupleFilterIterType :
+    public boost::iterator_facade<TableTupleFilterIterType<Marker, ValueType>,
+    ValueType,
+    boost::forward_traversal_tag> {
+    const TableTupleFilter* m_tableFilter = nullptr;
+    mutable ValueType m_tupleIdx{};
+public:
+    /**
+     * Default constructor
+     */
+    TableTupleFilterIterType() = default;
+
+    /**
+     * Constructor. Sets the iterator position pointing to the first tuple that
+     * have the TableTupleFilter value set to the Marker
+     */
+    inline TableTupleFilterIterType(TableTupleFilter* m_tableFilter);
+
+    ValueType& dereference() const {
+        return m_tupleIdx;
+    }
+
+    // Forward Iteration Support
+    void increment();
+
+    bool equal(TableTupleFilterIterType<Marker, ValueType> const& other) const {
+        // Shouldn't compare iterators from different tables
+        vassert(m_tableFilter == other.m_tableFilter);
+        return m_tupleIdx == other.m_tupleIdx;
+    }
+
+    /**
+     * Constructor. Sets the iterator position pointing to the specified position - usually the end
+     */
+    TableTupleFilterIterType(const TableTupleFilter* m_tableFilter, size_t tupleIdx) :
+        m_tableFilter(m_tableFilter), m_tupleIdx(tupleIdx) {}
+};
+
+template<int8_t Marker>
+using TableTupleFilter_iter = TableTupleFilterIterType<Marker, uint64_t>;
+template<int8_t Marker>
+using TableTupleFilter_const_iter = TableTupleFilterIterType<Marker, uint64_t const>;
+
 class Table;
-
-// Iterators forward declaration
-template<int8_t MARKER>
-class TableTupleFilter_iter;
-template<int8_t MARKER>
-class TableTupleFilter_const_iter;
-
 /**
  * A lightweight representation of a table - a contiguous array where
  * each tuple (active and non-active) is represented as a byte with a
@@ -92,21 +136,68 @@ class TableTupleFilter_const_iter;
  * relatively fast lookups.
  */
 class TableTupleFilter {
+public:
+    const static uint64_t INVALID_INDEX = std::numeric_limits<uint64_t>::max();
+private:
+    // Tuples (active and not active)
+    std::vector<char> m_tuples{};
 
-    public:
+    // Collection of table blocks addresses
+    std::vector<uint64_t> m_blocks{};
 
-    const static int8_t INACTIVE_TUPLE  = -1;
-    const static int8_t ACTIVE_TUPLE    =  0;
+    // (Block Address/ Block offset into the tuples array) map
+    std::unordered_map<uint64_t, uint64_t> m_blockIndexes{};
 
-    template<int8_t MARKER>
-    friend class TableTupleFilter_iter;
-    template<int8_t MARKER>
-    friend class TableTupleFilter_const_iter;
+    // Block/Tuple size
+    uint32_t m_tuplesPerBlock{};
+
+    // Length of tuples in this table
+    uint32_t m_tupleLength = 0;
+
+    // Previously accessed block address, cached to avoid
+    // excessive searches of m_blocks
+    uint64_t m_prevBlockAddress = INVALID_INDEX;
+
+    // Previously accessed block index, cached to avoid excessive
+    // lookups in m_blockIndexes
+    uint64_t m_prevBlockIndex = INVALID_INDEX;
+
+    // Index of the last ACTIVE tuple in the underlying table
+    uint64_t m_lastActiveTupleIndex = INVALID_INDEX;
+
+    void init(const std::vector<uint64_t>& blocks, uint32_t tuplesPerBlock, uint32_t tupleLength);
+
+    uint64_t getTupleIndex(const TableTuple& tuple) {
+        uint64_t tupleAddress = reinterpret_cast<uint64_t>(tuple.address());
+        uint64_t blockIndex = findBlockIndex(tupleAddress);
+        return (tupleAddress - m_prevBlockAddress) / m_tupleLength + blockIndex;
+    }
+
+    /**
+     * Initialize an active tuple by setting its value to ACTIVE_TUPLE and advance last active tuple index.
+     * This method should be called only once during the initialization.
+     * To update tuple value use updateTuple method
+     */
+    void initActiveTuple(const TableTuple& tuple) {
+        uint64_t tupleIdx = getTupleIndex(tuple);
+        vassert(m_tuples[tupleIdx] == INACTIVE_TUPLE);
+        m_tuples[tupleIdx] = ACTIVE_TUPLE;
+        // Advance last active tuple index if necessary
+        if (empty() || m_lastActiveTupleIndex < tupleIdx) {
+            m_lastActiveTupleIndex = tupleIdx;
+        }
+    }
+
+    uint64_t findBlockIndex(uint64_t tupleAddress);
+
+public:
+    constexpr static int8_t INACTIVE_TUPLE  = -1;
+    constexpr static int8_t ACTIVE_TUPLE    =  0;
 
     /**
      * Default constructor
      */
-    TableTupleFilter();
+    TableTupleFilter() = default;
 
     /**
      * Initialize TableTupleFilter from a table by setting the value for all active tuples
@@ -117,20 +208,22 @@ class TableTupleFilter {
     /**
      * Update an active tuple and return the tuple index
      */
-    uint64_t updateTuple(const TableTuple& tuple, char marker)
-    {
+    uint64_t updateTuple(const TableTuple& tuple, char marker) {
         uint64_t tupleIdx = getTupleIndex(tuple);
-        vassert(tupleIdx <= m_lastActiveTupleIndex && m_lastActiveTupleIndex != INVALID_INDEX);
+        vassert(tupleIdx <= m_lastActiveTupleIndex && ! empty());
         vassert(m_tuples[tupleIdx] != INACTIVE_TUPLE);
         m_tuples[tupleIdx] = marker;
         return tupleIdx;
     }
 
+    size_t getLastActiveTupleIndex() const {
+        return m_lastActiveTupleIndex;
+    }
+
     /**
      * Returns the tuple value
      */
-    char getTupleValue(size_t tupleIdx) const
-    {
+    char getTupleValue(size_t tupleIdx) const {
         vassert(tupleIdx < m_tuples.size());
         return m_tuples[tupleIdx];
     }
@@ -138,8 +231,7 @@ class TableTupleFilter {
     /**
      * Returns the tuple address
      */
-    uint64_t getTupleAddress(size_t tupleIdx)
-    {
+    uint64_t getTupleAddress(size_t tupleIdx) {
         vassert(tupleIdx < m_tuples.size());
         size_t blockIdx = tupleIdx / m_tuplesPerBlock;
         vassert(blockIdx < m_blocks.size());
@@ -150,283 +242,54 @@ class TableTupleFilter {
         return m_blocks[blockIdx] + (tupleIdx - m_prevBlockIndex) * m_tupleLength;
     }
 
-    bool empty() const
-    {
+    bool empty() const {
         return m_lastActiveTupleIndex == INVALID_INDEX;
     }
 
     // Non-const Iterators
     template<int8_t MARKER>
-    TableTupleFilter_iter<MARKER> begin();
+    TableTupleFilter_iter<MARKER> begin() {
+        return {this};
+    }
 
     template<int8_t MARKER>
-    TableTupleFilter_iter<MARKER> end();
+    TableTupleFilter_iter<MARKER> end() {
+        return {this,
+            getLastActiveTupleIndex() != TableTupleFilter::INVALID_INDEX ?
+                getLastActiveTupleIndex() + 1 : TableTupleFilter::INVALID_INDEX};
+    }
 
     // Const Iterators
     template<int8_t MARKER>
-    TableTupleFilter_const_iter<MARKER> begin() const;
+    TableTupleFilter_const_iter<MARKER> begin() const {
+        return {this};
+    }
 
     template<int8_t MARKER>
-    TableTupleFilter_const_iter<MARKER> end() const;
-
-    private:
-
-    const static uint64_t INVALID_INDEX;
-
-    void init(const std::vector<uint64_t>& blocks, uint32_t tuplesPerBlock, uint32_t tupleLength);
-
-    uint64_t getTupleIndex(const TableTuple& tuple)
-    {
-        uint64_t tupleAddress = (uint64_t) tuple.address();
-        uint64_t blockIndex = findBlockIndex(tupleAddress);
-        return (tupleAddress - m_prevBlockAddress) / m_tupleLength + blockIndex;
+    TableTupleFilter_const_iter<MARKER> end() const {
+        return {this,
+            getLastActiveTupleIndex() != TableTupleFilter::INVALID_INDEX ?
+                getLastActiveTupleIndex() + 1 : TableTupleFilter::INVALID_INDEX};
     }
-
-    /**
-     * Initialize an active tuple by setting its value to ACTIVE_TUPLE and advance last active tuple index.
-     * This method should be called only once during the initialization.
-     * To update tuple value use updateTuple method
-     */
-    void initActiveTuple(const TableTuple& tuple)
-    {
-        uint64_t tupleIdx = getTupleIndex(tuple);
-        vassert(m_tuples[tupleIdx] == INACTIVE_TUPLE);
-        m_tuples[tupleIdx] = ACTIVE_TUPLE;
-        // Advance last active tuple index if necessary
-        if (m_lastActiveTupleIndex == INVALID_INDEX || m_lastActiveTupleIndex < tupleIdx)
-        {
-            m_lastActiveTupleIndex = tupleIdx;
-        }
-    }
-
-    size_t getLastActiveTupleIndex() const
-    {
-        return m_lastActiveTupleIndex;
-    }
-
-    uint64_t findBlockIndex(uint64_t tupleAddress);
-
-    // Tuples (active and not active)
-    std::vector<char> m_tuples;
-
-    // Collection of table blocks addresses
-    std::vector<uint64_t> m_blocks;
-
-    // (Block Address/ Block offset into the tuples array) map
-    boost::unordered_map<uint64_t, uint64_t> m_blockIndexes;
-
-    // Block/Tuple size
-    uint32_t m_tuplesPerBlock;
-
-    // Length of tuples in this table
-    uint32_t m_tupleLength;
-
-    // Previously accessed block address, cached to avoid
-    // excessive searches of m_blocks
-    uint64_t m_prevBlockAddress;
-
-    // Previously accessed block index, cached to avoid excessive
-    // lookups in m_blockIndexes
-    uint64_t m_prevBlockIndex;
-
-    // Index of the last ACTIVE tuple in the underlying table
-    uint64_t m_lastActiveTupleIndex;
 };
 
-/**
- * Non-const TableTupleFilter Iterator. Implements FORWARD ITERATOR Concept.
- * Iterates over the tuples that have a certain value set in
- * underline TableTupleFilter.
- *
- * Parameter MARKER specifies the value to look for. Only tuples that have
- * their value set to MARKER will be iterated over
- */
-template<int8_t MARKER>
-class TableTupleFilter_iter
-  : public boost::iterator_facade<
-        TableTupleFilter_iter<MARKER>
-      , uint64_t
-      , boost::forward_traversal_tag>
-{
-    public:
-    /**
-     * Default constructor
-     */
-    TableTupleFilter_iter()
-      : m_tableFilter(0), m_tupleIdx()
-    {}
-
-    private:
-
-    friend class TableTupleFilter;
-    friend class boost::iterator_core_access;
-
-    /**
-     * Constructor. Sets the iterator position pointing to the first tuple that
-     * have the TableTupleFilter value set to the MARKER
-     */
-    explicit TableTupleFilter_iter(TableTupleFilter* m_tableFilter)
-      : m_tableFilter(m_tableFilter), m_tupleIdx(TableTupleFilter::INVALID_INDEX)
-    {
-        if (!m_tableFilter->empty())
-        {
-            increment();
-        }
+template<int8_t Marker, typename ValueType>
+TableTupleFilterIterType<Marker, ValueType>::TableTupleFilterIterType(
+        TableTupleFilter* m_tableFilter) :
+    m_tableFilter(m_tableFilter), m_tupleIdx(TableTupleFilter::INVALID_INDEX) {
+    if (!m_tableFilter->empty()) {
+        increment();
     }
-
-    /**
-     * Constructor. Sets the iterator position pointing to the specified position - usually the end
-     */
-    explicit TableTupleFilter_iter(const TableTupleFilter* m_tableFilter, size_t tupleIdx)
-        :  m_tableFilter(m_tableFilter), m_tupleIdx(tupleIdx)
-    {}
-
-    private:
-
-    bool equal(TableTupleFilter_iter const& other) const
-    {
-        // Shouldn't compare iterators from different tables
-        vassert(m_tableFilter == other.m_tableFilter);
-        return m_tupleIdx == other.m_tupleIdx;
-    }
-
-    uint64_t& dereference() const
-    {
-        return m_tupleIdx;
-    }
-
-    // Forward Iteration Support
-    void increment()
-    {
-        uint64_t lastActiveTupleIndex = m_tableFilter->getLastActiveTupleIndex();
-        do
-        {
-            ++m_tupleIdx;
-        } while(m_tupleIdx <= lastActiveTupleIndex && m_tableFilter->getTupleValue(m_tupleIdx) != MARKER);
-    }
-
-    const TableTupleFilter* m_tableFilter;
-    mutable uint64_t m_tupleIdx;
-};
-
-/**
- * Const TableTupleFilter Iterator. Implements FORWARD ITERATOR Concept.
- * Iterates over the tuples that have a certain value set in
- * underline TableTupleFilter.
- *
- * Once the C++11 template aliases will be supported, the Const and Non-const versions
- * can be merged into a sigle class
- *
- * template<int8_t MARKER, typedef Value>
- * class TableTupleFilter_iter;
- *
- * where Value is either uint64_t (non-const) or uint64_t const (Const)
- *
- * template <int8_t MARKER>
- * using TableTupleFilter_iter = TableTupleFilter_iter<MARKER, uint64_t>;
- *
- * Parameter MARKER specifies the value to look for. Only tuples that have
- * their value set to MARKER will be iterated over
- */
-template<int8_t MARKER>
-class TableTupleFilter_const_iter
-  : public boost::iterator_facade<
-        TableTupleFilter_iter<MARKER>
-      , uint64_t const
-      , boost::forward_traversal_tag>
-{
-    public:
-    /**
-     * Default constructor
-     */
-    TableTupleFilter_const_iter()
-      : m_tableFilter(0), m_tupleIdx()
-    {}
-
-    private:
-
-    friend class TableTupleFilter;
-    friend class boost::iterator_core_access;
-
-    /**
-     * Constructor. Sets the iterator position pointing to the first tuple that
-     * have the TableTupleFilter value set to the MARKER
-     */
-    explicit TableTupleFilter_const_iter(TableTupleFilter* m_tableFilter)
-      : m_tableFilter(m_tableFilter), m_tupleIdx(TableTupleFilter::INVALID_INDEX)
-    {
-        if (!m_tableFilter->empty())
-        {
-            increment();
-        }
-    }
-
-    /**
-     * Constructor. Sets the iterator position pointing to the specified position - usually the end
-     */
-    explicit TableTupleFilter_const_iter(const TableTupleFilter* m_tableFilter, size_t tupleIdx)
-        :  m_tableFilter(m_tableFilter), m_tupleIdx(tupleIdx)
-    {}
-
-    private:
-
-    bool equal(TableTupleFilter_const_iter const& other) const
-    {
-        // Shouldn't compare iterators from different tables
-        vassert(m_tableFilter == other.m_tableFilter);
-        return m_tupleIdx == other.m_tupleIdx;
-    }
-
-    uint64_t const& dereference() const
-    {
-        return m_tupleIdx;
-    }
-
-    // Forward Iteration Support
-    void increment()
-    {
-        uint64_t lastActiveTupleIndex = m_tableFilter->getLastActiveTupleIndex();
-        do
-        {
-            ++m_tupleIdx;
-        } while(m_tupleIdx <= lastActiveTupleIndex && m_tableFilter->getTupleValue(m_tupleIdx) != MARKER);
-    }
-
-    const TableTupleFilter* m_tableFilter;
-    uint64_t m_tupleIdx;
-};
-
-template <int8_t MARKER>
-inline
-TableTupleFilter_iter<MARKER> TableTupleFilter::begin()
-{
-    return TableTupleFilter_iter<MARKER>(this);
 }
 
-template <int8_t MARKER>
-inline
-TableTupleFilter_iter<MARKER> TableTupleFilter::end()
-{
-    uint64_t lastActiveTupleIndex = (getLastActiveTupleIndex() != TableTupleFilter::INVALID_INDEX) ?
-        getLastActiveTupleIndex() + 1 : TableTupleFilter::INVALID_INDEX;
-    return TableTupleFilter_iter<MARKER>(this, lastActiveTupleIndex);
-}
-
-template <int8_t MARKER>
-inline
-TableTupleFilter_const_iter<MARKER> TableTupleFilter::begin() const
-{
-    return TableTupleFilter_const_iter<MARKER>(this);
-}
-
-template <int8_t MARKER>
-inline
-TableTupleFilter_const_iter<MARKER> TableTupleFilter::end() const
-{
-    uint64_t lastActiveTupleIndex = (getLastActiveTupleIndex() != TableTupleFilter::INVALID_INDEX) ?
-        getLastActiveTupleIndex() + 1 : TableTupleFilter::INVALID_INDEX;
-    return TableTupleFilter_const_iter<MARKER>(this, lastActiveTupleIndex);
+template<int8_t Marker, typename ValueType>
+void TableTupleFilterIterType<Marker, ValueType>::increment() {
+    ValueType lastActiveTupleIndex = m_tableFilter->getLastActiveTupleIndex();
+    do {
+        ++m_tupleIdx;
+    } while(m_tupleIdx <= lastActiveTupleIndex &&
+            m_tableFilter->getTupleValue(m_tupleIdx) != Marker);
 }
 
 }
-#endif // VOLTDB_TABLETUPLEFILTER_H
+


### PR DESCRIPTION
This PR is part of effort when reviewing Mike's work, specifically on merge join executor (https://github.com/VoltDB/voltdb/pull/6596).
Two key changes in this refactory:
1. Changed signature for `LimitPlanNode::getLimitAndOffsetByReference()`, by moving two function parameters to return value, to make intention more clean.
2. Simplifying `TableTupleFilter` template design.