### PR TITLE
ENG-16636:

### DIFF
--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -193,7 +193,9 @@ public class ElasticJoinProducer extends JoinProducerBase implements TaskLog {
             if (m_snapshotCompletionMonitor.isDone()) {
                 try {
                     SnapshotCompletionEvent event = m_snapshotCompletionMonitor.get();
-                    siteConnection.setDRProtocolVersion(event.drVersion);
+                    if (event.drVersion != 0) {
+                        siteConnection.setDRProtocolVersion(event.drVersion);
+                    }
                     assert(event != null);
                     ELASTICLOG.debug("P" + m_partitionId + " noticed data transfer completion");
                     m_completionAction.setSnapshotTxnId(event.multipartTxnId);

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -388,7 +388,9 @@ public class RejoinProducer extends JoinProducerBase {
                     clusterCreateTime = event.clusterCreateTime;
 
                     // Tells EE which DR version going to use
-                    siteConnection.setDRProtocolVersion(event.drVersion);
+                    if (event.drVersion != 0) {
+                        siteConnection.setDRProtocolVersion(event.drVersion);
+                    }
 
                     REJOINLOG.debug(m_whoami + " monitor completed. Sending SNAPSHOT_FINISHED "
                             + "and handing off to site.");


### PR DESCRIPTION
Join tests were failing intermittently because join was calling setDrVersion with 0
if DR was not established before the join. setDrVersion has the side effect of starting
to write dr binay logs as well, which was causing "unexpected protocol version of 0" on the
consumer side.
Changed rejoin as well to check the version before calling setDrVersion, even though the tests
were not related to rejoin.