### PR TITLE
ENG-18410 duplicate counter collision fix 

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -783,7 +783,13 @@ public class SpScheduler extends Scheduler implements SnapshotCompletionInterest
         } else {
             // The partition leader on the local site is being migrated away, but the migration fails. The local site
             // can be elected again as leader. In this case, update the duplicate counter.
-            theCounter.updateReplicas(counter.m_expectedHSIds);
+
+            // If local site is already in the duplicate counter, retain it.
+            List<Long> expectedHSIDs = new ArrayList<Long>(counter.m_expectedHSIds);
+            if (!expectedHSIDs.contains(m_mailbox.getHSId())) {
+                expectedHSIDs.add(m_mailbox.getHSId());
+            }
+            theCounter.updateReplicas(expectedHSIDs);
         }
     }
 


### PR DESCRIPTION
When a partition leader is migrated away and the target host fails,  the original partition leader site can be elected as leader again. A duplicate counter for a particular transaction is created on the original partition leader. Prior to the partition leader promotion,  repair process will be triggered. A new duplicate counter will be created during the repair. If  the original duplicate count is not cleaned before the repair kicks in, the new duplicate counter will collide with the existing duplicate counter.