### PR TITLE
ENG-18247: Ignore failures during read only transition

### DIFF
--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -103,8 +103,6 @@ public final class TaskManager {
     private final Set<Integer> m_locallyLedPartitions = new HashSet<>();
     // Partition tasks are disabled while a host is performing the initial join work
     private boolean m_enableTasksOnPartitions;
-    // Supplier to indicate if this manager should be in read-only mode
-    private final BooleanSupplier m_readOnlySupplier;
     private final SimpleClientResponseAdapter m_adapter = new SimpleClientResponseAdapter(
             ClientInterface.TASK_MANAGER_CID, getClass().getSimpleName());
 
@@ -124,6 +122,8 @@ public final class TaskManager {
     // Used to execute the schedulers and scheduled procedures for partitioned schedules
     private final ScheduledExecutorHolder m_partitionedExecutor = new ScheduledExecutorHolder("PARTITIONED");
 
+    // Supplier to indicate if this manager should be in read-only mode
+    final BooleanSupplier m_readOnlySupplier;
     final ClientInterface m_clientInterface;
     final StatsAgent m_statsAgent;
 
@@ -1457,19 +1457,28 @@ public final class TaskManager {
             m_stats.addProcedureCall(m_scheduledAction.getExecutionTime(), m_scheduledAction.getWaitTime(), failed);
 
             if (failed) {
-                String onError = m_handler.m_definition.getOnerror();
+                if (response.getStatus() == ClientResponse.SERVER_UNAVAILABLE && m_readOnlySupplier.getAsBoolean()
+                        && !m_scheduler.isReadOnly()) {
+                    // Hit a race going into read only mode so just ignore or debug log
+                    if (log.isDebugEnabled() && response instanceof ClientResponseImpl) {
+                        log.debug(generateLogMessage("Ignoring server unavailable response in read only mode: "
+                                + ((ClientResponseImpl) response).toStatusJSONString()));
+                    }
+                } else {
+                    String onError = m_handler.m_definition.getOnerror();
 
-                boolean isIgnore = "IGNORE".equalsIgnoreCase(onError);
-                if (!isIgnore || log.isDebugEnabled()) {
-                    String message = "Procedure " + m_scheduledAction.getProcedure() + " with parameters "
-                            + Arrays.toString(m_scheduledAction.getProcedureParameters()) + " failed: "
-                            + m_scheduledAction.getResponse().getStatusString();
+                    boolean isIgnore = "IGNORE".equalsIgnoreCase(onError);
+                    if (!isIgnore || log.isDebugEnabled()) {
+                        String message = "Procedure " + m_scheduledAction.getProcedure() + " with parameters "
+                                + Arrays.toString(m_scheduledAction.getProcedureParameters()) + " failed: "
+                                + m_scheduledAction.getResponse().getStatusString();
 
-                    if (isIgnore || "LOG".equalsIgnoreCase(onError)) {
-                        log.log(isIgnore ? Level.DEBUG : Level.INFO, generateLogMessage(message), null);
-                    } else {
-                        errorOccurred(message);
-                        return;
+                        if (isIgnore || "LOG".equalsIgnoreCase(onError)) {
+                            log.log(isIgnore ? Level.DEBUG : Level.INFO, generateLogMessage(message), null);
+                        } else {
+                            errorOccurred(message);
+                            return;
+                        }
                     }
                 }
             } else if (log.isTraceEnabled() && response instanceof ClientResponseImpl) {

--- a/tests/frontend/org/voltdb/task/TestTaskManager.java
+++ b/tests/frontend/org/voltdb/task/TestTaskManager.java
@@ -674,6 +674,8 @@ public class TestTaskManager {
      */
     @Test
     public void readOnlyMode() throws Exception {
+        when(m_response.getStatus())
+                .then(m -> m_readOnly ? ClientResponse.SERVER_UNAVAILABLE : ClientResponse.SUCCESS);
         m_readOnly = true;
 
         Task task1 = createTask(TestActionScheduler.class, TaskScope.DATABASE);
@@ -783,6 +785,11 @@ public class TestTaskManager {
 
         // Go back to read only mode
         m_readOnly = true;
+
+        // Let the tasks run a bit before calling evaluateReadOnlyMode so they should see server unavailable errors
+        Thread.sleep(5);
+        validateStats(2);
+
         m_taskManager.evaluateReadOnlyMode().get();
         Thread.sleep(5);
         validateStats(2, null, r -> {
@@ -873,7 +880,7 @@ public class TestTaskManager {
         task.setName(name);
         task.setScope(scope.getId());
         task.setUser(USER_NAME);
-        task.setOnerror("ABORT");
+        task.setOnerror("STOP");
         return task;
     }
 


### PR DESCRIPTION
It is possible for a procedure to return an error when the system is going in
to paused mode. When this happens it is OK to ignore the failure as long as the
manager is supposed to be in read only mode and the scheduler is not read only.
The task should be paused shortly when evaluateReadOnlyMode completes
execution.

Stop task when any exception is caught in the executor