### PR TITLE
Eng 17910. Add version information to licensee field in trial license.

### DIFF
--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -162,7 +162,7 @@ def makeTrialLicense(licensee, days=30, dr_and_xdcr="true", nodes=12):
     with cd(builddir + "/pro"):
         run("ant -f licensetool.xml createlicense \
         -Dallowreplication=true -DallowDrActiveActive=true\
-                     -Dlicensdays=%d -Dlicensee='%s'" % (days, licensee))
+                     -Dlicensedays=%d -Dlicensee='%s'" % (days, licensee))
 
 ################################################
 # MAKE A SHA256 checksum

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -163,7 +163,7 @@ def makeTrialLicense(licensee, days=30, dr_and_xdcr="true", nodes=12):
     filename = 'trial_' + timestring + '.xml'
     with cd(builddir + "/pro"):
         run("ant -f licensetool.xml createlicense \
-        -Dfilename=%s \
+        -Dfilename=%s -Dlicensetype=t -Dhardexpire=true \
         -Dallowreplication=true -DallowDrActiveActive=true\
                      -Dlicensedays=%d -Dlicensee='%s'" % (filename, days, licensee))
         return filename

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -97,7 +97,7 @@ def buildEnterprise(version):
         run("git describe --dirty")
         run("VOLTCORE=../voltdb ant -f mmt.xml \
         -Djmemcheck=NO_MEMCHECK \
-        -DallowDrReplication=true -DallowDrActiveActive \
+        -DallowDrReplication=true -DallowDrActiveActive=true \
         -Dlicensedays=%d -Dlicensee='%s' \
         -Dkitbuild=%s %s \
         clean dist.pro" \

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -111,14 +111,14 @@ def buildEnterprise(version):
 def packagePro(version):
     print "Making license"
     licensee="VoltDB Pro Trial User " + version
-    license = makeTrialLicense(licensee=licensee, days=defaultlicensedays, dr_and_xdcr=False, nodes=3)
+    licensefile = makeTrialLicense(licensee=licensee, days=defaultlicensedays, dr_and_xdcr=False, nodes=3)
     print "Repacking pro kit"
     with cd(builddir + "/pro/obj/pro"):
         run("mkdir pro_kit_staging")
     with cd(builddir + "/pro/obj/pro/pro_kit_staging"):
         run("tar xf ../voltdb-ent-%s.tar.gz" % version)
         run("mv voltdb-ent-%s voltdb-pro-%s" % (version, version))
-        run("cp %s/pro/%s voltdb-pro-%s/voltdb/license.xml" % (builddir, license, version))
+        run("cp %s/pro/%s voltdb-pro-%s/voltdb/license.xml" % (builddir, licensefile, version))
         run("tar cvfz ../voltdb-pro-%s.tar.gz voltdb-pro-%s" % (version, version))
 
 ################################################

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -97,7 +97,7 @@ def buildEnterprise(version):
         run("git describe --dirty")
         run("VOLTCORE=../voltdb ant -f mmt.xml \
         -Djmemcheck=NO_MEMCHECK \
-        -Dallowreplication=true -DallowDrActiveActive=true \
+        -DallowDrReplication=true -DallowDrActiveActive \
         -Dlicensedays=%d -Dlicensee='%s' \
         -Dkitbuild=%s %s \
         clean dist.pro" \
@@ -164,8 +164,8 @@ def makeTrialLicense(licensee, days=30, dr_and_xdcr="true", nodes=12):
     with cd(builddir + "/pro"):
         run("ant -f licensetool.xml createlicense \
         -Dfilename=%s -Dlicensetype=t -Dhardexpire=true \
-        -Dallowreplication=true -DallowDrActiveActive=true\
-                     -Dlicensedays=%d -Dlicensee='%s'" % (filename, days, licensee))
+        -DallowDrReplication=true -DallowDrActiveActive=true\
+        -Dlicensedays=%d -Dlicensee='%s'" % (filename, days, licensee))
         return filename
 
 ################################################

--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -164,8 +164,8 @@ def makeTrialLicense(licensee, days=30, dr_and_xdcr="true", nodes=12):
     with cd(builddir + "/pro"):
         run("ant -f licensetool.xml createlicense \
         -Dfilename=%s -Dlicensetype=t -Dhardexpire=true \
-        -DallowDrReplication=true -DallowDrActiveActive=true\
-        -Dlicensedays=%d -Dlicensee='%s'" % (filename, days, licensee))
+        -DallowDrReplication=%s -DallowDrActiveActive=%s\
+        -Dlicensedays=%d -Dlicensee='%s'" % (filename, dr_and_xdcr, dr_and_xdcr, days, licensee))
         return filename
 
 ################################################
@@ -361,7 +361,7 @@ if __name__ == "__main__":
             packagePro(versionCentos)
             makeSHA256SUM(versionCentos,"pro")
             copyFilesToReleaseDir(releaseDir, versionCentos, "pro")
-            licensefile = makeTrialLicense(licensee="VoltDB Internal Use Only V" + versionCentos)
+            licensefile = makeTrialLicense(licensee="VoltDB Internal Use Only " + versionCentos)
             copyTrialLicenseToReleaseDir(builddir + "/pro/" + licensefile, releaseDir)
             makeMavenJars()
             copyMavenJarsToReleaseDir(releaseDir, versionCentos)


### PR DESCRIPTION
- Add the version to the licensee field in the trial downloads kit. 
- Change the licensee for the internal-use license to say "Internal Use"

See changes in the pro repo for more details.