### PR TITLE
ENG-18289: Wait for tuples to be in stats

### DIFF
--- a/tests/frontend/org/voltdb/export/TestExportSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportSuite.java
@@ -202,7 +202,7 @@ public class TestExportSuite extends TestExportBaseSocketExport {
         }
         // Make sure some are exported and seen by me
         assertTrue((m_verifier.getExportedDataCount() - icnt > 0));
-        quiesceAndVerifyTarget(client, m_streamNames, m_verifier);
+        quiesceAndVerifyTarget(client, m_streamNames, m_verifier, DEFAULT_DELAY_MS, true);
     }
 
     //


### PR DESCRIPTION
With E3 stats are reported with 0 tuples during initialized eventhough there
are some tuples in the stream. Wait for some tuples to show up before waiting
for the backlog to be 0.