### PR TITLE
ENG-18358 The duplicate counters for run-everywhere MP system procedures could be cleaned

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -530,7 +530,7 @@ public class MpScheduler extends Scheduler
                 final Set<Integer> liveHosts = VoltDB.instance().getHostMessenger().getLiveHostIds();
 
                 // Message is from a dead host
-                if (!liveHosts.contains(CoreUtils.hsIdToString(message.m_sourceHSId))) {
+                if (!liveHosts.contains(CoreUtils.getHostIdFromHSId(message.m_sourceHSId))) {
                     return;
                 }
 

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -523,7 +523,21 @@ public class MpScheduler extends Scheduler
         } else {
             advanceRepairTruncationHandle(message);
             MpTransactionState txn = (MpTransactionState)m_outstandingTxns.remove(message.getTxnId());
-            assert(txn != null);
+            if (txn == null) {
+                // The thread (updateReplicas) could wipe out duplicate counters for run-everywhere system procedures
+                // if the duplicate counters contain only the partition masters from failed hosts.
+                // If a response from a failed partition master get here after the transaction has been declared completed, ignore it.
+                final Set<Integer> liveHosts = VoltDB.instance().getHostMessenger().getLiveHostIds();
+
+                // Message is from a dead host
+                if (!liveHosts.contains(CoreUtils.hsIdToString(message.m_sourceHSId))) {
+                    return;
+                }
+
+                // This should not happen
+                tmLog.warn("Received InitiateResponseMessage after the transaction is completed from " + CoreUtils.hsIdToString(message.m_sourceHSId));
+                assert(false);
+            }
             // the initiatorHSId is the ClientInterface mailbox. Yeah. I know.
             m_mailbox.send(message.getInitiatorHSId(), message);
             // We actually completed this MP transaction.  Create a fake CompleteTransactionMessage

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -528,15 +528,13 @@ public class MpScheduler extends Scheduler
                 // if the duplicate counters contain only the partition masters from failed hosts.
                 // If a response from a failed partition master get here after the transaction has been declared completed, ignore it.
                 final Set<Integer> liveHosts = VoltDB.instance().getHostMessenger().getLiveHostIds();
-
-                // Message is from a dead host
-                if (!liveHosts.contains(CoreUtils.getHostIdFromHSId(message.m_sourceHSId))) {
-                    return;
+                if (liveHosts.contains(CoreUtils.getHostIdFromHSId(message.m_sourceHSId))) {
+                    // This should not happen
+                    tmLog.warn("Received InitiateResponseMessage after the transaction is completed from " + CoreUtils.hsIdToString(message.m_sourceHSId));
+                    assert(false);
                 }
-
-                // This should not happen
-                tmLog.warn("Received InitiateResponseMessage after the transaction is completed from " + CoreUtils.hsIdToString(message.m_sourceHSId));
-                assert(false);
+                // Message is from a dead host
+                return;
             }
             // the initiatorHSId is the ClientInterface mailbox. Yeah. I know.
             m_mailbox.send(message.getInitiatorHSId(), message);


### PR DESCRIPTION
… on the repair path if the duplicate counters contain only the partition masters from failed hosts. The transaction is then declared completed. Ignore responses from failed partition masters after the transaction has been  completed.