### PR TITLE
ENG-18327 return last response on partition master as response to client

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -324,9 +324,7 @@ public class MpScheduler extends Scheduler
                     message.getInitiatorHSId(),
                     mpTxnId,
                     m_iv2Masters,
-                    message,
-                    localId,
-                    true);
+                    message);
             safeAddToDuplicateCounterMap(mpTxnId, counter);
             EveryPartitionTask eptask =
                 new EveryPartitionTask(m_mailbox, m_pendingTasks, sp,

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -45,10 +45,9 @@ public class SysProcDuplicateCounter extends DuplicateCounter
             long destinationHSId,
             long realTxnId,
             List<Long> expectedHSIds,
-            TransactionInfoBaseMessage message,
-            long leaderHSID)
+            TransactionInfoBaseMessage message)
     {
-        super(destinationHSId, realTxnId, expectedHSIds, message, leaderHSID);
+        super(destinationHSId, realTxnId, expectedHSIds, message);
     }
 
     /**
@@ -105,7 +104,7 @@ public class SysProcDuplicateCounter extends DuplicateCounter
         // needs to be a three long array to work
         int[] hashes = new int[] { (int) hash, 0, 0 };
 
-        return checkCommon(hashes, message.isRecovering(), message, false);
+        return checkCommon(hashes, message.isRecovering(), null, message, false);
     }
 
     @Override


### PR DESCRIPTION
Changes were made to always return the response from partition master to client.  However, the response from the partition master usually is the first response the partition master receives since it is local, which could be corrupted when other responses arrive.  So revert previous changes.