### PR TITLE
Eng 17134 left join gives error

### DIFF
--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -510,7 +510,7 @@ public final class ExpressionUtil {
      */
     public static void collectPartitioningFilters(
             Collection<AbstractExpression> filterList,
-            HashMap<AbstractExpression, Set<AbstractExpression>> equivalenceSet) {
+            Map<AbstractExpression, Set<AbstractExpression>> equivalenceSet) {
         for (AbstractExpression expr : filterList) {
             if ( ! expr.isColumnEquivalenceFilter()) {
                 continue;

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -1639,7 +1639,7 @@ public abstract class AbstractParsedStmt {
      * TupleValueExpressions, ConstantValueExpressions, or ParameterValueExpressions,
      * that they are constrained to equal.
      */
-    HashMap<AbstractExpression, Set<AbstractExpression>> analyzeValueEquivalence() {
+    Map<AbstractExpression, Set<AbstractExpression>> analyzeValueEquivalence() {
         // collect individual where/join expressions
         m_joinTree.analyzeJoinExpressions(m_noTableSelectionList);
         return m_joinTree.getAllEquivalenceFilters();
@@ -2064,7 +2064,7 @@ public abstract class AbstractParsedStmt {
             return;
         }
 
-        HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence =
+        Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence =
                 analyzeValueEquivalence();
         for (ParsedColInfo colInfo : candidateColumns) {
             AbstractExpression colExpr = colInfo.m_expression;
@@ -2303,7 +2303,7 @@ public abstract class AbstractParsedStmt {
         }
 
         // Collect value equivalence expression for the SQL statement
-        HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence = analyzeValueEquivalence();
+        Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence = analyzeValueEquivalence();
 
         // If no value equivalence filter defined in SQL statement, there's no use to continue
         if (valueEquivalence.isEmpty()) {

--- a/src/frontend/org/voltdb/planner/CommonTableLeafNode.java
+++ b/src/frontend/org/voltdb/planner/CommonTableLeafNode.java
@@ -32,6 +32,7 @@
  */
 package org.voltdb.planner;
 
+import java.util.Deque;
 import java.util.List;
 
 import org.voltdb.expressions.AbstractExpression;
@@ -57,12 +58,9 @@ public class CommonTableLeafNode extends JoinNode {
 
     @Override
     public Object clone() {
-        AbstractExpression joinExpr = (m_joinExpr != null) ?
-                (AbstractExpression) m_joinExpr.clone() : null;
-        AbstractExpression whereExpr = (m_whereExpr != null) ?
-                (AbstractExpression) m_whereExpr.clone() : null;
-        JoinNode newNode = new CommonTableLeafNode(m_id, joinExpr, whereExpr, m_commonTableScan);
-        return newNode;
+        AbstractExpression joinExpr = m_joinExpr != null ? m_joinExpr.clone() : null;
+        AbstractExpression whereExpr =m_whereExpr != null ? m_whereExpr.clone() : null;
+        return new CommonTableLeafNode(m_id, joinExpr, whereExpr, m_commonTableScan);
     }
 
     @Override
@@ -72,8 +70,7 @@ public class CommonTableLeafNode extends JoinNode {
 
     @Override
     public JoinNode cloneWithoutFilters() {
-        JoinNode newNode = new CommonTableLeafNode(m_id, null, null, m_commonTableScan);
-        return newNode;
+        return new CommonTableLeafNode(m_id, null, null, m_commonTableScan);
     }
 
     @Override
@@ -90,6 +87,10 @@ public class CommonTableLeafNode extends JoinNode {
     public boolean hasSubqueryScans() {
         // No subquery scans here.
         return false;
+    }
+
+    @Override
+    protected void queueChildren(Deque<JoinNode> joinNodes) {
     }
 }
 

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -364,7 +364,7 @@ public class PlanAssembler {
             // This throws off the accounting of equivalence join filters until they can be
             // normalized in analyzeJoinFilters, but that normalization process happens on a
             // per-join-order basis, and so, so must this analysis.
-            HashMap<AbstractExpression, Set<AbstractExpression>>
+            Map<AbstractExpression, Set<AbstractExpression>>
                 valueEquivalence = parsedStmt.analyzeValueEquivalence();
             Collection<StmtTableScan> scans = parsedStmt.allScans();
             m_partitioning.analyzeForMultiPartitionAccess(scans, valueEquivalence);

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -278,12 +278,11 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
             // no more join orders => no more plans to generate
             if (joinTree == null) {
                 return null;
-            }
-
-            // Analyze join and filter conditions
-            joinTree.analyzeJoinExpressions(m_parsedStmt);
-            // a query that is a little too quirky or complicated.
-            if (!m_parsedStmt.m_noTableSelectionList.isEmpty()) {
+            } else if (! joinTree.analyzeJoinExpressions(m_parsedStmt)) {
+                // current join order is not plannable
+                return null;
+            } else if (! m_parsedStmt.m_noTableSelectionList.isEmpty()) {
+                // a query that is a little too quirky or complicated.
                 throw new PlanningErrorException("Join with filters that do not depend on joined tables is not supported in VoltDB");
             }
 

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -848,12 +848,9 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
         indexedExprs.addAll(endExprs);
         // Find an outer TVE by ignoring any TVEs based on the inner table.
         for (AbstractExpression indexed : indexedExprs) {
-            Collection<TupleValueExpression> indexedTVEs =
-                    indexed.findAllTupleValueSubexpressions();
-            for (AbstractExpression indexedTVExpr : indexedTVEs) {
-                if (! TupleValueExpression.isOperandDependentOnTable(indexedTVExpr, innerTableAlias)) {
-                    return true;
-                }
+            if (! indexed.findAllTupleValueSubexpressions().stream()
+                    .allMatch(e -> TupleValueExpression.isOperandDependentOnTable(e, innerTableAlias))) {
+                return true;
             }
         }
         return false;

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -284,7 +284,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
             }
 
             // Analyze join and filter conditions
-            joinTree.analyzeJoinExpressions(m_parsedStmt.m_noTableSelectionList);
+            joinTree.analyzeJoinExpressions(m_parsedStmt);
             // a query that is a little too quirky or complicated.
             if (!m_parsedStmt.m_noTableSelectionList.isEmpty()) {
                 throw new PlanningErrorException("Join with filters that do not depend on joined tables is not supported in VoltDB");
@@ -704,8 +704,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
         boolean canHaveNLJ = true;
         boolean canHaveNLIJ = true;
         if (innerPlan instanceof IndexScanPlanNode) {
-            if (hasInnerOuterIndexExpression(
-                        joinNode.getRightNode().getTableAlias(), innerAccessPath.indexExprs,
+            if (hasInnerOuterIndexExpression(joinNode.getRightNode().getTableAlias(), innerAccessPath.indexExprs,
                         innerAccessPath.initialExpr, innerAccessPath.endExprs)) {
                 canHaveNLJ = false;
             }
@@ -779,7 +778,8 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
             // right child node.
             if (needInnerSendReceive) {
                 // This trick only works once per plan.
-                if (outerPlan.hasAnyNodeOfClass(AbstractReceivePlanNode.class) || innerPlan.hasAnyNodeOfClass(AbstractReceivePlanNode.class)) {
+                if (outerPlan.hasAnyNodeOfClass(AbstractReceivePlanNode.class) ||
+                        innerPlan.hasAnyNodeOfClass(AbstractReceivePlanNode.class)) {
                     return null;
                 }
                 innerPlan = addSendReceivePair(innerPlan);

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -53,10 +53,10 @@ import org.voltdb.utils.PermutationGenerator;
 public class SelectSubPlanAssembler extends SubPlanAssembler {
 
     /** The list of generated plans. This allows their generation in batches.*/
-    ArrayDeque<AbstractPlanNode> m_plans = new ArrayDeque<>();
+    Deque<AbstractPlanNode> m_plans = new ArrayDeque<>();
 
     /** The list of all possible join orders, assembled by queueAllJoinOrders */
-    private ArrayDeque<JoinNode> m_joinOrders = new ArrayDeque<>();
+    private Deque<JoinNode> m_joinOrders = new ArrayDeque<>();
 
     private static final Runtime RUN_TIME = Runtime.getRuntime();
     // Number of times generateSubPlanForJoinNode() gets called recursively that we collect an estimate of heap size,
@@ -97,7 +97,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
      * Compute every permutation of the list of involved tables and put them in a deque.
      * TODO(XIN): takes at least 3.3% cpu of planner. Optimize it when possible.
      */
-    public static ArrayDeque<JoinNode> queueJoinOrders(JoinNode joinNode, boolean findAll) {
+    public static Deque<JoinNode> queueJoinOrders(JoinNode joinNode, boolean findAll) {
         assert(joinNode != null);
 
         // Clone the original
@@ -106,7 +106,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
         List<JoinNode> subTrees = clonedTree.extractSubTrees();
         assert(!subTrees.isEmpty());
         // Generate possible join orders for each sub-tree separately
-        ArrayList<List<JoinNode>> joinOrderList = generateJoinOrders(subTrees);
+        List<List<JoinNode>> joinOrderList = generateJoinOrders(subTrees);
         // Reassemble the all possible combinations of the sub-tree and queue them
         ArrayDeque<JoinNode> joinOrders = new ArrayDeque<>();
         queueSubJoinOrders(joinOrderList, 0, new ArrayList<>(), joinOrders, findAll);
@@ -114,29 +114,26 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
     }
 
     private static void queueSubJoinOrders(List<List<JoinNode>> joinOrderList, int joinOrderListIdx,
-            ArrayList<JoinNode> currentJoinOrder, ArrayDeque<JoinNode> joinOrders, boolean findAll) {
+            List<JoinNode> currentJoinOrder, Deque<JoinNode> joinOrders, boolean findAll) {
         if (!findAll && joinOrders.size() > 0) {
             // At least find one valid join order
-            return;
-        }
-
-        if (joinOrderListIdx == joinOrderList.size()) {
+        } else if (joinOrderListIdx == joinOrderList.size()) {
             // End of recursion
             assert(!currentJoinOrder.isEmpty());
             JoinNode joinTree = JoinNode.reconstructJoinTreeFromSubTrees(currentJoinOrder);
             joinOrders.add(joinTree);
-            return;
-        }
-        // Recursive step
-        List<JoinNode> nextTrees = joinOrderList.get(joinOrderListIdx);
-        for (JoinNode headTree: nextTrees) {
-            ArrayList<JoinNode> updatedJoinOrder = new ArrayList<>();
-            // Order is important: The top sub-trees must be first
-            for (JoinNode node : currentJoinOrder) {
-                updatedJoinOrder.add((JoinNode)node.clone());
+        } else {
+            // Recursive step
+            List<JoinNode> nextTrees = joinOrderList.get(joinOrderListIdx);
+            for (JoinNode headTree : nextTrees) {
+                ArrayList<JoinNode> updatedJoinOrder = new ArrayList<>();
+                // Order is important: The top sub-trees must be first
+                for (JoinNode node : currentJoinOrder) {
+                    updatedJoinOrder.add((JoinNode) node.clone());
+                }
+                updatedJoinOrder.add((JoinNode) headTree.clone());
+                queueSubJoinOrders(joinOrderList, joinOrderListIdx + 1, updatedJoinOrder, joinOrders, findAll);
             }
-            updatedJoinOrder.add((JoinNode)headTree.clone());
-            queueSubJoinOrders(joinOrderList, joinOrderListIdx + 1, updatedJoinOrder, joinOrders, findAll);
         }
     }
 
@@ -147,8 +144,8 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
      * @param subTrees the list of join trees.
      * @return The list containing the list of trees of all possible permutations of the input trees
      */
-    private static ArrayList<List<JoinNode>> generateJoinOrders(List<JoinNode> subTrees) {
-        ArrayList<List<JoinNode>> permutations = new ArrayList<>();
+    private static List<List<JoinNode>> generateJoinOrders(List<JoinNode> subTrees) {
+        List<List<JoinNode>> permutations = new ArrayList<>();
         for (JoinNode subTree : subTrees) {
             permutations.add(generateJoinOrdersForTree(subTree));
         }
@@ -389,7 +386,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
         JoinType joinType = parentNode.getJoinType();
         // For LEFT and FULL join types, the outer join expressions are kept as a pre-join predicate
         // at the join node to pre-qualify the outer rows
-        List<AbstractExpression> joinOuterList =  (joinType == JoinType.INNER) ?
+        List<AbstractExpression> joinOuterList =  joinType == JoinType.INNER ?
                 parentNode.m_joinOuterList : null;
         if (outerChildNode instanceof BranchNode) {
             generateOuterAccessPaths((BranchNode)outerChildNode);
@@ -484,9 +481,9 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
 
         // Don't bother generating these redundant or inferior access paths unless there is
         // an inner-outer expression and a chance that NLIJ will be taken out of the running.
-        boolean mayNeedInnerSendReceive = ( ! m_partitioning.wasSpecifiedAsSingle()) &&
-                (m_partitioning.getCountOfPartitionedTables() > 0) &&
-                (parentNode.getJoinType() != JoinType.INNER) &&
+        boolean mayNeedInnerSendReceive = ! m_partitioning.wasSpecifiedAsSingle() &&
+                m_partitioning.getCountOfPartitionedTables() > 0 &&
+                parentNode.getJoinType() != JoinType.INNER &&
                 ! innerTable.getIsReplicated();
 // too expensive/complicated to test here? (parentNode.m_leftNode has a replicated result?) &&
 
@@ -542,16 +539,13 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
                 }
                 m_plans.add(plan);
             }
-            return;
-        }
-
-        // If we have drained heap memory, don't recurse further on.
-        if (! m_plans.isEmpty() && m_plans.size() % PLAN_ESTIMATE_PERIOD == 0 && shouldStopPlanning()) {
-            return;
-        }
-        for (AccessPath path : joinNode.m_accessPaths) {
-            joinNode.m_currentAccessPath = path;
-            generateSubPlanForJoinNodeRecursively(rootNode, nextNode+1, nodes);
+        } else if (! m_plans.isEmpty() && m_plans.size() % PLAN_ESTIMATE_PERIOD == 0 && shouldStopPlanning()) {
+            // If we have drained heap memory, don't recurse further on.
+        } else {
+            for (AccessPath path : joinNode.m_accessPaths) {
+                joinNode.m_currentAccessPath = path;
+                generateSubPlanForJoinNodeRecursively(rootNode, nextNode + 1, nodes);
+            }
         }
     }
 
@@ -580,9 +574,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
                 return null;
             }
             // Join Node
-            IndexSortablePlanNode answer = getSelectSubPlanForJoin(branchJoinNode,
-                                                              outerScanPlan,
-                                                              innerScanPlan);
+            IndexSortablePlanNode answer = getSelectSubPlanForJoin(branchJoinNode, outerScanPlan, innerScanPlan);
             // Propagate information used for order by clauses in window functions
             // and the statement level order by clause.  This is only if the
             // branch node is an inner join.
@@ -633,7 +625,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
     private IndexSortablePlanNode getSelectSubPlanForJoin(
             BranchNode joinNode, AbstractPlanNode outerPlan, AbstractPlanNode innerPlan) {
         // Filter (post-join) expressions
-        ArrayList<AbstractExpression> whereClauses  = new ArrayList<>();
+        List<AbstractExpression> whereClauses  = new ArrayList<>();
         whereClauses.addAll(joinNode.m_whereInnerList);
         whereClauses.addAll(joinNode.m_whereInnerOuterList);
         if (joinNode.getJoinType() == JoinType.FULL) {
@@ -726,14 +718,14 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
             canHaveNLJ = false;
         }
 
-        AbstractJoinPlanNode ajNode = null;
+        AbstractJoinPlanNode ajNode;
         if (canHaveNLJ) {
             NestLoopPlanNode nljNode = new NestLoopPlanNode();
             // get all the clauses that join the applicable two tables
             // Copy innerAccessPath.joinExprs to leave it unchanged,
             // avoiding accumulation of redundant expressions when
             // joinClauses gets built up for various alternative plans.
-            ArrayList<AbstractExpression> joinClauses = new ArrayList<>(innerAccessPath.joinExprs);
+            List<AbstractExpression> joinClauses = new ArrayList<>(innerAccessPath.joinExprs);
             if ((innerPlan instanceof IndexScanPlanNode) ||
                 (innerPlan instanceof NestLoopIndexPlanNode
                     && innerPlan.getChild(0) instanceof MaterializedScanPlanNode)) {
@@ -850,7 +842,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
     private static boolean hasInnerOuterIndexExpression(
             String innerTableAlias, Collection<AbstractExpression> indexExprs,
             Collection<AbstractExpression> initialExpr, Collection<AbstractExpression> endExprs) {
-        HashSet<AbstractExpression> indexedExprs = new HashSet<>();
+        Set<AbstractExpression> indexedExprs = new HashSet<>();
         indexedExprs.addAll(indexExprs);
         indexedExprs.addAll(initialExpr);
         indexedExprs.addAll(endExprs);
@@ -859,7 +851,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
             Collection<TupleValueExpression> indexedTVEs =
                     indexed.findAllTupleValueSubexpressions();
             for (AbstractExpression indexedTVExpr : indexedTVEs) {
-                if ( ! TupleValueExpression.isOperandDependentOnTable(indexedTVExpr, innerTableAlias)) {
+                if (! TupleValueExpression.isOperandDependentOnTable(indexedTVExpr, innerTableAlias)) {
                     return true;
                 }
             }

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -306,7 +306,7 @@ public class SelectSubPlanAssembler extends SubPlanAssembler {
                 // detected, skip the plan generation for that particular ordering.
                 // If this causes all plans to be skipped, commonly the case, the PlanAssembler
                 // should propagate an error message identifying partitioning as the problem.
-                HashMap<AbstractExpression, Set<AbstractExpression>>
+                Map<AbstractExpression, Set<AbstractExpression>>
                     valueEquivalence = joinTree.getAllEquivalenceFilters();
                 Collection<StmtTableScan> scans = m_parsedStmt.allScans();
                 m_partitioning.analyzeForMultiPartitionAccess(scans, valueEquivalence);

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -17,11 +17,7 @@
 
 package org.voltdb.planner;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Column;
@@ -388,7 +384,7 @@ public class StatementPartitioning implements Cloneable{
      *         The caller can raise an alarm if there is more than one.
      */
     public void analyzeForMultiPartitionAccess(Collection<StmtTableScan> scans,
-            HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence) {
+            Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence) {
         //* enable to debug */ System.out.println("DEBUG: analyze4MPAccess w/ scans:" + scans.size() + " filters:" + valueEquivalence.size());
         TupleValueExpression tokenPartitionKey = null;
         Set< Set<AbstractExpression> > eqSets = new HashSet< >();

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -91,6 +91,17 @@ public abstract class SubPlanAssembler {
     }
 
     /**
+     * Used to mark that current plan cannot be generated, but nevertheless should not abort
+     * further plan generation.
+     * See how it affects plan generation in PlanAssembler#getBestCostPlan().
+     */
+    public static final class SkipCurrentPlanException extends RuntimeException {
+        public SkipCurrentPlanException() {
+            super();
+        }
+    }
+
+    /**
      * Called repeatedly to iterate through possible embedable select plans.
      * Returns null when no more plans exist.
      *

--- a/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
@@ -67,7 +67,7 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
             // only once on the node.
             JoinNode tableNode = (JoinNode) m_parsedStmt.m_joinTree.clone();
             // Analyze join conditions
-            tableNode.analyzeJoinExpressions(m_parsedStmt.m_noTableSelectionList);
+            tableNode.analyzeJoinExpressions(m_parsedStmt);
             // these just shouldn't happen right?
             assert(m_parsedStmt.m_noTableSelectionList.size() == 0);
 

--- a/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
@@ -18,8 +18,8 @@
 package org.voltdb.planner;
 
 import java.util.ArrayDeque;
+import java.util.Deque;
 
-import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 import org.voltdb.planner.parseinfo.JoinNode;
 import org.voltdb.plannodes.AbstractPlanNode;
@@ -39,7 +39,7 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
     final Table m_targetTable;
 
     /** The list of generated plans. This allows generation in batches.*/
-    final ArrayDeque<AbstractPlanNode> m_plans = new ArrayDeque<AbstractPlanNode>();
+    final Deque<AbstractPlanNode> m_plans = new ArrayDeque<>();
 
     /** Only create access plans once - all are created in the first pass. */
     boolean m_generatedPlans = false;
@@ -50,7 +50,6 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
      */
     WriterSubPlanAssembler(AbstractParsedStmt parsedStmt, StatementPartitioning partitioning) {
         super(parsedStmt, partitioning);
-
         assert(m_parsedStmt.m_tableList.size() == 1);
         m_targetTable = m_parsedStmt.m_tableList.get(0);
     }
@@ -69,7 +68,7 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
             // Analyze join conditions
             tableNode.analyzeJoinExpressions(m_parsedStmt);
             // these just shouldn't happen right?
-            assert(m_parsedStmt.m_noTableSelectionList.size() == 0);
+            assert m_parsedStmt.m_noTableSelectionList.isEmpty();
 
             m_generatedPlans = true;
             // This is either UPDATE or DELETE statement. Consolidate all expressions
@@ -77,17 +76,13 @@ public class WriterSubPlanAssembler extends SubPlanAssembler {
             tableNode.m_whereInnerList.addAll(tableNode.m_joinInnerList);
             tableNode.m_joinInnerList.clear();
             tableNode.m_accessPaths.addAll(getRelevantAccessPathsForTable(tableNode.getTableScan(),
-                    null,
-                    tableNode.m_whereInnerList,
-                    null));
+                    null, tableNode.m_whereInnerList, null));
 
             for (AccessPath path : tableNode.m_accessPaths) {
                 tableNode.m_currentAccessPath = path;
-
                 AbstractPlanNode plan = getAccessPlanForTable(tableNode);
                 m_plans.add(plan);
             }
-
         }
         return m_plans.poll();
     }

--- a/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
@@ -109,21 +109,21 @@ public class BranchNode extends JoinNode {
         // At this moment all RIGHT joins are already converted to the LEFT ones
         assert (getJoinType() != JoinType.RIGHT);
 
-        ArrayList<AbstractExpression> joinList = new ArrayList<>();
-        ArrayList<AbstractExpression> whereList = new ArrayList<>();
+        List<AbstractExpression> joinList = new ArrayList<>();
+        List<AbstractExpression> whereList = new ArrayList<>();
 
         // Collect node's own join and where expressions
         joinList.addAll(ExpressionUtil.uncombineAny(getJoinExpression()));
         whereList.addAll(ExpressionUtil.uncombineAny(getWhereExpression()));
 
         // Collect children expressions only if a child is a leaf. They are not classified yet
-        if ( ! (leftChild instanceof BranchNode)) {
+        if (! (leftChild instanceof BranchNode)) {
             joinList.addAll(leftChild.m_joinInnerList);
             leftChild.m_joinInnerList.clear();
             whereList.addAll(leftChild.m_whereInnerList);
             leftChild.m_whereInnerList.clear();
         }
-        if ( ! (rightChild instanceof BranchNode)) {
+        if (! (rightChild instanceof BranchNode)) {
             joinList.addAll(rightChild.m_joinInnerList);
             rightChild.m_joinInnerList.clear();
             whereList.addAll(rightChild.m_whereInnerList);
@@ -290,10 +290,10 @@ public class BranchNode extends JoinNode {
         // non-inner query. In general, they do not prevent results from being generated
         // on the partitions that don't have partition-key-qualified rows.
         if (m_joinType == JoinType.INNER) {
-            if ( ! m_joinInnerList.isEmpty()) {
+            if (! m_joinInnerList.isEmpty()) {
                 ExpressionUtil.collectPartitioningFilters(m_joinInnerList, equivalenceSet);
             }
-            if ( ! m_joinOuterList.isEmpty()) {
+            if (! m_joinOuterList.isEmpty()) {
                 ExpressionUtil.collectPartitioningFilters(m_joinOuterList, equivalenceSet);
             }
         }
@@ -343,8 +343,7 @@ public class BranchNode extends JoinNode {
      */
     @Override
     protected void extractSubTree(List<JoinNode> leafNodes) {
-        JoinNode[] children = {m_leftNode, m_rightNode};
-        for (JoinNode child : children) {
+        for (JoinNode child : new JoinNode[]{m_leftNode, m_rightNode}) {
 
             // Leaf nodes don't have a significant join type,
             // test for them first and never attempt to start a new tree at a leaf.
@@ -376,8 +375,7 @@ public class BranchNode extends JoinNode {
     @Override
     public boolean hasOuterJoin() {
         assert(m_leftNode != null && m_rightNode != null);
-        return m_joinType != JoinType.INNER ||
-                m_leftNode.hasOuterJoin() || m_rightNode.hasOuterJoin();
+        return m_joinType != JoinType.INNER || m_leftNode.hasOuterJoin() || m_rightNode.hasOuterJoin();
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
@@ -24,6 +24,7 @@ import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ConstantValueExpression;
 import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
+import org.voltdb.planner.AbstractParsedStmt;
 import org.voltdb.planner.AccessPath;
 import org.voltdb.planner.StmtEphemeralTableScan;
 import org.voltdb.types.ExpressionType;
@@ -50,6 +51,7 @@ public abstract class JoinNode implements Cloneable {
     public final List<AbstractExpression> m_whereOuterList = new ArrayList<>();
     public final List<AbstractExpression> m_whereInnerList = new ArrayList<>();
     public final List<AbstractExpression> m_whereInnerOuterList = new ArrayList<>();
+    protected Set<String> m_tableAliases = new HashSet<>();
 
     // All possible access paths for this node
     public List<AccessPath> m_accessPaths = new ArrayList<>();
@@ -314,7 +316,7 @@ public abstract class JoinNode implements Cloneable {
      * Reconstruct a join tree from the list of tables always appending the next node to the right.
      *
      * @param tableNodes the list of tables to build the tree from.
-     * @param JoinType the join type for all the joins
+     * @param joinType the join type for all the joins
      * @return The reconstructed tree
      */
     public static JoinNode reconstructJoinTreeFromTableNodes(List<JoinNode> tableNodes, JoinType joinType) {
@@ -368,9 +370,10 @@ public abstract class JoinNode implements Cloneable {
         return false;
     }
 
-    public void analyzeJoinExpressions(List<AbstractExpression> noneList) {
+    public void analyzeJoinExpressions(AbstractParsedStmt stmt) {
         m_joinInnerList.addAll(ExpressionUtil.uncombineAny(getJoinExpression()));
         m_whereInnerList.addAll(ExpressionUtil.uncombineAny(getWhereExpression()));
+        m_tableAliases = new HashSet<>(stmt.m_joinTree.generateTableJoinOrder());
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
@@ -370,10 +370,16 @@ public abstract class JoinNode implements Cloneable {
         return false;
     }
 
-    public void analyzeJoinExpressions(AbstractParsedStmt stmt) {
+    /**
+     * Analyze the m_joinTree structure to extract useful components.
+     * @param stmt parsed statement
+     * @return true if the Join expression is successfully analyzed, and can be added as a plan candidate.
+     */
+    public boolean analyzeJoinExpressions(AbstractParsedStmt stmt) {
         m_joinInnerList.addAll(ExpressionUtil.uncombineAny(getJoinExpression()));
         m_whereInnerList.addAll(ExpressionUtil.uncombineAny(getWhereExpression()));
         m_tableAliases = new HashSet<>(stmt.m_joinTree.generateTableJoinOrder());
+        return true;
     }
 
     /**
@@ -450,7 +456,7 @@ public abstract class JoinNode implements Cloneable {
      * @param innerList expressions with inner table only
      * @param innerOuterList with inner and outer tables
      */
-    protected static void classifyJoinExpressions(Collection<AbstractExpression> exprList,
+    protected static boolean classifyJoinExpressions(Collection<AbstractExpression> exprList,
             Collection<String> outerTables, Collection<String> innerTables,
             List<AbstractExpression> outerList, List<AbstractExpression> innerList,
             List<AbstractExpression> innerOuterList, List<AbstractExpression> noneList) {
@@ -467,8 +473,10 @@ public abstract class JoinNode implements Cloneable {
                 final boolean
                         outer = tableAliasSet.stream().anyMatch(outerSet::contains),
                         inner = tableAliasSet.stream().anyMatch(innerSet::contains);
-                assert outer || inner : "Outer and inner tables does not contain all the aliases used";
-                if (outer && inner) {
+                // assert outer || inner : "Outer and inner tables does not contain all the aliases used";
+                if (! outer && ! inner) {   // alias not found in either outer/inner table. This happens in multi-join query.
+                    return false;
+                } else if (outer && inner) {
                     innerOuterList.add(expr);
                 } else if (outer) {
                     outerList.add(expr);
@@ -477,6 +485,7 @@ public abstract class JoinNode implements Cloneable {
                 }
             }
         }
+        return true;
     }
 
     private static Set<String> getTablesForExpression(AbstractExpression expr) {

--- a/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
@@ -17,13 +17,8 @@
 
 package org.voltdb.planner.parseinfo;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ConstantValueExpression;
@@ -49,12 +44,12 @@ public abstract class JoinNode implements Cloneable {
     protected AbstractExpression m_whereExpr = null;
 
     // Buckets for children expression classification
-    public final ArrayList<AbstractExpression> m_joinOuterList = new ArrayList<>();
-    public final ArrayList<AbstractExpression> m_joinInnerList = new ArrayList<>();
-    public final ArrayList<AbstractExpression> m_joinInnerOuterList = new ArrayList<>();
-    public final ArrayList<AbstractExpression> m_whereOuterList = new ArrayList<>();
-    public final ArrayList<AbstractExpression> m_whereInnerList = new ArrayList<>();
-    public final ArrayList<AbstractExpression> m_whereInnerOuterList = new ArrayList<>();
+    public final List<AbstractExpression> m_joinOuterList = new ArrayList<>();
+    public final List<AbstractExpression> m_joinInnerList = new ArrayList<>();
+    public final List<AbstractExpression> m_joinInnerOuterList = new ArrayList<>();
+    public final List<AbstractExpression> m_whereOuterList = new ArrayList<>();
+    public final List<AbstractExpression> m_whereInnerList = new ArrayList<>();
+    public final List<AbstractExpression> m_whereInnerOuterList = new ArrayList<>();
 
     // All possible access paths for this node
     public List<AccessPath> m_accessPaths = new ArrayList<>();
@@ -110,8 +105,7 @@ public abstract class JoinNode implements Cloneable {
 
     /// For debug purposes:
     @Override
-    public String toString()
-    {
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         explain_recurse(sb, "");
         return sb.toString();
@@ -119,7 +113,7 @@ public abstract class JoinNode implements Cloneable {
 
     public void explain_recurse(StringBuilder sb, String indent) {
         // Node id. Must be unique within a given tree
-        sb.append(indent).append("JOIN NODE id: " + m_id).append("\n");
+        sb.append(indent).append("JOIN NODE id: ").append(m_id).append("\n");
         // Table
         sb.append(indent).append("table alias: ").append(getTableAlias()).append("\n");
         // Join expression associated with this node
@@ -161,34 +155,29 @@ public abstract class JoinNode implements Cloneable {
      * So ALL manner of where clause but ONLY inner-outer column=column JOIN clauses can
      * influence partitioning.
      */
-    public HashMap<AbstractExpression, Set<AbstractExpression> > getAllEquivalenceFilters()
-    {
-        HashMap<AbstractExpression, Set<AbstractExpression> > equivalenceSet =
-                new HashMap< >();
-        ArrayDeque<JoinNode> joinNodes = new ArrayDeque<>();
+    public Map<AbstractExpression, Set<AbstractExpression>> getAllEquivalenceFilters() {
+        Map<AbstractExpression, Set<AbstractExpression>> equivalenceSet = new HashMap<>();
+        Deque<JoinNode> joinNodes = new ArrayDeque<>();
         // Iterate over the join nodes to collect their join and where equivalence filter expressions
         joinNodes.add(this);
-        while ( ! joinNodes.isEmpty()) {
+        while (! joinNodes.isEmpty()) {
             JoinNode joinNode = joinNodes.poll();
             joinNode.collectEquivalenceFilters(equivalenceSet, joinNodes);
         }
         return equivalenceSet;
     }
 
-    protected void collectEquivalenceFilters(HashMap<AbstractExpression,
-                                                     Set<AbstractExpression>> equivalenceSet,
-                                             ArrayDeque<JoinNode> joinNodes) {
+    protected void collectEquivalenceFilters(Map<AbstractExpression,
+            Set<AbstractExpression>> equivalenceSet, Deque<JoinNode> joinNodes) {
         if ( ! m_whereInnerList.isEmpty()) {
-            ExpressionUtil.collectPartitioningFilters(m_whereInnerList,
-                                                      equivalenceSet);
+            ExpressionUtil.collectPartitioningFilters(m_whereInnerList, equivalenceSet);
         }
         // HSQL sometimes tags single-table filters in inner joins as join clauses
         // rather than where clauses? OR does analyzeJoinExpressions correct for this?
         // If so, these CAN contain constant equivalences that get used as the basis for equivalence
         // conditions that determine partitioning, so process them as where clauses.
         if ( ! m_joinInnerList.isEmpty()) {
-            ExpressionUtil.collectPartitioningFilters(m_joinInnerList,
-                                                      equivalenceSet);
+            ExpressionUtil.collectPartitioningFilters(m_joinInnerList, equivalenceSet);
         }
     }
 
@@ -196,9 +185,9 @@ public abstract class JoinNode implements Cloneable {
      * Collect all JOIN and WHERE expressions combined with AND for the entire tree.
      */
     public AbstractExpression getAllFilters() {
-        ArrayDeque<JoinNode> joinNodes = new ArrayDeque<>();
-        ArrayDeque<AbstractExpression> in = new ArrayDeque<>();
-        ArrayDeque<AbstractExpression> out = new ArrayDeque<>();
+        Deque<JoinNode> joinNodes = new ArrayDeque<>();
+        Deque<AbstractExpression> in = new ArrayDeque<>();
+        Deque<AbstractExpression> out = new ArrayDeque<>();
         // Iterate over the join nodes to collect their join and where expressions
         joinNodes.add(this);
         while (!joinNodes.isEmpty()) {
@@ -214,40 +203,40 @@ public abstract class JoinNode implements Cloneable {
 
         // this chunk of code breaks the code into a list of expression that
         // all have to be true for the where clause to be true
-        AbstractExpression inExpr = null;
+        AbstractExpression inExpr;
         while ((inExpr = in.poll()) != null) {
             if (inExpr.getExpressionType() == ExpressionType.CONJUNCTION_AND) {
                 in.add(inExpr.getLeft());
                 in.add(inExpr.getRight());
-            }
-            else {
+            } else {
                 out.add(inExpr);
             }
         }
         return ExpressionUtil.combinePredicates(ExpressionType.CONJUNCTION_AND, out);
     }
 
-    protected void queueChildren(ArrayDeque<JoinNode> joinNodes) { }
+    protected abstract void queueChildren(Deque<JoinNode> joinNodes);
 
     /**
      * Get the WHERE expression for a single-table statement.
      */
-    public AbstractExpression getSimpleFilterExpression()
-    {
+    public AbstractExpression getSimpleFilterExpression() {
         if (m_whereExpr != null) {
             if (m_joinExpr != null) {
                 return ExpressionUtil.combine(m_whereExpr, m_joinExpr);
+            } else {
+                return m_whereExpr;
             }
-            return m_whereExpr;
+        } else {
+            return m_joinExpr;
         }
-        return m_joinExpr;
     }
 
     /**
      * Returns tables in the order they are joined in the tree by iterating the tree depth-first
      */
     public List<JoinNode> generateLeafNodesJoinOrder() {
-        ArrayList<JoinNode> leafNodes = new ArrayList<>();
+        List<JoinNode> leafNodes = new ArrayList<>();
         listNodesJoinOrderRecursive(leafNodes, false);
         return leafNodes;
     }
@@ -256,18 +245,12 @@ public abstract class JoinNode implements Cloneable {
      * Returns tables in the order they are joined in the tree by iterating the tree depth-first
      */
     public Collection<String> generateTableJoinOrder() {
-        List<JoinNode> leafNodes = generateLeafNodesJoinOrder();
-        Collection<String> tables = new ArrayList<>();
-        for (JoinNode node : leafNodes) {
-            tables.add(node.getTableAlias());
-        }
-        return tables;
+        return generateLeafNodesJoinOrder().stream()
+                .map(JoinNode::getTableAlias)
+                .collect(Collectors.toList());
     }
 
-    @SuppressWarnings("static-method")
-    public String getTableAlias() {
-        return null;
-    }
+    public abstract String getTableAlias();
 
     /**
      * Returns nodes in the order they are joined in the tree by iterating the tree depth-first
@@ -278,7 +261,7 @@ public abstract class JoinNode implements Cloneable {
         return nodes;
     }
 
-    protected void listNodesJoinOrderRecursive(ArrayList<JoinNode> nodes, boolean appendBranchNodes) {
+    protected void listNodesJoinOrderRecursive(List<JoinNode> nodes, boolean appendBranchNodes) {
         nodes.add(this);
     }
 
@@ -286,7 +269,9 @@ public abstract class JoinNode implements Cloneable {
      * Returns true if one of the tree nodes has outer join
      */
     @SuppressWarnings("static-method")
-    public boolean hasOuterJoin() { return false; }
+    public boolean hasOuterJoin() {
+        return false;
+    }
 
     /**
      * Returns a list of immediate sub-queries which are part of this query.
@@ -349,7 +334,10 @@ public abstract class JoinNode implements Cloneable {
     }
 
     @SuppressWarnings("static-method")
-    protected JoinNode cloneWithoutFilters() { assert(false); return null; }
+    protected JoinNode cloneWithoutFilters() {
+        assert(false);
+        return null;
+    }
 
     /**
      * Reconstruct a join tree from the list of sub-trees connecting the sub-trees in the order
@@ -376,7 +364,7 @@ public abstract class JoinNode implements Cloneable {
 
     protected boolean replaceChild(JoinNode node) {
         // can't replace self
-        assert (Math.abs(m_id) != Math.abs(node.m_id));
+        assert Math.abs(m_id) != Math.abs(node.m_id);
         return false;
     }
 
@@ -394,22 +382,18 @@ public abstract class JoinNode implements Cloneable {
      * @param innerOuterTableExprs inner-outer tables expressions
      */
     protected static void applyTransitiveEquivalence(List<AbstractExpression> outerTableExprs,
-            List<AbstractExpression> innerTableExprs,
-            List<AbstractExpression> innerOuterTableExprs)
-    {
-        List<AbstractExpression> simplifiedOuterExprs = applyTransitiveEquivalence(innerTableExprs, innerOuterTableExprs);
-        List<AbstractExpression> simplifiedInnerExprs = applyTransitiveEquivalence(outerTableExprs, innerOuterTableExprs);
+            List<AbstractExpression> innerTableExprs, List<AbstractExpression> innerOuterTableExprs) {
+        final List<AbstractExpression>
+                simplifiedOuterExprs = applyTransitiveEquivalence(innerTableExprs, innerOuterTableExprs),
+                simplifiedInnerExprs = applyTransitiveEquivalence(outerTableExprs, innerOuterTableExprs);
         outerTableExprs.addAll(simplifiedOuterExprs);
         innerTableExprs.addAll(simplifiedInnerExprs);
     }
 
-    private static List<AbstractExpression>
-    applyTransitiveEquivalence(List<AbstractExpression> singleTableExprs,
-                               List<AbstractExpression> twoTableExprs)
-    {
-        ArrayList<AbstractExpression> simplifiedExprs = new ArrayList<>();
-        HashMap<AbstractExpression, Set<AbstractExpression> > eqMap1 =
-                new HashMap< >();
+    private static List<AbstractExpression> applyTransitiveEquivalence(
+            List<AbstractExpression> singleTableExprs, List<AbstractExpression> twoTableExprs) {
+        List<AbstractExpression> simplifiedExprs = new ArrayList<>();
+        Map<AbstractExpression, Set<AbstractExpression>> eqMap1 = new HashMap<>();
         ExpressionUtil.collectPartitioningFilters(singleTableExprs, eqMap1);
 
         for (AbstractExpression expr : twoTableExprs) {
@@ -458,7 +442,7 @@ public abstract class JoinNode implements Cloneable {
      * The inner tables are the tables reachable from the inner node of the join
      * @param exprList expression list to split
      * @param outerTables outer table
-     * @param innerTable outer table
+     * @param innerTables outer table
      * @param outerList expressions with outer table only
      * @param innerList expressions with inner table only
      * @param innerOuterList with inner and outer tables
@@ -466,45 +450,38 @@ public abstract class JoinNode implements Cloneable {
     protected static void classifyJoinExpressions(Collection<AbstractExpression> exprList,
             Collection<String> outerTables, Collection<String> innerTables,
             List<AbstractExpression> outerList, List<AbstractExpression> innerList,
-            List<AbstractExpression> innerOuterList, List<AbstractExpression> noneList)
-    {
-        HashSet<String> tableAliasSet = new HashSet<>();
-        HashSet<String> outerSet = new HashSet<>(outerTables);
-        HashSet<String> innerSet = new HashSet<>(innerTables);
+            List<AbstractExpression> innerOuterList, List<AbstractExpression> noneList) {
+        final String outerTableStr = String.join(", ", outerTables),
+                innerTableStr = String.join(", ", innerTables);
+        System.out.format("Outer tables: %s\nInner tables: %s\n= = = = = = = = = =\n", outerTableStr, innerTableStr);
+        final Set<String> outerSet = new HashSet<>(outerTables);
+        final Set<String> innerSet = new HashSet<>(innerTables);
         for (AbstractExpression expr : exprList) {
-            tableAliasSet.clear();
-            getTablesForExpression(expr, tableAliasSet);
-            String tableAliases[] = tableAliasSet.toArray(new String[0]);
+            final Set<String> tableAliasSet = getTablesForExpression(expr);
             if (tableAliasSet.isEmpty()) {
                 noneList.add(expr);
             } else {
-                boolean outer = false;
-                boolean inner = false;
-                for (String alias : tableAliases) {
-                    outer = outer || outerSet.contains(alias);
-                    inner = inner || innerSet.contains(alias);
-                }
+                final boolean
+                        outer = tableAliasSet.stream().anyMatch(outerSet::contains),
+                        inner = tableAliasSet.stream().anyMatch(innerSet::contains);
+                assert outer || inner : "Outer and inner tables does not contain all the aliases used";
                 if (outer && inner) {
                     innerOuterList.add(expr);
                 } else if (outer) {
                     outerList.add(expr);
-                } else if (inner) {
-                    innerList.add(expr);
                 } else {
-                    // can not be, right?
-                    assert(false);
+                    innerList.add(expr);
                 }
             }
         }
     }
 
-    private static void getTablesForExpression(AbstractExpression expr, HashSet<String> tableAliasSet)
-    {
-        List<TupleValueExpression> tves = ExpressionUtil.getTupleValueExpressions(expr);
-        for (TupleValueExpression tupleExpr : tves) {
-            String tableAlias = tupleExpr.getTableAlias();
-            tableAliasSet.add(tableAlias);
-        }
+    private static Set<String> getTablesForExpression(AbstractExpression expr) {
+        return ExpressionUtil
+                .getTupleValueExpressions(expr)
+                .stream()
+                .map(TupleValueExpression::getTableAlias)
+                .collect(Collectors.toSet());
     }
 
     @SuppressWarnings("static-method")

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -17,11 +17,7 @@
 
 package org.voltdb.planner.parseinfo;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.voltdb.catalog.Index;
 import org.voltdb.exceptions.PlanningErrorException;
@@ -93,7 +89,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
      * @param eqSets
      */
     public void promoteSinglePartitionInfo(
-            HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
+            Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
             Set< Set<AbstractExpression> > eqSets) {
         if (getScanPartitioning() == null) {
             throw new PlanningErrorException("Unsupported statement, subquery expressions are only supported for " +
@@ -138,7 +134,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
     // (Xin): If it changes valueEquivalence, we have to update eqSets
     // Because HashSet stored a legacy hashcode for the non-final object.
     private void updateEqualSets(Set<AbstractExpression> values,
-            HashMap<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
+            Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
             Set< Set<AbstractExpression> > eqSets,
             AbstractExpression tveKey, AbstractExpression spExpr) {
         boolean hasLegacyValues = false;

--- a/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
@@ -17,6 +17,7 @@
 
 package org.voltdb.planner.parseinfo;
 
+import java.util.Deque;
 import java.util.List;
 
 import org.voltdb.expressions.AbstractExpression;
@@ -84,4 +85,7 @@ public class SubqueryLeafNode extends JoinNode {
         return true;
     }
 
+    @Override
+    protected void queueChildren(Deque<JoinNode> joinNodes) {
+    }
 }

--- a/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
@@ -17,6 +17,7 @@
 
 package org.voltdb.planner.parseinfo;
 
+import java.util.Deque;
 import java.util.List;
 
 import org.voltdb.expressions.AbstractExpression;
@@ -49,24 +50,25 @@ public class TableLeafNode extends JoinNode {
      */
     @Override
     public Object clone() {
-        AbstractExpression joinExpr = (m_joinExpr != null) ?
-                (AbstractExpression) m_joinExpr.clone() : null;
-        AbstractExpression whereExpr = (m_whereExpr != null) ?
-                (AbstractExpression) m_whereExpr.clone() : null;
-        JoinNode newNode = new TableLeafNode(m_id, joinExpr, whereExpr, m_tableScan);
-        return newNode;
+        final AbstractExpression joinExpr = (m_joinExpr != null) ? m_joinExpr.clone() : null;
+        final AbstractExpression whereExpr = (m_whereExpr != null) ? m_whereExpr.clone() : null;
+        return new TableLeafNode(m_id, joinExpr, whereExpr, m_tableScan);
     }
 
     @Override
     public JoinNode cloneWithoutFilters() {
-        JoinNode newNode = new TableLeafNode(m_id, null, null, m_tableScan);
-        return newNode;
+        return new TableLeafNode(m_id, null, null, m_tableScan);
     }
 
     @Override
-    public StmtTableScan getTableScan() { return m_tableScan; }
+    public StmtTableScan getTableScan() {
+        return m_tableScan;
+    }
 
-    @Override public String getTableAlias() { return m_tableScan.getTableAlias(); }
+    @Override
+    public String getTableAlias() {
+        return m_tableScan.getTableAlias();
+    }
 
     @Override
     public boolean hasSubqueryScans() {
@@ -76,4 +78,8 @@ public class TableLeafNode extends JoinNode {
 
     @Override
     public void extractEphemeralTableQueries(List<StmtEphemeralTableScan> scans) { }
+
+    @Override
+    protected void queueChildren(Deque<JoinNode> joinNodes) {
+    }
 }

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -113,8 +113,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     /**
      * @param predicate the where predicate to set
      */
-    public void setWherePredicate(AbstractExpression predicate)
-    {
+    public void setWherePredicate(AbstractExpression predicate) {
         if (predicate != null) {
             m_wherePredicate = predicate.clone();
         } else {
@@ -125,8 +124,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     /**
      * @param predicate the join predicate to set
      */
-    public void setPreJoinPredicate(AbstractExpression predicate)
-    {
+    public void setPreJoinPredicate(AbstractExpression predicate) {
         if (predicate != null) {
             m_preJoinPredicate = predicate.clone();
         } else {
@@ -137,8 +135,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     /**
      * @param predicate the join predicate to set
      */
-    public void setJoinPredicate(AbstractExpression predicate)
-    {
+    public void setJoinPredicate(AbstractExpression predicate) {
         if (predicate != null) {
             m_joinPredicate = predicate.clone();
         } else {
@@ -147,8 +144,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         // FUTURE: At some point it would be awesome to further
         // cull the columns out of the join to remove columns that were only
         // used by scans/joins.  I think we can coerce HSQL into provide this
@@ -168,11 +164,9 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
         }
 
         // Join the schema together to form the output schema
-        m_outputSchemaPreInlineAgg =
-            m_children.get(0).getOutputSchema().
-            join(m_children.get(1).getOutputSchema()).copyAndReplaceWithTVE();
+        m_outputSchemaPreInlineAgg = m_children.get(0).getOutputSchema().
+                join(m_children.get(1).getOutputSchema()).copyAndReplaceWithTVE();
         m_hasSignificantOutputSchema = true;
-
         generateRealOutputSchema(db);
     }
 
@@ -185,11 +179,10 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     }
 
     protected void generateRealOutputSchema(Database db) {
-        AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(this);
+        final AggregatePlanNode aggNode = AggregatePlanNode.getInlineAggregationNode(this);
         if (aggNode != null) {
             // generate its subquery output schema
             aggNode.generateOutputSchema(db);
-
             m_outputSchema = aggNode.getOutputSchema().copyAndReplaceWithTVE();
         } else {
             m_outputSchema = m_outputSchemaPreInlineAgg;
@@ -199,12 +192,10 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     // Given any non-inlined type of join, this method will resolve the column
     // order and TVE indexes for the output SchemaColumns.
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         // First, assert that our topology is sane and then
         // recursively resolve all child/inline column indexes
-        IndexScanPlanNode index_scan =
-            (IndexScanPlanNode) getInlinePlanNode(PlanNodeType.INDEXSCAN);
+        IndexScanPlanNode index_scan = (IndexScanPlanNode) getInlinePlanNode(PlanNodeType.INDEXSCAN);
         assert(m_children.size() == 2 && index_scan == null);
         for (AbstractPlanNode child : m_children) {
             child.resolveColumnIndexes();
@@ -213,7 +204,6 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
         final NodeSchema outer_schema = m_children.get(0).getOutputSchema();
         final NodeSchema inner_schema = m_children.get(1).getOutputSchema();
         final int outerSize = outer_schema.size();
-        final int innerSize = inner_schema.size();
 
         // resolve predicates
         resolvePredicate(m_preJoinPredicate, outer_schema, inner_schema);
@@ -233,15 +223,13 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
             int index;
             if (i < outerSize) {
                 index = tve.setColumnIndexUsingSchema(outer_schema);
-            }
-            else {
+            } else {
                 index = tve.setColumnIndexUsingSchema(inner_schema);
                 index += outerSize;
             }
 
             if (index == -1) {
-                throw new RuntimeException("Unable to find index for column: " +
-                                               col.toString());
+                throw new RuntimeException("Unable to find index for column: " + col.toString());
             }
 
             tve.setColumnIndex(index);
@@ -279,12 +267,12 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
         AbstractPlanNode aggrNode = AggregatePlanNode.getInlineAggregationNode(this);
         if (aggrNode != null && aggrNode.getPlanNodeType() == PlanNodeType.HASHAGGREGATE) {
             return false;
-        }
-        // Not yet handling ORDER BY expressions based on more than just the left-most table
-        if (outerTable.getPlanNodeType() == PlanNodeType.INDEXSCAN || outerTable instanceof AbstractJoinPlanNode) {
+        } else if (outerTable.getPlanNodeType() == PlanNodeType.INDEXSCAN || outerTable instanceof AbstractJoinPlanNode) {
+            // Not yet handling ORDER BY expressions based on more than just the left-most table
             return outerTable.isOutputOrdered(sortExpressions, sortDirections);
+        } else {
+            return false;
         }
-        return false;
     }
 
     // TODO: need to extend the sort direction for join from one table to the other table if possible
@@ -324,20 +312,17 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     }
 
     @Override
-    public void loadFromJSONObject(JSONObject jobj, Database db)
-            throws JSONException {
+    public void loadFromJSONObject(JSONObject jobj, Database db) throws JSONException {
         helpLoadFromJSONObject(jobj, db);
         m_joinType = JoinType.get( jobj.getString( Members.JOIN_TYPE.name() ) );
         m_preJoinPredicate = AbstractExpression.fromJSONChild(jobj, Members.PRE_JOIN_PREDICATE.name());
         m_joinPredicate = AbstractExpression.fromJSONChild(jobj, Members.JOIN_PREDICATE.name());
         m_wherePredicate = AbstractExpression.fromJSONChild(jobj, Members.WHERE_PREDICATE.name());
 
-        if ( !jobj.isNull( Members.OUTPUT_SCHEMA_PRE_AGG.name() ) ) {
+        if (! jobj.isNull( Members.OUTPUT_SCHEMA_PRE_AGG.name())) {
             m_hasSignificantOutputSchema = true;
-            m_outputSchemaPreInlineAgg = loadSchemaFromJSONObject(jobj,
-                    Members.OUTPUT_SCHEMA_PRE_AGG.name());
-        }
-        else {
+            m_outputSchemaPreInlineAgg = loadSchemaFromJSONObject(jobj, Members.OUTPUT_SCHEMA_PRE_AGG.name());
+        } else {
             m_outputSchemaPreInlineAgg = m_outputSchema;
         }
     }
@@ -351,16 +336,13 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
      */
     protected static void resolvePredicate(AbstractExpression expression,
             NodeSchema outer_schema, NodeSchema inner_schema) {
-        List<TupleValueExpression> predicate_tves =
-                ExpressionUtil.getTupleValueExpressions(expression);
-        for (TupleValueExpression tve : predicate_tves) {
+        for (TupleValueExpression tve : ExpressionUtil.getTupleValueExpressions(expression)) {
             int index = tve.setColumnIndexUsingSchema(outer_schema);
             int tableIdx = 0;   // 0 for outer table
             if (index == -1) {
                 index = tve.setColumnIndexUsingSchema(inner_schema);
                 if (index == -1) {
-                    throw new RuntimeException(
-                            "Unable to resolve column index for join TVE: " + tve.toString());
+                    throw new RuntimeException("Unable to resolve column index for join TVE: " + tve.toString());
                 }
                 tableIdx = 1;   // 1 for inner table
             }
@@ -376,16 +358,16 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     }
 
     protected String explainFilters(String indent) {
-        String result = "";
+        StringBuilder result = new StringBuilder();
         String prefix = "\n" + indent + " filter by ";
         AbstractExpression[] predicates = { m_preJoinPredicate, m_joinPredicate, m_wherePredicate };
         for (AbstractExpression pred : predicates) {
             if (pred != null) {
-                result += prefix + pred.explain("!?"); // No default table name prefix for columns.
+                result.append(prefix).append(pred.explain("!?")); // No default table name prefix for columns.
                 prefix = " AND ";
             }
         }
-        return result;
+        return result.toString();
     }
 
     @Override
@@ -416,13 +398,13 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
         // 0.888... (=8/9) for many EQUALITY filters.
         // The discount value is less than the partial index discount (0.1) to make sure
         // the index wins
-        AbstractExpression predicate = null;
+        final AbstractExpression predicate;
         if (childNode instanceof AbstractScanPlanNode) {
             predicate = ((AbstractScanPlanNode) childNode).getPredicate();
         } else if (childNode instanceof NestLoopPlanNode) {
             predicate = ((NestLoopPlanNode) childNode).getWherePredicate();
         } else if (childNode instanceof NestLoopIndexPlanNode) {
-            AbstractPlanNode inlineIndexScan = ((NestLoopIndexPlanNode) childNode).getInlinePlanNode(PlanNodeType.INDEXSCAN);
+            AbstractPlanNode inlineIndexScan = childNode.getInlinePlanNode(PlanNodeType.INDEXSCAN);
             assert(inlineIndexScan != null);
             predicate = ((AbstractScanPlanNode) inlineIndexScan).getPredicate();
         } else {

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -360,8 +360,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
                 index = tve.setColumnIndexUsingSchema(inner_schema);
                 if (index == -1) {
                     throw new RuntimeException(
-                            "Unable to resolve column index for join TVE: " +
-                            tve.toString());
+                            "Unable to resolve column index for join TVE: " + tve.toString());
                 }
                 tableIdx = 1;   // 1 for inner table
             }

--- a/tests/frontend/org/voltdb/planner/TestParsedStatements.java
+++ b/tests/frontend/org/voltdb/planner/TestParsedStatements.java
@@ -87,7 +87,7 @@ public class TestParsedStatements extends TestCase {
         // analyze expressions
         // except for "insert" statements that currently do without a joinTree.
         if (parsedStmt.m_joinTree != null) {
-            parsedStmt.m_joinTree.analyzeJoinExpressions(parsedStmt.m_noTableSelectionList);
+            parsedStmt.m_joinTree.analyzeJoinExpressions(parsedStmt);
         }
         // output a description of the parsed stmt
         BuildDirectoryUtils.writeFile("statement-hsql-parsed", stmtName + ".txt", parsedStmt.toString(), true);


### PR DESCRIPTION
Fortify support for planning multi-table join query.
In a SELECT query that has table joins, our (legacy) planner would enumerate different join orders and filters, and find a best join order as plan. 
However, when mutating join order (and filter), it is likely that the join condition could refer to some other table not seen yet; or the same thing could happen to filter. We did not consider such case, and it results in table not found when resolving TVE expression.
The fix is to add eager validation check in those two phases, and abort current join order (and continue with next candidate), since apparently it is not a valid permutation.

As usual, there are lots of code refactories/clean ups on related code path that were necessary (not really; but it always helps) to understand what goes on. The key changes are in the last 3 commits.