### PR TITLE
ENG-17844 & ENG-16349: More junit fixes/improvements

### DIFF
--- a/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
+++ b/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
@@ -152,7 +152,7 @@ public class TestExportConstraintsSuite extends TestExportBaseSocketExport {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
@@ -522,7 +522,7 @@ public class TestExportLiveDDLSuite extends TestExportBaseSocketExport {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
@@ -498,7 +498,7 @@ public class TestExportLiveDDLSuiteLegacy extends TestExportBaseSocketExport {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestExportRejoinWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRejoinWithView.java
@@ -198,7 +198,7 @@ public class TestExportRejoinWithView extends TestExportBase {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
@@ -26,11 +26,9 @@ package org.voltdb;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,8 +41,8 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.compiler.deploymentfile.ServerExportEnum;
 import org.voltdb.export.ExportDataProcessor;
 import org.voltdb.export.ExportLocalClusterBase;
-import org.voltdb.export.TestExportBase;
 import org.voltdb.export.SocketExportTestServer;
+import org.voltdb.export.TestExportBase;
 import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 
@@ -221,7 +219,7 @@ public class TestExportSuiteReplicatedSocketExport extends TestExportBase {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
         return builder;
     }
 }

--- a/tests/frontend/org/voltdb/TestExportView.java
+++ b/tests/frontend/org/voltdb/TestExportView.java
@@ -177,7 +177,7 @@ public class TestExportView extends TestExportBase {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
         return builder;
     }
 }

--- a/tests/frontend/org/voltdb/TestImportStatistics.java
+++ b/tests/frontend/org/voltdb/TestImportStatistics.java
@@ -567,7 +567,7 @@ public class TestImportStatistics extends RegressionSuite {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestImportSuite.java
+++ b/tests/frontend/org/voltdb/TestImportSuite.java
@@ -581,7 +581,7 @@ public class TestImportSuite extends RegressionSuite {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/TestSnapshotWithViews.java
+++ b/tests/frontend/org/voltdb/TestSnapshotWithViews.java
@@ -335,7 +335,7 @@ public class TestSnapshotWithViews extends TestExportBase {
         config.setMaxHeap(1024);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
 
         compile = config.compile(project);

--- a/tests/frontend/org/voltdb/export/TestExportStatsSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportStatsSuite.java
@@ -344,7 +344,7 @@ public class TestExportStatsSuite extends TestExportBaseSocketExport {
         config.setHasLocalServer(false);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
         MiscUtils.copyFile(project.getPathToDeployment(), Configuration.getPathToCatalogForTest("stats_full.xml"));
 
 

--- a/tests/frontend/org/voltdb/export/TestExportSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportSuite.java
@@ -306,7 +306,7 @@ public class TestExportSuite extends TestExportBaseSocketExport {
         MiscUtils.copyFile(project.getPathToDeployment(),
                 Configuration.getPathToCatalogForTest("export-ddl-sans-nonulls-and-allownulls.xml"));
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
 
         /*

--- a/tests/frontend/org/voltdb/export/TestExportV2SuitePro.java
+++ b/tests/frontend/org/voltdb/export/TestExportV2SuitePro.java
@@ -135,7 +135,7 @@ public class TestExportV2SuitePro extends TestExportBaseSocketExport {
         config.setMaxHeap(1024);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         /*
          * compile a catalog with an added table for add tests

--- a/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
+++ b/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
@@ -28,13 +28,13 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google_voltpatches.common.base.Predicate;
-import com.google_voltpatches.common.base.Predicates;
-
 import org.junit.Test;
-import org.voltdb.FlakyTestStandardRunner;
 import org.voltdb.FlakyTestRule.Flaky;
 import org.voltdb.FlakyTestRule.FlakyTestRunner;
+import org.voltdb.FlakyTestStandardRunner;
+
+import com.google_voltpatches.common.base.Predicate;
+import com.google_voltpatches.common.base.Predicates;
 
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -188,16 +188,16 @@ public class MultiConfigSuiteBuilder extends TestSuite {
         if (DEBUG) {
             System.out.println("DEBUG: Entering MultiConfigSuiteBuilder.addServerConfig (1): "+config);
         }
-        return addServerConfig(config, true);
+        return addServerConfig(config, ReuseServer.DEFAULT);
     }
 
-    public boolean addServerConfig(VoltServerConfig config, boolean reuseServer) {
+    public boolean addServerConfig(VoltServerConfig config, ReuseServer reuseServer) {
         if (DEBUG) {
             System.out.println("DEBUG: Entering MultiConfigSuiteBuilder.addServerConfig (2): "+config+", "+reuseServer);
         }
 
-        if (config.isValgrind()) {
-            reuseServer = false;
+        if (reuseServer == ReuseServer.DEFAULT && config.isValgrind()) {
+            reuseServer = ReuseServer.NEVER;
         }
 
         final String enabled_configs = System.getenv().get("VOLT_REGRESSIONS");
@@ -266,7 +266,7 @@ public class MultiConfigSuiteBuilder extends TestSuite {
             rs.setConfig(config);
             // The last test method for the current cluster configuration will need to
             // shutdown the cluster completely after finishing the test.
-            rs.m_completeShutdown = ! reuseServer || (i == methods.size() - 1);
+            rs.m_completeShutdown = reuseServer == ReuseServer.NEVER || (i == methods.size() - 1);
 
             if (DEBUG) {
                 if (i < 3 || i > 145) {
@@ -294,5 +294,9 @@ public class MultiConfigSuiteBuilder extends TestSuite {
     public void addTestSuite(Class<? extends TestCase> testClass) {
         // don't let users do this
         throw new RuntimeException("Unsupported Usage");
+    }
+
+    public enum ReuseServer {
+        ALWAYS, NEVER, DEFAULT;
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/StatisticsTestSuiteBase.java
+++ b/tests/frontend/org/voltdb/regressionsuites/StatisticsTestSuiteBase.java
@@ -192,10 +192,11 @@ public class StatisticsTestSuiteBase extends SaveRestoreBase {
     // JUnit magic that uses the regression suite helper classes.
     //
     static public Test suite(Class classzz, boolean isCommandLogTest, int replicationPort) throws IOException {
-        return suite(classzz, isCommandLogTest, replicationPort, true);
+        return suite(classzz, isCommandLogTest, replicationPort, MultiConfigSuiteBuilder.ReuseServer.DEFAULT);
     }
 
-    static public Test suite(Class classzz, boolean isCommandLogTest, int replicationPort, boolean reuseServer) throws IOException {
+    static public Test suite(Class classzz, boolean isCommandLogTest, int replicationPort,
+            MultiConfigSuiteBuilder.ReuseServer reuseServer) throws IOException {
         VoltServerConfig config = null;
 
         MultiConfigSuiteBuilder builder

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdminMode.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdminMode.java
@@ -361,7 +361,7 @@ public class TestAdminMode extends RegressionSuite
         assertTrue(success);
 
         // add this config to the set of tests to run
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
@@ -1088,7 +1088,7 @@ public class TestCatalogUpdateSuite extends RegressionSuite {
         MiscUtils.copyFile(project.getPathToDeployment(), Configuration.getPathToCatalogForTest("catalogupdate-cluster-base.xml"));
 
         // add this config to the set of tests to run
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         /////////////////////////////////////////////////////////////
         // DELTA CATALOGS FOR TESTING

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
@@ -113,7 +113,7 @@ public class TestExportRowLengthLimit extends RegressionSuite {
         config.setExpectedToCrash(true);
         boolean compile = config.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.junit.Test;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTableRow;
@@ -52,8 +53,6 @@ import org.voltdb_testprocs.regressionsuites.matviewprocs.TruncateMatViewDataMP;
 import org.voltdb_testprocs.regressionsuites.matviewprocs.TruncatePeople;
 import org.voltdb_testprocs.regressionsuites.matviewprocs.TruncateTables;
 import org.voltdb_testprocs.regressionsuites.matviewprocs.UpdatePerson;
-
-import org.junit.Test;
 
 import com.google_voltpatches.common.collect.Lists;
 
@@ -2599,8 +2598,9 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         //* enable for simplified config */ config = new LocalCluster("matview-onesite.jar", 1, 1, 0, BackendTarget.NATIVE_EE_JNI);
         // build the jarfile
         assertTrue(config.compile(project));
-        // add this config to the set of tests to run
-        builder.addServerConfig(config);
+        // add this config to the set of tests to run forcing it to always reuse the server. This makes memcheck
+        // failures harder to diagnose so if they do occur rerun the test without reuseServer set
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.ALWAYS);
 
         /////////////////////////////////////////////////////////////
         // CONFIG #2: 1 Local Site/Partition running on HSQL backend
@@ -2614,7 +2614,7 @@ public class TestMaterializedViewSuite extends RegressionSuite {
         /////////////////////////////////////////////////////////////
         config = new LocalCluster("matview-cluster.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
         assertTrue(config.compile(project));
-        builder.addServerConfig(config);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.ALWAYS);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestRestoreEmptyDatabaseSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRestoreEmptyDatabaseSuite.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 import org.voltdb.BackendTarget;
-import org.voltdb.TheHashinator;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
 import org.voltdb.client.ProcCallException;
@@ -328,7 +327,7 @@ public class TestRestoreEmptyDatabaseSuite extends SaveRestoreBase {
         m_nonEmptyConfig.setNewCli(false);
         boolean compile = m_nonEmptyConfig.compile(project);
         assertTrue(compile);
-        builder.addServerConfig(m_nonEmptyConfig, false);
+        builder.addServerConfig(m_nonEmptyConfig, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
 
         m_emptyConfig = new LocalCluster("empty-database.jar", 4, 3, 0, BackendTarget.NATIVE_EE_JNI);

--- a/tests/frontend/org/voltdb/regressionsuites/TestRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRestoreSysprocSuite.java
@@ -26,7 +26,6 @@ package org.voltdb.regressionsuites;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.junit.Test;
-import org.voltdb.VoltProcedure.VoltAbortException;
 import org.voltdb.BackendTarget;
 import org.voltdb.VoltTable;
 import org.voltdb.client.Client;
@@ -332,7 +331,7 @@ public class TestRestoreSysprocSuite extends SaveRestoreBase{
                                                  BackendTarget.NATIVE_EE_JNI);
         boolean success = config.compile(project);
         assert(success);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -3992,7 +3992,7 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
                                                  BackendTarget.NATIVE_EE_JNI);
         boolean success = config.compile(project);
         assert(success);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSecuritySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSecuritySuite.java
@@ -461,7 +461,7 @@ public class TestSecuritySuite extends RegressionSuite {
         if (!config.compile(project)) fail();
 
         // add this config to the set of tests to run
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         // Not testing a cluster and assuming security shouldn't be affected by this
 

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
@@ -121,7 +121,7 @@ public class TestSnapshotStatus extends SaveRestoreBase {
         LocalCluster lcconfig = new LocalCluster("testsnapshotstatus.jar", 2, 2, 1,
                                                BackendTarget.NATIVE_EE_JNI);
         assertTrue(lcconfig.compile(project));
-        builder.addServerConfig(lcconfig, false);
+        builder.addServerConfig(lcconfig, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/TestStopNode.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStopNode.java
@@ -426,7 +426,7 @@ public class TestStopNode extends RegressionSuite
         assertTrue(success);
 
         // add this config to the set of tests to run
-        builder.addServerConfig(m_config, false);
+        builder.addServerConfig(m_config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
         return builder;
     }
 }

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
@@ -492,7 +492,7 @@ public class TestUpdateDeployment extends RegressionSuite {
         MiscUtils.copyFile(project.getPathToDeployment(), Configuration.getPathToCatalogForTest("catalogupdate-cluster-base.xml"));
 
         // add this config to the set of tests to run
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         /////////////////////////////////////////////////////////////
         // DELTA CATALOGS FOR TESTING

--- a/tests/frontend/org/voltdb/regressionsuites/TestViewsInPartialSnapshotRestore.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestViewsInPartialSnapshotRestore.java
@@ -322,7 +322,7 @@ public class TestViewsInPartialSnapshotRestore extends SaveRestoreBase{
                                                  BackendTarget.NATIVE_EE_JNI);
         boolean success = config.compile(project);
         assert(success);
-        builder.addServerConfig(config, false);
+        builder.addServerConfig(config, MultiConfigSuiteBuilder.ReuseServer.NEVER);
 
         return builder;
     }

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -39,8 +39,8 @@ import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.deploymentfile.DrRoleType;
-import org.voltdb.dr2.DRProtocol;
 import org.voltdb.regressionsuites.LocalCluster;
+import org.voltdb.regressionsuites.MultiConfigSuiteBuilder;
 import org.voltdb.regressionsuites.StatisticsTestSuiteBase;
 
 import junit.framework.Test;
@@ -282,7 +282,8 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
     // JUnit magic that uses the regression suite helper classes.
     //
     static public Test suite() throws IOException {
-        return StatisticsTestSuiteBase.suite(TestStatisticsSuiteDRStats.class, false, REPLICATION_PORT, false);
+        return StatisticsTestSuiteBase.suite(TestStatisticsSuiteDRStats.class, false, REPLICATION_PORT,
+                MultiConfigSuiteBuilder.ReuseServer.NEVER);
     }
 
     private Client createClient(ClientConfig config, LocalCluster cluster) throws IOException {


### PR DESCRIPTION
 ENG-17844: Files.deleteIfExists() throws an exception with the reason why the delete failed which can be good for information reasons. Also, if delete fails because directory is not empty retry the delete and if it continues to fail throw an exception with the contents of the directory.

ENG-16349: When the server is restarted between tests of TestMaterializedViewSuite the memcheck runs take over 30 minutes to run and cause a timeout. Force the server to never restart between runs.