### PR TITLE
ENG-16292 & ENG-17299: Fix memcheck test failures

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -670,8 +670,10 @@ void VoltDBEngine::serializeToUDFOutputBuffer(int32_t functionId, const NValue& 
     }
     resetUDFOutputBuffer();
 
-    // Serialize buffer size, function ID, and udaf index
-    m_udfOutput.writeInt(bufferSizeNeeded);
+    // size of data
+    m_udfOutput.writeInt(bufferSizeNeeded - sizeof(int32_t));
+
+    // Serialize function ID, and udaf index
     m_udfOutput.writeInt(functionId);
     m_udfOutput.writeInt(udafIndex);
 
@@ -729,8 +731,10 @@ void VoltDBEngine::serializeToUDFOutputBuffer(int32_t functionId,
     }
     resetUDFOutputBuffer();
 
+    // size of data
+    m_udfOutput.writeInt(bufferSizeNeeded - sizeof(int32_t));
+
     // serialize data
-    m_udfOutput.writeInt(bufferSizeNeeded);
     m_udfOutput.writeInt(functionId);
     m_udfOutput.writeInt(udafIndex);
     m_udfOutput.writeInt(argCount);

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -47,6 +47,7 @@
 
 static int g_cleanUpCountdownLatch = -1;
 static pthread_mutex_t g_cleanUpMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t g_cleanUpCondition = PTHREAD_COND_INITIALIZER;
 
 namespace voltdb {
 class Pool;
@@ -146,7 +147,7 @@ public:
      * and this method will make sure that the VoltDBEngine is deleted and that the program will attempt
      * to free all memory allocated on the heap.
      */
-    void terminate();
+    void shutDown();
 
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
     void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::ExportStreamBlock *block);
@@ -184,8 +185,6 @@ private:
     int8_t tick(struct ipc_command *cmd);
 
     int8_t quiesce(struct ipc_command *cmd);
-
-    int8_t shutDown();
 
     int8_t setLogLevels(struct ipc_command *cmd);
 
@@ -491,11 +490,13 @@ VoltDBIPC::VoltDBIPC(int fd)
 }
 
 VoltDBIPC::~VoltDBIPC() {
-    // Normally, all resources should be freed by the server calling "shutDown".
     if (m_engine != NULL) {
-        // If the server simulates a crash, shutDown message may never get sent.
-        // Clean up here so that valgrind doesn't complain
-        shutDown();
+        delete m_engine;
+        delete [] m_reusedResultBuffer;
+        delete [] m_perFragmentStatsBuffer;
+        delete [] m_udfBuffer;
+        delete [] m_tupleBuffer;
+        delete [] m_exceptionBuffer;
     }
 }
 
@@ -588,7 +589,8 @@ bool VoltDBIPC::execute(struct ipc_command *cmd) {
           result = kErrorCode_None;
           break;
       case 30:
-          result = shutDown();
+          shutDown();
+          result = kErrorCode_Success;
           break;
       case 31:
           setViewsEnabled(cmd);
@@ -845,19 +847,6 @@ int8_t VoltDBIPC::quiesce(struct ipc_command *cmd) {
     return kErrorCode_Success;
 }
 
-int8_t VoltDBIPC::shutDown() {
-    delete m_engine;
-    delete [] m_reusedResultBuffer;
-    delete [] m_perFragmentStatsBuffer;
-    delete [] m_udfBuffer;
-    delete [] m_tupleBuffer;
-    delete [] m_exceptionBuffer;
-
-    m_engine = NULL;
-
-    return kErrorCode_Success;
-}
-
 void VoltDBIPC::executePlanFragments(struct ipc_command *cmd) {
     int errors = 0;
 
@@ -1069,7 +1058,7 @@ int8_t VoltDBIPC::setLogLevels(struct ipc_command *cmd) {
     return kErrorCode_Success;
 }
 
-void VoltDBIPC::terminate() {
+void VoltDBIPC::shutDown() {
     m_terminate = true;
 }
 
@@ -1796,23 +1785,22 @@ struct VoltDBIPCDeleter {
         if (voltipc->getEngine() == NULL || !voltipc->getEngine()->isLowestSite()) {
             // if the engine was already destroyed, or if it's not the lowest site,
             // just decrement the latch.
+            delete voltipc;
             pthread_mutex_lock(&g_cleanUpMutex);
-            --g_cleanUpCountdownLatch;
+            if (--g_cleanUpCountdownLatch <= 1) {
+                pthread_cond_broadcast(&g_cleanUpCondition);
+            }
             pthread_mutex_unlock(&g_cleanUpMutex);
         }
         else {
             // The lowest site: wait for the other sites to shut down before exiting.
-            while (true) {
-                pthread_mutex_lock(&g_cleanUpMutex);
-                volatile int latchVal = g_cleanUpCountdownLatch;
-                pthread_mutex_unlock(&g_cleanUpMutex);
-                if (latchVal <= 1) {
-                    break;
-                }
+            pthread_mutex_lock(&g_cleanUpMutex);
+            while (g_cleanUpCountdownLatch > 1) {
+                pthread_cond_wait(&g_cleanUpCondition, &g_cleanUpMutex);
             }
+            pthread_mutex_unlock(&g_cleanUpMutex);
+            delete voltipc;
         }
-
-        delete voltipc;
     }
 };
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -975,6 +975,9 @@ int VoltDBIPC::callJavaUserDefinedFunction() {
 }
 
 int VoltDBIPC::callJavaUserDefinedAggregateStart(int functionId) {
+    ReferenceSerializeOutput udfOutput(m_udfBuffer, MAX_MSG_SZ);
+    udfOutput.writeInt(sizeof(functionId));
+    udfOutput.writeInt(functionId);
     return callJavaUserDefinedHelper(kErrorCode_callJavaUserDefinedAggregateStart);
 }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -17,8 +17,11 @@
 
 package org.voltdb.jni;
 
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
@@ -38,8 +41,10 @@ import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.StatsSelector;
 import org.voltdb.TableStreamType;
 import org.voltdb.TheHashinator.HashinatorConfig;
+import org.voltdb.UserDefinedAggregateFunctionRunner;
 import org.voltdb.UserDefinedScalarFunctionRunner;
 import org.voltdb.VoltTable;
+import org.voltdb.VoltType;
 import org.voltdb.common.Constants;
 import org.voltdb.exceptions.EEException;
 import org.voltdb.exceptions.SerializableException;
@@ -47,8 +52,8 @@ import org.voltdb.export.ExportManager;
 import org.voltdb.iv2.DeterminismHash;
 import org.voltdb.messaging.FastDeserializer;
 import org.voltdb.messaging.FastSerializer;
-import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.sysprocs.saverestore.HiddenColumnFilter;
+import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.utils.CompressionService;
 import org.voltdb.utils.SerializationHelper;
 
@@ -277,10 +282,34 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         static final int kErrorCode_callJavaUserDefinedFunction = 107;
 
         /**
-         * An error code that can be sent at any time indicating that
-         * an export stream is dropped
+         * An error code that can be sent at any time indicating that an export stream is dropped
          */
         static final int kErrorCode_pushEndOfStream = 113;
+
+        /**
+         * Instruct the Java side to start a user-defined aggregate function.
+         */
+        static final int kErrorCode_callJavaUserDefinedAggregateStart = 114;
+
+        /**
+         * Instruct the Java side to assemble a user-defined aggregate function.
+         */
+        static final int kErrorCode_callJavaUserDefinedAggregateAssemble = 115;
+
+        /**
+         * Instruct the Java side to combine a result from another user-defined aggregate with this one.
+         */
+        static final int kErrorCode_callJavaUserDefinedAggregateCombine = 116;
+
+        /**
+         * Instruct the Java side to complete the worker portion of a user-defined aggregate function.
+         */
+        static final int kErrorCode_callJavaUserDefinedAggregateWorkerEnd = 117;
+
+        /**
+         * Instruct the Java side to calculate the result of a user-defined aggregate function.
+         */
+        static final int kErrorCode_callJavaUserDefinedAggregateCoordinatorEnd = 118;
 
         ByteBuffer getBytes(int size) throws IOException {
             ByteBuffer header = ByteBuffer.allocate(size);
@@ -294,18 +323,24 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             return header;
         }
 
+        private ByteBuffer readMessage() throws IOException {
+            int bufferSize = m_connection.readInt();
+            final ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+            while (buffer.hasRemaining()) {
+                int read = m_socketChannel.read(buffer);
+                if (read == -1) {
+                    throw new EOFException();
+                }
+            }
+            buffer.flip();
+            return buffer;
+        }
+
         // Read per-fragment stats from the wire.
         void extractPerFragmentStatsInternal() {
             try {
-                int bufferSize = m_connection.readInt();
-                final ByteBuffer perFragmentStatsBuffer = ByteBuffer.allocate(bufferSize);
-                while (perFragmentStatsBuffer.hasRemaining()) {
-                    int read = m_socketChannel.read(perFragmentStatsBuffer);
-                    if (read == -1) {
-                        throw new EOFException();
-                    }
-                }
-                perFragmentStatsBuffer.flip();
+                final ByteBuffer perFragmentStatsBuffer = readMessage();
+
                 // Skip the perFragmentTimingEnabled flag.
                 perFragmentStatsBuffer.get();
                 m_succeededFragmentsCount = perFragmentStatsBuffer.getInt();
@@ -328,15 +363,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         void callJavaUserDefinedFunctionInternal() {
             try {
                 // Read the request content from the wire.
-                int bufferSize = m_connection.readInt();
-                final ByteBuffer udfBuffer = ByteBuffer.allocate(bufferSize);
-                while (udfBuffer.hasRemaining()) {
-                    int read = m_socketChannel.read(udfBuffer);
-                    if (read == -1) {
-                        throw new EOFException();
-                    }
-                }
-                udfBuffer.flip();
+                ByteBuffer udfBuffer = readMessage();
 
                 int functionId = udfBuffer.getInt();
                 UserDefinedScalarFunctionRunner udfRunner = m_functionManager.getFunctionRunnerById(functionId);
@@ -375,6 +402,85 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 m_connection.write();
             }
             catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        void callJavaUserDefinedAggregateFunction(int operationId) {
+            try {
+                // Read the request content from the wire.
+                ByteBuffer udafBuffer = readMessage();
+
+                int functionId = udafBuffer.getInt();
+                UserDefinedAggregateFunctionRunner udafRunner = m_functionManager
+                        .getAggregateFunctionRunnerById(functionId);
+                assert (udafRunner != null);
+
+                Throwable throwable = null;
+                try {
+                    m_data.clear();
+                    // Put the status code for success (zero) into the buffer.
+                    m_data.putInt(0);
+
+                    if (operationId == kErrorCode_callJavaUserDefinedAggregateStart) {
+                        udafRunner.start();
+                    } else {
+                        int udafIndex = udafBuffer.getInt();
+
+                        switch (operationId) {
+                        case kErrorCode_callJavaUserDefinedAggregateAssemble:
+                            udafRunner.assemble(udafBuffer, udafIndex);
+                            break;
+                        case kErrorCode_callJavaUserDefinedAggregateCombine:
+                            udafRunner.combine(UserDefinedAggregateFunctionRunner.readObject(udafBuffer), udafIndex);
+                            break;
+                        case kErrorCode_callJavaUserDefinedAggregateWorkerEnd:
+                            Object workerInstance = udafRunner.getFunctionInstance(udafIndex);
+
+                            udafRunner.clearFunctionInstance(udafIndex);
+
+                            try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                                    ObjectOutput out = new ObjectOutputStream(bos)) {
+                                out.writeObject(workerInstance);
+                                out.flush();
+
+                                UserDefinedScalarFunctionRunner.writeValueToBuffer(m_data, VoltType.VARBINARY,
+                                        bos.toByteArray());
+                            }
+                            break;
+                        case kErrorCode_callJavaUserDefinedAggregateCoordinatorEnd:
+                            Object returnValue = udafRunner.end(udafIndex);
+                            UserDefinedScalarFunctionRunner.writeValueToBuffer(m_data, udafRunner.getReturnType(),
+                                    returnValue);
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unknown operation: " + operationId);
+                        }
+                    }
+
+                    // Write the result to the buffer.
+
+                    m_data.flip();
+                    m_connection.write();
+                    return;
+                } catch (InvocationTargetException ex1) {
+                    // Exceptions thrown during Java reflection will be wrapped into this InvocationTargetException.
+                    // We need to get its cause and throw that to the user.
+                    throwable = ex1.getCause();
+                } catch (Throwable ex2) {
+                    throwable = ex2;
+                }
+
+                // Getting here means the execution was not successful.
+                m_data.clear();
+
+                // Exception thrown, put return code = -1.
+                m_data.putInt(-1);
+                byte[] errorMsg = throwable.toString().getBytes(Constants.UTF8ENCODING);
+                SerializationHelper.writeVarbinary(errorMsg, m_data);
+                m_data.flip();
+                m_connection.write();
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -538,6 +644,9 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 }
                 else if (status == kErrorCode_callJavaUserDefinedFunction) {
                     callJavaUserDefinedFunctionInternal();
+                } else if (status >= kErrorCode_callJavaUserDefinedAggregateStart
+                        && status <= kErrorCode_callJavaUserDefinedAggregateCoordinatorEnd) {
+                    callJavaUserDefinedAggregateFunction(status);
                 }
                 else {
                     break;


### PR DESCRIPTION
ENG-16292:
    Even though the java layer invokes shutdown in the order highest to lowest it
    does not wait for one to complete before invoking the next shutdown. This means
    that even though the lowest site shutdown is initiated last it could execute
    before the the others. Simplify the deallocation of m_engine in VoltDBIPC so
    there is only one path and it always deallocates all other sites prior to the
    lowest site.

ENG-17299: Implement IPC for user defined aggregate functions

Valgrind identified read of uninitialized memory which was that during sending
    of user defined aggregate function method invocations the size of the message
    was including the size value which should be excluded.