### PR TITLE
ENG-18197: Add read only mode to TaskManager

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -592,6 +592,7 @@ DISTRIBUTION
             <include name="src/frontend/org/voltdb/task/ActionScheduler.java" />
             <include name="src/frontend/org/voltdb/task/DelayedAction.java" />
             <include name="src/frontend/org/voltdb/task/ActionGenerator.java" />
+            <include name="src/frontend/org/voltdb/task/ActionGeneratorBase.java" />
             <include name="src/frontend/org/voltdb/task/Action.java" />
             <include name="src/frontend/org/voltdb/task/ActionSchedule.java" />
             <include name="src/frontend/org/voltdb/task/ActionDelay.java" />

--- a/src/frontend/org/voltdb/task/ActionGenerator.java
+++ b/src/frontend/org/voltdb/task/ActionGenerator.java
@@ -20,7 +20,7 @@ package org.voltdb.task;
 /**
  * Interface which generates actions to be be performed as part of a task on a schedule
  */
-public interface ActionGenerator extends Initializable {
+public interface ActionGenerator extends ActionGeneratorBase {
     /**
      * This method is invoked for the first action to be performed. All subsequent invocation will be of
      * {@link Action#getCallback()}
@@ -31,21 +31,4 @@ public interface ActionGenerator extends Initializable {
      * @return {@link Action} to perform
      */
     Action getFirstAction();
-
-    /**
-     * If this method returns {@code true} that means the type of procedure which this scheduler can run is restricted
-     * based upon the scope type.
-     * <ul>
-     * <li>SYSTEM - Cannot run single partition procedures</li>
-     * <li>HOSTS - Only NT procedures are allowed</li>
-     * <li>PARTITIONS - Only partitioned procedures are allowed</li>
-     * </ul>
-     * <p>
-     * Default return is {@code false}
-     *
-     * @return {@code true} if the type of procedure this scheduler can run should be restricted based upon scope
-     */
-    default boolean restrictProcedureByScope() {
-        return false;
-    }
 }

--- a/src/frontend/org/voltdb/task/ActionGeneratorBase.java
+++ b/src/frontend/org/voltdb/task/ActionGeneratorBase.java
@@ -1,0 +1,49 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.task;
+
+/**
+ * Base interface for {@link ActionGenerator} and {@link ActionScheduler} to define methods which appear in both
+ */
+interface ActionGeneratorBase extends Initializable {
+    /**
+     * If this method returns {@code true} that means the type of procedure which this scheduler can run is restricted
+     * based upon the scope type.
+     * <ul>
+     * <li>SYSTEM - Cannot run single partition procedures</li>
+     * <li>HOSTS - Only NT procedures are allowed</li>
+     * <li>PARTITIONS - Only partitioned procedures are allowed</li>
+     * </ul>
+     * <p>
+     * Default return is {@code false}
+     *
+     * @return {@code true} if the type of procedure this scheduler can run should be restricted based upon scope
+     */
+    default boolean restrictProcedureByScope() {
+        return false;
+    }
+
+    /**
+     * Return {@code false} unless it is guaranteed that all procedures are also read only.
+     *
+     * @return {@code true} if all procedures returned by this instance are read only
+     */
+    default boolean isReadOnly() {
+        return false;
+    }
+}

--- a/src/frontend/org/voltdb/task/ActionScheduler.java
+++ b/src/frontend/org/voltdb/task/ActionScheduler.java
@@ -21,7 +21,7 @@ package org.voltdb.task;
  * Interface which generates actions to be performed as well as calculating the delay until that should be performed
  * according to a schedule
  */
-public interface ActionScheduler extends Initializable {
+public interface ActionScheduler extends ActionGeneratorBase {
     /**
      * This method is invoked for the first action to be performed. All subsequent invocation will be of
      * {@link DelayedAction#getCallback()}. After the delay has elapsed and the action has been performed.
@@ -32,21 +32,4 @@ public interface ActionScheduler extends Initializable {
      * @return {@link DelayedAction} with the action and delay of that action
      */
     DelayedAction getFirstDelayedAction();
-
-    /**
-     * If this method returns {@code true} that means the type of procedure which this scheduler can run is restricted
-     * based upon the scope type.
-     * <ul>
-     * <li>SYSTEM - Cannot run single partition procedures</li>
-     * <li>HOSTS - Only NT procedures are allowed</li>
-     * <li>PARTITIONS - Only partitioned procedures are allowed</li>
-     * </ul>
-     * <p>
-     * Default return is {@code false}
-     *
-     * @return {@code true} if the type of procedure this scheduler can run should be restricted based upon scope
-     */
-    default boolean restrictProcedureByScope() {
-        return false;
-    }
 }

--- a/src/frontend/org/voltdb/task/CompositeActionScheduler.java
+++ b/src/frontend/org/voltdb/task/CompositeActionScheduler.java
@@ -44,4 +44,9 @@ final class CompositeActionScheduler implements ActionScheduler {
     public boolean restrictProcedureByScope() {
         return m_actionGenerator.restrictProcedureByScope();
     }
+
+    @Override
+    public boolean isReadOnly() {
+        return m_actionGenerator.isReadOnly();
+    }
 }

--- a/src/frontend/org/voltdb/task/SingleProcGenerator.java
+++ b/src/frontend/org/voltdb/task/SingleProcGenerator.java
@@ -23,6 +23,7 @@ package org.voltdb.task;
  */
 public final class SingleProcGenerator implements ActionGenerator {
     private Action m_action;
+    private boolean m_isReadOnly;
 
     public static String validateParameters(TaskHelper helper, String procedure, Object... procedureParameters) {
         TaskValidationErrors errors = new TaskValidationErrors();
@@ -32,6 +33,7 @@ public final class SingleProcGenerator implements ActionGenerator {
 
     public void initialize(TaskHelper helper, String procedure, Object... procedureParameters) {
         m_action = Action.createProcedure(r -> m_action, procedure, procedureParameters);
+        m_isReadOnly = helper.isProcedureReadOnly(procedure);
     }
 
     @Override
@@ -42,5 +44,10 @@ public final class SingleProcGenerator implements ActionGenerator {
     @Override
     public Action getFirstAction() {
         return m_action;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return m_isReadOnly;
     }
 }

--- a/src/frontend/org/voltdb/task/TaskHelper.java
+++ b/src/frontend/org/voltdb/task/TaskHelper.java
@@ -234,6 +234,21 @@ public final class TaskHelper {
         }
     }
 
+    /**
+     * Test if a procedure is read only. If a procedure cannot be found with {@code procedureName} then {@code false} is
+     * returned
+     *
+     * @param procedureName Name of procedure.
+     * @return {@code true} if {@code procedureName} is read only
+     */
+    public boolean isProcedureReadOnly(String procedureName) {
+        if (m_procedureGetter == null) {
+            return false;
+        }
+        Procedure procedure = m_procedureGetter.apply(procedureName);
+        return procedure == null ? false : procedure.getReadonly();
+    }
+
     private String generateLogMessage(String body) {
         return m_generateLogMessage.apply(body);
     }

--- a/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
+++ b/tests/frontend/org/voltdb/task/TestTasksEnd2End.java
@@ -46,8 +46,6 @@ import org.voltdb.tasktest.CustomTestActionGenerator;
 import org.voltdb.tasktest.CustomTestActionScheduler;
 import org.voltdb.utils.MiscUtils;
 
-import com.google_voltpatches.common.collect.ImmutableSet;
-
 public class TestTasksEnd2End extends LocalClustersTestBase {
     private static final String s_userName = "TestUser";
 
@@ -400,56 +398,7 @@ public class TestTasksEnd2End extends LocalClustersTestBase {
         }
     }
 
-    /*
-     * Test that partition tasks can run concurrently with an elastic join operation and that if one of the new hosts
-     * goes down the tasks will fail over to the remaining new host
-     */
-    @Test(timeout = 60_000)
-    public void elasticJoinAndFailOver() throws Exception {
-        if (!MiscUtils.isPro()) {
-            return;
-        }
-
-        cleanupAfterTest();
-
-        Client client = getClient(0);
-
-        String tableName = getTableName(0, TableType.PARTITIONED);
-
-        String procName = getMethodName() + "_prune";
-        client.callProcedure("@AdHoc",
-                "CREATE PROCEDURE " + procName + " DIRECTED AS DELETE FROM " + tableName + " ORDER BY key OFFSET 10");
-
-        String schedule = getMethodName();
-        client.callProcedure("@AdHoc", "CREATE TASK " + schedule + " ON SCHEDULE DELAY 10 MILLISECONDS PROCEDURE "
-                + procName + " RUN ON PARTITIONS");
-
-        Thread.sleep(200);
-        VoltTable table = getTaskStats(client);
-        assertEquals(6, table.getRowCount());
-
-        getCluster(0).join(ImmutableSet.of(3, 4));
-
-        // Wait for rebalance to start so the kill doesn't kill all hosts
-        int rowCount;
-        do {
-            rowCount = client.callProcedure("@Statistics", "REBALANCE", 0).getResults()[0].getRowCount();
-            if (rowCount != 0) {
-                break;
-            }
-            Thread.sleep(500);
-        } while (true);
-
-        table = getTaskStats(client);
-        assertEquals(10, table.getRowCount());
-
-        getCluster(0).killSingleHost(3);
-        Thread.sleep(500);
-        table = getTaskStats(client);
-        assertEquals(10, table.getRowCount());
-    }
-
-    private static VoltTable getTaskStats(Client client)
+    static VoltTable getTaskStats(Client client)
             throws NoConnectionsException, IOException, ProcCallException {
         return client.callProcedure("@Statistics", "TASK", 0).getResults()[0];
     }


### PR DESCRIPTION
Add the concept of read only mode to TaskManager, which causes all read/write
tasks to enter paused mode. When the task manager exits read only mode than all
paused tasks will be started. TaskManager is in read only mode whenever the
database is paused or the database is a replica.

All interfaces which return an Action have a isReadOnly() method which by
default returns false. A custom implementor can override this method to return
an appropriate value. The builtin one returns the read only flag on the
procedure.