### PR TITLE
Eng 13840 debug build failed assertion for select subquery2

### DIFF
--- a/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
+++ b/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
@@ -74,10 +74,10 @@ public class AdHocPlannedStatement {
         assert(core.aggregatorFragment != null);
 
         // dml => !readonly
-        assert((core.isReplicatedTableDML == false) || (core.readOnly == false));
+        assert(!core.isReplicatedTableDML || !core.readOnly);
 
         // repdml => 2partplan
-        assert((core.isReplicatedTableDML == false) || (core.collectorFragment != null));
+        assert(!core.isReplicatedTableDML || (core.collectorFragment != null));
 
         // zero param types => null extracted params
         // nonzero param types => param types and extracted params have same size
@@ -86,6 +86,7 @@ public class AdHocPlannedStatement {
         // any extracted params => extracted param size == param type array size
         assert((extractedParamValues.size() == 0) ||
                 (extractedParamValues.size() == core.parameterTypes.length));
+        core.validate();
     }
 
     @Override

--- a/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
+++ b/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
@@ -71,21 +71,9 @@ public class AdHocPlannedStatement {
 
     private void validate() {
         assert(core != null);
-        assert(core.aggregatorFragment != null);
-
-        // dml => !readonly
-        assert(!core.isReplicatedTableDML || !core.readOnly);
-
-        // repdml => 2partplan
-        assert(!core.isReplicatedTableDML || (core.collectorFragment != null));
-
-        // zero param types => null extracted params
-        // nonzero param types => param types and extracted params have same size
-        assert(core.parameterTypes != null);
         assert(extractedParamValues != null);
         // any extracted params => extracted param size == param type array size
-        assert((extractedParamValues.size() == 0) ||
-                (extractedParamValues.size() == core.parameterTypes.length));
+        assert(extractedParamValues.size() == 0 || extractedParamValues.size() == core.parameterTypes.length);
         core.validate();
     }
 

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -277,7 +277,7 @@ public class PlannerTool {
                 .replace(RelDistributions.ANY);
 
         // Apply physical conversion rules.
-        Phase physicalPhase = (canCommuteJoins) ?
+        final Phase physicalPhase = canCommuteJoins ?
                 Phase.PHYSICAL_CONVERSION_WITH_JOIN_COMMUTE : Phase.PHYSICAL_CONVERSION;
         transformed = planner.transform(physicalPhase.ordinal(), requiredPhysicalOutputTraits, transformed);
 

--- a/src/frontend/org/voltdb/exceptions/PlanningErrorException.java
+++ b/src/frontend/org/voltdb/exceptions/PlanningErrorException.java
@@ -17,11 +17,22 @@
 
 package org.voltdb.exceptions;
 
+import java.util.Formatter;
+
 public class PlanningErrorException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public PlanningErrorException(String msg) {
         super(msg);
+    }
+
+    /**
+     * Formatted error msg, the same way we use String.format.
+     * @param format format string
+     * @param args args in the format string
+     */
+    public PlanningErrorException(String format, Object... args) {
+        this(new Formatter().format(format, args).toString());
     }
     public PlanningErrorException(Throwable e) {
         super(e);

--- a/src/frontend/org/voltdb/exceptions/ValidationError.java
+++ b/src/frontend/org/voltdb/exceptions/ValidationError.java
@@ -1,0 +1,39 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.exceptions;
+
+/**
+ * Validation error includes invariant violations when validating a plan node, e.g.
+ * in all AbstractPlanNode validate methods, and all AbstractExpression validate methods.
+ */
+public class ValidationError extends PlanningErrorException {
+    public ValidationError(String msg) {
+        super("ValidationError: " + msg);
+    }
+    public ValidationError(Throwable e) {
+        super(e);
+    }
+    public ValidationError(String msg, Throwable e) {
+        super("ValidationError: " + msg, e);
+    }
+    public ValidationError(String format, Object... args) {
+        super("ValidationError: " + format, args);
+    }
+    // Hides PlanningErrorException ctor with stack trace erased,
+    // because we always need the stack trace to understand what is going on.
+}

--- a/src/frontend/org/voltdb/exceptions/ValidationError.java
+++ b/src/frontend/org/voltdb/exceptions/ValidationError.java
@@ -23,7 +23,7 @@ package org.voltdb.exceptions;
  */
 public class ValidationError extends PlanningErrorException {
     public ValidationError(String msg) {
-        super("ValidationError: " + msg);
+        super(msg);
     }
     public ValidationError(Throwable e) {
         super(e);
@@ -36,4 +36,9 @@ public class ValidationError extends PlanningErrorException {
     }
     // Hides PlanningErrorException ctor with stack trace erased,
     // because we always need the stack trace to understand what is going on.
+
+    @Override
+    public String toString() {
+        return "ValidationError: " + super.toString();
+    }
 }

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -31,6 +31,7 @@ import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Table;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.planner.ParsedColInfo;
 import org.voltdb.planner.parseinfo.StmtTableScan;
 import org.voltdb.types.ExpressionType;
@@ -169,22 +170,22 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         // Expression Type
         //
         if (m_type == null) {
-            throw new RuntimeException("ERROR: The ExpressionType for '" + this + "' is NULL");
+            throw new ValidationError("The ExpressionType for '%s' is NULL", toString());
         }
 
         if (m_type == ExpressionType.INVALID) {
-            throw new RuntimeException("ERROR: The ExpressionType for '" + this + "' is " + m_type);
+            throw new ValidationError("The ExpressionType for '%s' is %s", toString(), m_type);
         }
 
         //
         // Output Type
         //
         if (m_valueType == null) {
-            throw new RuntimeException("ERROR: The output VoltType for '" + this + "' is NULL");
+            throw new ValidationError("The output VoltType for '%s' is NULL", toString());
         }
 
         if (m_valueType == VoltType.INVALID) {
-            throw new RuntimeException("ERROR: The output VoltType for '" + this + "' is " + m_valueType);
+            throw new ValidationError("The output VoltType for '%s' is %s", toString(), m_valueType);
         }
 
         //
@@ -193,8 +194,8 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         //
         Class<?> check_class = m_type.getExpressionClass();
         if (!check_class.isInstance(this)) {
-            throw new RuntimeException("ERROR: Expression '" + this + "' is class type '" +
-                    getClass().getSimpleName() + "' but needs to be '" + check_class.getSimpleName() + "'");
+            throw new ValidationError("Expression '%s' is class type '%s' but needs to be '%s'", toString(),
+                    getClass().getSimpleName(), check_class.getSimpleName());
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -21,9 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hsqldb_voltpatches.FunctionSQL;
-import org.hsqldb_voltpatches.FunctionForVoltDB.FunctionDescriptor;
 import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
@@ -142,8 +142,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         m_type = type;
     }
 
-    public AbstractExpression(ExpressionType type,
-            AbstractExpression left, AbstractExpression right) {
+    public AbstractExpression(ExpressionType type, AbstractExpression left, AbstractExpression right) {
         this(type);
         m_left = left;
         m_right = right;
@@ -204,25 +203,21 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         AbstractExpression clone;
         try {
             clone = (AbstractExpression)super.clone();
-        }
-        catch (CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
             // umpossible
             return null;
         }
 
         if (m_left != null) {
-            AbstractExpression left_clone = m_left.clone();
-            clone.m_left = left_clone;
+            clone.m_left = m_left.clone();
         }
         if (m_right != null) {
-            AbstractExpression right_clone = m_right.clone();
-            clone.m_right = right_clone;
+            clone.m_right = m_right.clone();
         }
         if (m_args != null) {
-            clone.m_args = new ArrayList<>();
-            for (AbstractExpression argument : m_args) {
-                clone.m_args.add(argument.clone());
-            }
+            clone.m_args = m_args.stream()
+                    .map(AbstractExpression::clone)
+                    .collect(Collectors.toList());
         }
 
         return clone;
@@ -352,34 +347,34 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
 
     private void toStringHelper(String linePrefix, StringBuilder sb) {
         sb.append(linePrefix);
-        sb.append(getExpressionNodeNameForToString() + " [" + getExpressionType().toString() + "] : ");
+        sb.append(getExpressionNodeNameForToString()).append(" [")
+                .append(getExpressionType().toString()).append("] : ");
         if (m_valueType != null) {
             sb.append(m_valueType.toSQLString());
             if (m_valueType.isVariableLength()) {
-                sb.append("(" + m_valueSize);
+                sb.append("(").append(m_valueSize);
                 if (m_valueType == VoltType.STRING) {
                     sb.append(m_inBytes ? " bytes" : " chars");
                 }
                 sb.append(")");
             }
-        }
-        else {
+        } else {
             sb.append("[null type]");
         }
         sb.append("\n");
 
         if (m_left != null) {
-            sb.append(linePrefix + "Left:\n");
+            sb.append(linePrefix).append("Left:\n");
             m_left.toStringHelper(linePrefix + INDENT, sb);
         }
 
         if (m_right != null) {
-            sb.append(linePrefix + "Right:\n");
+            sb.append(linePrefix).append("Right:\n");
             m_right.toStringHelper(linePrefix + INDENT, sb);
         }
 
         if (m_args != null) {
-            sb.append(linePrefix + "Args:\n");
+            sb.append(linePrefix).append("Args:\n");
             for (AbstractExpression arg : m_args) {
                 arg.toStringHelper(linePrefix + INDENT, sb);
             }
@@ -388,7 +383,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof AbstractExpression == false) {
+        if (! (obj instanceof AbstractExpression)) {
             return false;
         }
 
@@ -398,7 +393,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             return false;
         }
 
-        if ( ! hasEqualAttributes(expr)) {
+        if (! hasEqualAttributes(expr)) {
             return false;
         }
 
@@ -418,20 +413,14 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         }
 
         // Check that the children identify themselves as equal
-        if (expr.m_left != null) {
-            if (expr.m_left.equals(m_left) == false) {
-                return false;
-            }
+        if (expr.m_left != null && ! expr.m_left.equals(m_left)) {
+            return false;
         }
-        if (expr.m_right != null) {
-            if (expr.m_right.equals(m_right) == false) {
-                return false;
-            }
+        if (expr.m_right != null && ! expr.m_right.equals(m_right)) {
+            return false;
         }
         if (expr.m_args != null) {
-            if (expr.m_args.equals(m_args) == false) {
-                return false;
-            }
+            return expr.m_args.equals(m_args);
         }
 
         return true;
@@ -451,14 +440,12 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      * @return true iff the two strings represent lists of the same expressions,
      * allowing for value type differences
      */
-    public static boolean areOverloadedJSONExpressionLists(
-            String jsontext1, String jsontext2) {
+    public static boolean areOverloadedJSONExpressionLists(String jsontext1, String jsontext2) {
         try {
             List<AbstractExpression> list1 = fromJSONArrayString(jsontext1, null);
             List<AbstractExpression> list2 = fromJSONArrayString(jsontext2, null);
             return list1.equals(list2);
-        }
-        catch (JSONException je) {
+        } catch (JSONException je) {
             return false;
         }
     }
@@ -594,8 +581,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             stringer.object();
             toJSONString(stringer);
             stringer.endObject();
-        }
-        catch (JSONException e) {
+        } catch (JSONException e) {
             e.printStackTrace();
             return null;
         }
@@ -608,8 +594,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         if (m_valueType == null) {
             stringer.keySymbolValuePair(Members.VALUE_TYPE, VoltType.NULL.getValue());
             stringer.keySymbolValuePair(Members.VALUE_SIZE, m_valueSize);
-        }
-        else {
+        } else {
             stringer.keySymbolValuePair(Members.VALUE_TYPE, m_valueType.getValue());
             if (m_valueType.getLengthInBytesForFixedTypesWithoutCheck() == -1) {
                 stringer.keySymbolValuePair(Members.VALUE_SIZE, m_valueSize);
@@ -660,8 +645,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             sortExpressions.get(ii).toJSONString(stringer);
             stringer.endObject();
             if (sortDirections != null) {
-                stringer.keySymbolValuePair(SortMembers.SORT_DIRECTION,
-                        sortDirections.get(ii).toString());
+                stringer.keySymbolValuePair(SortMembers.SORT_DIRECTION, sortDirections.get(ii).toString());
             }
             stringer.endObject();
         }
@@ -669,23 +653,19 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     protected void loadFromJSONObject(JSONObject obj) throws JSONException { }
-    protected void loadFromJSONObject(JSONObject obj, StmtTableScan tableScan)
-            throws JSONException {
+    protected void loadFromJSONObject(JSONObject obj, StmtTableScan tableScan) throws JSONException {
         loadFromJSONObject(obj);
     }
 
-    public static AbstractExpression fromJSONChild(
-            JSONObject jobj, String label) throws JSONException {
+    public static AbstractExpression fromJSONChild(JSONObject jobj, String label) throws JSONException {
         if (jobj.isNull(label)) {
             return null;
         }
         return fromJSONObject(jobj.getJSONObject(label), null);
-
     }
 
     public static AbstractExpression fromJSONChild(
-            JSONObject jobj, String label,  StmtTableScan tableScan)
-            throws JSONException {
+            JSONObject jobj, String label,  StmtTableScan tableScan) throws JSONException {
         if (jobj.isNull(label)) {
             return null;
         }
@@ -698,12 +678,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         AbstractExpression expr;
         try {
             expr = type.getExpressionClass().newInstance();
-        }
-        catch (InstantiationException e) {
-            e.printStackTrace();
-            return null;
-        }
-        catch (IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException e) {
             e.printStackTrace();
             return null;
         }
@@ -713,15 +688,14 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         expr.m_valueType = VoltType.get((byte) obj.getInt(Members.VALUE_TYPE));
         if (obj.has(Members.VALUE_SIZE)) {
             expr.m_valueSize = obj.getInt(Members.VALUE_SIZE);
-        }
-        else {
+        } else {
             expr.m_valueSize = expr.m_valueType.getLengthInBytesForFixedTypes();
         }
 
         expr.m_left = fromJSONChild(obj, Members.LEFT, tableScan);
         expr.m_right = fromJSONChild(obj, Members.RIGHT, tableScan);
 
-        if ( ! obj.isNull(Members.ARGS)) {
+        if (! obj.isNull(Members.ARGS)) {
             JSONArray jarray = obj.getJSONArray(Members.ARGS);
             ArrayList<AbstractExpression> arguments = new ArrayList<>();
             loadFromJSONArray(arguments, jarray, tableScan);
@@ -766,8 +740,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
                 JSONObject tempObj = jarray.getJSONObject(ii);
                 sortExpressions.add(
                         fromJSONChild(tempObj, SortMembers.SORT_EXPRESSION));
-                if (sortDirections == null ||
-                        ! tempObj.has(SortMembers.SORT_DIRECTION)) {
+                if (sortDirections == null || ! tempObj.has(SortMembers.SORT_DIRECTION)) {
                     continue;
                 }
                 String sdAsString = tempObj.getString(SortMembers.SORT_DIRECTION);
@@ -779,10 +752,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
 
     public static List<AbstractExpression> fromJSONArrayString(
             String jsontext, StmtTableScan tableScan) throws JSONException {
-        JSONArray jarray = new JSONArray(jsontext);
-        List<AbstractExpression> result = new ArrayList<>();
-        loadFromJSONArray(result, jarray, tableScan);
-        return result;
+        return loadFromJSONArray(new ArrayList<>(), new JSONArray(jsontext), tableScan);
     }
 
     public static void fromJSONArrayString(String jsontext,
@@ -792,8 +762,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     public static AbstractExpression fromJSONString(
-            String jsontext, StmtTableScan tableScan)
-                    throws JSONException {
+            String jsontext, StmtTableScan tableScan) throws JSONException {
         JSONObject jobject = new JSONObject(jsontext);
         return fromJSONObject(jobject, tableScan);
     }
@@ -915,11 +884,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         }
 
         if (m_args != null) {
-            for (AbstractExpression expr: m_args) {
-                if (expressionSet.contains(expr)) {
-                    return true;
-                }
-            }
+            return m_args.stream().anyMatch(expressionSet::contains);
         }
         return false;
     }
@@ -931,11 +896,9 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     public AbstractExpression replaceAVG () {
         if (getExpressionType() == ExpressionType.AGGREGATE_AVG) {
             AbstractExpression child = getLeft();
-            AbstractExpression left =
-                    new AggregateExpression(ExpressionType.AGGREGATE_SUM);
+            AbstractExpression left = new AggregateExpression(ExpressionType.AGGREGATE_SUM);
             left.setLeft(child.clone());
-            AbstractExpression right =
-                    new AggregateExpression(ExpressionType.AGGREGATE_COUNT);
+            AbstractExpression right = new AggregateExpression(ExpressionType.AGGREGATE_COUNT);
             right.setLeft(child.clone());
 
             return new OperatorExpression(ExpressionType.OPERATOR_DIVIDE,
@@ -1018,8 +981,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      * @param aeClass expression class to search for
      * @return whether the expression or any contained expressions are of the desired type
      */
-    public boolean hasAnySubexpressionOfClass(
-            Class< ? extends AbstractExpression> aeClass) {
+    public boolean hasAnySubexpressionOfClass(Class<? extends AbstractExpression> aeClass) {
         if (aeClass.isInstance(this)) {
             return true;
         }
@@ -1032,14 +994,8 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             return true;
         }
 
-        if (m_args != null) {
-            for (AbstractExpression argument : m_args) {
-                if (argument.hasAnySubexpressionOfClass(aeClass)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return m_args != null &&
+                m_args.stream().anyMatch(a -> a.hasAnySubexpressionOfClass(aeClass));
     }
 
     public boolean hasTVE() {
@@ -1074,11 +1030,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         }
 
         if (m_args != null) {
-            for (AbstractExpression argument : m_args) {
-                if (argument.hasAnySubexpressionWithPredicate(pred)) {
-                    return true;
-                }
-            }
+            return m_args.stream().anyMatch(e -> e.hasAnySubexpressionWithPredicate(pred));
         }
 
         return false;
@@ -1145,8 +1097,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         if (valueType == VoltType.DECIMAL) {
             m_valueType = VoltType.DECIMAL;
             m_valueSize = VoltType.DECIMAL.getLengthInBytesForFixedTypes();
-        }
-        else {
+        } else {
             m_valueType = VoltType.FLOAT;
             m_valueSize = VoltType.FLOAT.getLengthInBytesForFixedTypes();
         }
@@ -1390,12 +1341,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      * @return
      */
     public static boolean validateExprsForIndexesAndMVs(List<AbstractExpression> checkList, StringBuffer msg, boolean isMV) {
-        for (AbstractExpression expr : checkList) {
-            if (!expr.isValidExprForIndexesAndMVs(msg, isMV)) {
-                return false;
-            }
-        }
-        return true;
+        return checkList.stream().allMatch(e -> e.isValidExprForIndexesAndMVs(msg, isMV));
     }
 
     /**
@@ -1435,7 +1381,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
      */
     public boolean isValueTypeIndexable(StringBuffer msg) {
         if (!m_valueType.isIndexable()) {
-            msg.append("expression of type " + m_valueType.getName());
+            msg.append("expression of type ").append(m_valueType.getName());
             return false;
         }
         return true;
@@ -1460,7 +1406,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             return false;
         }
         if (!m_valueType.isUniqueIndexable()) {
-            msg.append("expression of type " + m_valueType.getName());
+            msg.append("expression of type ").append(m_valueType.getName());
             return false;
         }
         return true;
@@ -1517,8 +1463,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
     }
 
     public static void toJSONArray(JSONStringer stringer, String keyString, List<AbstractExpression> exprs) throws JSONException {
-        stringer.key(keyString)
-                .array();
+        stringer.key(keyString).array();
         if (exprs != null) {
             for (AbstractExpression ae : exprs) {
                 stringer.object();
@@ -1539,7 +1484,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             return m_left;
         }
         if (m_args != null && m_args.size() > 0) {
-            assert(m_left == null && m_right == null);
+            assert m_right == null;
             return m_args.get(0);
         }
         return null;
@@ -1560,11 +1505,8 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             return false;
         }
         AbstractExpression rightExpr = getRight();
-        if ( ( ! (rightExpr instanceof TupleValueExpression)) &&
-                rightExpr.hasAnySubexpressionOfClass(TupleValueExpression.class) ) {
-            return false;
-        }
-        return true;
+        return rightExpr instanceof TupleValueExpression ||
+                ! rightExpr.hasAnySubexpressionOfClass(TupleValueExpression.class);
     }
 
 }

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -31,6 +31,7 @@ import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Table;
+import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.exceptions.ValidationError;
 import org.voltdb.planner.ParsedColInfo;
 import org.voltdb.planner.parseinfo.StmtTableScan;
@@ -583,8 +584,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
             toJSONString(stringer);
             stringer.endObject();
         } catch (JSONException e) {
-            e.printStackTrace();
-            return null;
+            throw new PlanningErrorException(e);
         }
         return stringer.toString();
     }

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -149,7 +149,7 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         m_right = right;
     }
 
-    public void validate() throws Exception {
+    public void validate() {
         //
         // Validate our children first
         //
@@ -170,22 +170,22 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         // Expression Type
         //
         if (m_type == null) {
-            throw new Exception("ERROR: The ExpressionType for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The ExpressionType for '" + this + "' is NULL");
         }
 
         if (m_type == ExpressionType.INVALID) {
-            throw new Exception("ERROR: The ExpressionType for '" + this + "' is " + m_type);
+            throw new RuntimeException("ERROR: The ExpressionType for '" + this + "' is " + m_type);
         }
 
         //
         // Output Type
         //
         if (m_valueType == null) {
-            throw new Exception("ERROR: The output VoltType for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The output VoltType for '" + this + "' is NULL");
         }
 
         if (m_valueType == VoltType.INVALID) {
-            throw new Exception("ERROR: The output VoltType for '" + this + "' is " + m_valueType);
+            throw new RuntimeException("ERROR: The output VoltType for '" + this + "' is " + m_valueType);
         }
 
         //
@@ -194,7 +194,8 @@ public abstract class AbstractExpression implements JSONString, Cloneable {
         //
         Class<?> check_class = m_type.getExpressionClass();
         if (!check_class.isInstance(this)) {
-            throw new Exception("ERROR: Expression '" + this + "' is class type '" + getClass().getSimpleName() + "' but needs to be '" + check_class.getSimpleName() + "'");
+            throw new RuntimeException("ERROR: Expression '" + this + "' is class type '" +
+                    getClass().getSimpleName() + "' but needs to be '" + check_class.getSimpleName() + "'");
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -115,12 +115,15 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
-        if (m_subqueryNode != null && m_subqueryNode.getPlanNodeId() != m_subqueryNodeId)
-            throw new Exception("ERROR: A subquery plan node id mismatch");
-
+        if (m_subqueryNode != null) {
+            if (m_subqueryNode.getPlanNodeId() != m_subqueryNodeId) {
+                throw new RuntimeException("ERROR: A subquery plan node id mismatch");
+            }
+            m_subqueryNode.validate();
+        }
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -52,7 +52,7 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
     protected AbstractPlanNode m_subqueryNode = null;
     // List of correlated parameter indexes that originate at the immediate parent's level
     // and need to be set by this SubqueryExpression on the EE side prior to the evaluation
-    private List<Integer> m_parameterIdxList = new ArrayList<Integer>();
+    private List<Integer> m_parameterIdxList = new ArrayList<>();
 
     protected AbstractSubqueryExpression() {
         m_valueType = VoltType.BIGINT;

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -26,6 +26,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Database;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.planner.ParameterizationInfo;
 import org.voltdb.plannodes.AbstractPlanNode;
 
@@ -120,7 +121,7 @@ public abstract class AbstractSubqueryExpression extends AbstractExpression {
 
         if (m_subqueryNode != null) {
             if (m_subqueryNode.getPlanNodeId() != m_subqueryNodeId) {
-                throw new RuntimeException("ERROR: A subquery plan node id mismatch");
+                throw new ValidationError("A subquery plan node id mismatch");
             }
             m_subqueryNode.validate();
         }

--- a/src/frontend/org/voltdb/expressions/AbstractValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractValueExpression.java
@@ -60,14 +60,12 @@ public abstract class AbstractValueExpression extends AbstractExpression {
     }
 
     @Override
-    public void normalizeOperandTypes_recurse()
-    {
+    public void normalizeOperandTypes_recurse() {
         // Nothing to do... no operands.
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         // Nothing to do... This is all about pulling types UP from child expressions.
     }
 

--- a/src/frontend/org/voltdb/expressions/AggregateExpression.java
+++ b/src/frontend/org/voltdb/expressions/AggregateExpression.java
@@ -148,9 +148,10 @@ public class AggregateExpression extends AbstractExpression {
         ExpressionType type = getExpressionType();
         if (type == ExpressionType.AGGREGATE_COUNT_STAR) {
             return "COUNT(*)";
+        } else {
+            return type.symbol() + (m_distinct ? " DISTINCT(" : "(") +
+                    m_left.explain(impliedTableName) + ")";
         }
-        return type.symbol() + ( m_distinct ? " DISTINCT(" : "(" ) +
-            m_left.explain(impliedTableName) + ")";
     }
 
     public boolean isUserDefined() {

--- a/src/frontend/org/voltdb/expressions/ComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/ComparisonExpression.java
@@ -85,8 +85,7 @@ public class ComparisonExpression extends AbstractExpression {
     protected void loadFromJSONObject(JSONObject obj) throws JSONException {
         if (obj.has(Members.QUANTIFIER)) {
             m_quantifier = QuantifierType.get(obj.getInt(Members.QUANTIFIER));
-        }
-        else {
+        } else {
             m_quantifier = QuantifierType.NONE;
         }
     }
@@ -99,27 +98,25 @@ public class ComparisonExpression extends AbstractExpression {
         }
     }
 
-    public static final Map<ExpressionType,ExpressionType> reverses = new HashMap<ExpressionType, ExpressionType>();
-    static {
-        reverses.put(ExpressionType.COMPARE_EQUAL, ExpressionType.COMPARE_EQUAL);
-        reverses.put(ExpressionType.COMPARE_NOTDISTINCT, ExpressionType.COMPARE_NOTDISTINCT);
-        reverses.put(ExpressionType.COMPARE_NOTEQUAL, ExpressionType.COMPARE_NOTEQUAL);
-        reverses.put(ExpressionType.COMPARE_LESSTHAN, ExpressionType.COMPARE_GREATERTHAN);
-        reverses.put(ExpressionType.COMPARE_GREATERTHAN, ExpressionType.COMPARE_LESSTHAN);
-        reverses.put(ExpressionType.COMPARE_LESSTHANOREQUALTO, ExpressionType.COMPARE_GREATERTHANOREQUALTO);
-        reverses.put(ExpressionType.COMPARE_GREATERTHANOREQUALTO, ExpressionType.COMPARE_LESSTHANOREQUALTO);
-    }
+    public static final Map<ExpressionType,ExpressionType> reverses =
+            new HashMap<ExpressionType, ExpressionType>() {{
+                put(ExpressionType.COMPARE_EQUAL, ExpressionType.COMPARE_EQUAL);
+                put(ExpressionType.COMPARE_NOTDISTINCT, ExpressionType.COMPARE_NOTDISTINCT);
+                put(ExpressionType.COMPARE_NOTEQUAL, ExpressionType.COMPARE_NOTEQUAL);
+                put(ExpressionType.COMPARE_LESSTHAN, ExpressionType.COMPARE_GREATERTHAN);
+                put(ExpressionType.COMPARE_GREATERTHAN, ExpressionType.COMPARE_LESSTHAN);
+                put(ExpressionType.COMPARE_LESSTHANOREQUALTO, ExpressionType.COMPARE_GREATERTHANOREQUALTO);
+                put(ExpressionType.COMPARE_GREATERTHANOREQUALTO, ExpressionType.COMPARE_LESSTHANOREQUALTO);
+            }};
 
     public ComparisonExpression reverseOperator() {
         ExpressionType reverseType = reverses.get(this.m_type);
         // Left and right exprs are reversed on purpose
-        ComparisonExpression reversed = new ComparisonExpression(reverseType, m_right, m_left);
-        return reversed;
+        return new ComparisonExpression(reverseType, m_right, m_left);
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         finalizeChildValueTypes();
         //
         // IMPORTANT:
@@ -141,13 +138,13 @@ public class ComparisonExpression extends AbstractExpression {
      * @param comparand - a string operand value derived from the LIKE operator's rhs pattern
      * A helper for getGteFilterFromPrefixLike/getLtFilterFromPrefixLike
      **/
-    static private ComparisonExpression rangeFilterFromPrefixLike(AbstractExpression leftExpr, ExpressionType rangeComparator, String comparand) {
+    static private ComparisonExpression rangeFilterFromPrefixLike(
+            AbstractExpression leftExpr,ExpressionType rangeComparator, String comparand) {
         ConstantValueExpression cve = new ConstantValueExpression();
         cve.setValueType(VoltType.STRING);
         cve.setValue(comparand);
         cve.setValueSize(comparand.length());
-        ComparisonExpression rangeFilter = new ComparisonExpression(rangeComparator, leftExpr, cve);
-        return rangeFilter;
+        return new ComparisonExpression(rangeComparator, leftExpr, cve);
     }
 
     /**
@@ -162,8 +159,7 @@ public class ComparisonExpression extends AbstractExpression {
         if (m_right instanceof ParameterValueExpression) {
             ParameterValueExpression pve = (ParameterValueExpression)m_right;
             cve = pve.getOriginalValue();
-        }
-        else {
+        } else {
             assert(m_right instanceof ConstantValueExpression);
             cve = (ConstantValueExpression)m_right;
         }
@@ -181,8 +177,7 @@ public class ComparisonExpression extends AbstractExpression {
         String starter = extractLikePatternPrefix();
         // Right or wrong, this mimics what HSQL does for the case of " column LIKE prefix-pattern ".
         // It assumes that this last-sorting JAVA UTF-16 character maps to a suitably last-sorting UTF-8 string.
-        String ender = starter + "\uffff";
-        return ender;
+        return starter + "\uffff";
     }
 
     /// Construct the lower bound comparison filter implied by a prefix LIKE comparison.
@@ -212,7 +207,7 @@ public class ComparisonExpression extends AbstractExpression {
     @Override
     public boolean isValueTypeIndexable(StringBuffer msg) {
         // comparison expression result in boolean result type, which is not indexable
-        msg.append("comparison expression '" + getExpressionType().symbol() +"'");
+        msg.append("comparison expression '").append(getExpressionType().symbol()).append("'");
         return false;
     }
 

--- a/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
@@ -42,8 +42,7 @@ public class ConjunctionExpression extends AbstractExpression {
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         finalizeChildValueTypes();
         //
         // IMPORTANT:
@@ -70,7 +69,7 @@ public class ConjunctionExpression extends AbstractExpression {
     public boolean isValueTypeIndexable(StringBuffer msg) {
         // Conjunction expression include and and or expression that results in boolean result
         // boolean result are not indexable
-        msg.append("logical expression: '" + getExpressionType().symbol() + "'");
+        msg.append("logical expression: '").append(getExpressionType().symbol()).append("'");
         return false;
     }
 

--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -46,18 +46,16 @@ public class ConstantValueExpression extends AbstractValueExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // Make sure our value is not null
-        if (m_value == null && !m_isNull)
-        {
-            throw new Exception("ERROR: The constant value for '" + this +
+        if (m_value == null && !m_isNull) {
+            throw new RuntimeException("ERROR: The constant value for '" + this +
                                 "' is inconsistently null");
         // Make sure the value type is something we support here
-        } else if (m_valueType == VoltType.NULL ||
-                   m_valueType == VoltType.VOLTTABLE) {
-            throw new Exception("ERROR: Invalid constant value type '" + m_valueType + "' for '" + this + "'");
+        } else if (m_valueType == VoltType.NULL || m_valueType == VoltType.VOLTTABLE) {
+            throw new RuntimeException("ERROR: Invalid constant value type '" + m_valueType + "' for '" + this + "'");
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -22,6 +22,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.exceptions.PlanningErrorException;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.parser.SQLParser;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.types.TimestampType;
@@ -51,11 +52,10 @@ public class ConstantValueExpression extends AbstractValueExpression {
 
         // Make sure our value is not null
         if (m_value == null && !m_isNull) {
-            throw new RuntimeException("ERROR: The constant value for '" + this +
-                                "' is inconsistently null");
+            throw new ValidationError("The constant value for '%s' is inconsistently null", toString());
         // Make sure the value type is something we support here
         } else if (m_valueType == VoltType.NULL || m_valueType == VoltType.VOLTTABLE) {
-            throw new RuntimeException("ERROR: Invalid constant value type '" + m_valueType + "' for '" + this + "'");
+            throw new ValidationError("Invalid constant value type '%s' for '%s'", m_valueType, toString());
         }
     }
 
@@ -71,16 +71,12 @@ public class ConstantValueExpression extends AbstractValueExpression {
      */
     public void setValue(String value) {
         m_value = value;
-        m_isNull = false;
-        if (m_value == null)
-        {
-            m_isNull = true;
-        }
+        m_isNull = m_value == null;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof ConstantValueExpression == false) {
+        if (! (obj instanceof ConstantValueExpression)) {
             return false;
         }
         ConstantValueExpression expr = (ConstantValueExpression) obj;
@@ -116,9 +112,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
             stringer.value("NULL");
             return;
         }
-        {
-            switch (m_valueType)
-            {
+        switch (m_valueType) {
             case INVALID:
                 throw new JSONException("ConstantValueExpression.toJSONString(): value_type should never be VoltType.INVALID");
             case NULL:
@@ -156,18 +150,15 @@ public class ConstantValueExpression extends AbstractValueExpression {
                 break;
             default:
                 throw new JSONException("ConstantValueExpression.toJSONString(): Unrecognized value_type " + m_valueType);
-            }
         }
     }
 
     @Override
-    public void loadFromJSONObject(JSONObject obj) throws JSONException
-    {
+    public void loadFromJSONObject(JSONObject obj) throws JSONException {
         m_isNull = false;
         if (!obj.isNull(Members.VALUE.name())) {
             m_value = obj.getString(Members.VALUE.name());
-        }
-        else {
+        } else {
             m_isNull = true;
         }
         if (!obj.isNull(Members.ISNULL.name())) {
@@ -225,8 +216,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
      * and in HSQL's ExpressionValue class.
      */
     @Override
-    public void refineValueType(VoltType neededType, int neededSize)
-    {
+    public void refineValueType(VoltType neededType, int neededSize) {
         int size_unit = 1;
         if (neededType == m_valueType) {
 
@@ -236,9 +226,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
             // Variably sized types need to fit within the target width.
             if (neededType == VoltType.VARBINARY) {
                 if ( ! Encoder.isHexEncodedString(getValue())) {
-                    throw new PlanningErrorException("Value (" + getValue() +
-                                                     ") has an invalid format for a constant " +
-                                                     neededType.toSQLString() + " value");
+                    throw new PlanningErrorException("Value (" + getValue() + ") has an invalid format for a constant " +
+                            neededType.toSQLString() + " value");
                 }
                 size_unit = 2;
             }
@@ -247,10 +236,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
             }
 
             if (getValue().length() > size_unit*neededSize ) {
-                throw new PlanningErrorException("Value (" + getValue() +
-                                                 ") is too wide for a constant " +
-                                                 neededType.toSQLString() +
-                                                 " value of size " + neededSize);
+                throw new PlanningErrorException("Value (" + getValue() + ") is too wide for a constant " +
+                        neededType.toSQLString() + " value of size " + neededSize);
             }
             setValueSize(neededSize);
             return;
@@ -266,16 +253,13 @@ public class ConstantValueExpression extends AbstractValueExpression {
         if (neededType == VoltType.VARBINARY &&
                 (m_valueType == VoltType.STRING || m_valueType == null)) {
             if ( ! Encoder.isHexEncodedString(getValue())) {
-                throw new PlanningErrorException("Value (" + getValue() +
-                                                 ") has an invalid format for a constant " +
-                                                 neededType.toSQLString() + " value");
+                throw new PlanningErrorException("Value (" + getValue() + ") has an invalid format for a constant " +
+                        neededType.toSQLString() + " value");
             }
             size_unit = 2;
             if (getValue().length() > size_unit*neededSize ) {
-                throw new PlanningErrorException("Value (" + getValue() +
-                                                 ") is too wide for a constant " +
-                                                 neededType.toSQLString() +
-                                                 " value of size " + neededSize);
+                throw new PlanningErrorException("Value (" + getValue() + ") is too wide for a constant " +
+                        neededType.toSQLString() + " value of size " + neededSize);
             }
             setValueType(neededType);
             setValueSize(neededSize);
@@ -284,10 +268,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
 
         if (neededType == VoltType.STRING && m_valueType == null) {
             if (getValue().length() > size_unit*neededSize ) {
-                throw new PlanningErrorException("Value (" + getValue() +
-                                                 ") is too wide for a constant " +
-                                                 neededType.toSQLString() +
-                                                 " value of size " + neededSize);
+                throw new PlanningErrorException("Value (" + getValue() + ") is too wide for a constant " +
+                        neededType.toSQLString() + " value of size " + neededSize);
             }
             setValueType(neededType);
             setValueSize(neededSize);
@@ -310,9 +292,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
                     // TimeStampType to a datetime string.
                     TimestampType ts = new TimestampType(m_value);
                     m_value = String.valueOf(ts.getTime());
-                }
-                // It couldn't be converted to timestamp.
-                catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException e) { // It couldn't be converted to timestamp.
                     throw new PlanningErrorException("Value (" + getValue() +
                                                      ") has an invalid format for a constant " +
                                                      neededType.toSQLString() + " value");
@@ -331,9 +311,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
                 try {
                     Double.parseDouble(getValue());
                 } catch (NumberFormatException nfe) {
-                    throw new PlanningErrorException("Value (" + getValue() +
-                                                     ") has an invalid format for a constant " +
-                                                     neededType.toSQLString() + " value");
+                    throw new PlanningErrorException("Value (" + getValue() + ") has an invalid format for a constant " +
+                            neededType.toSQLString() + " value");
                 }
             }
             setValueType(neededType);
@@ -352,9 +331,8 @@ public class ConstantValueExpression extends AbstractValueExpression {
                     value = Long.parseLong(getValue());
                 }
             } catch (SQLParser.Exception | NumberFormatException exc) {
-                throw new PlanningErrorException("Value (" + getValue() +
-                                                 ") has an invalid format for a constant " +
-                                                 neededType.toSQLString() + " value");
+                throw new PlanningErrorException("Value (" + getValue() + ") has an invalid format for a constant " +
+                        neededType.toSQLString() + " value");
             }
             checkIntegerValueRange(value, neededType);
             m_valueType = neededType;
@@ -363,8 +341,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
         }
 
         // That's it for known type conversions.
-        throw new PlanningErrorException("Value (" + getValue() +
-                ") has an invalid format for a constant " +
+        throw new PlanningErrorException("Value (" + getValue() + ") has an invalid format for a constant " +
                 neededType.toSQLString() + " value");
     }
 
@@ -375,21 +352,14 @@ public class ConstantValueExpression extends AbstractValueExpression {
         // to use the literal NULL. Thus the NULL values for each of the 4 integer types are considered
         // an underflow exception for the type.
 
-        if (integerType == VoltType.BIGINT || integerType == VoltType.TIMESTAMP) {
-            if (value == VoltType.NULL_BIGINT)
-                throw new PlanningErrorException("Constant value underflows BIGINT type.");
-        }
-        if (integerType == VoltType.INTEGER) {
-            if ((value > Integer.MAX_VALUE) || (value <= VoltType.NULL_INTEGER))
-                throw new PlanningErrorException("Constant value overflows/underflows INTEGER type.");
-        }
-        if (integerType == VoltType.SMALLINT) {
-            if ((value > Short.MAX_VALUE) || (value <= VoltType.NULL_SMALLINT))
-                throw new PlanningErrorException("Constant value overflows/underflows SMALLINT type.");
-        }
-        if (integerType == VoltType.TINYINT) {
-            if ((value > Byte.MAX_VALUE) || (value <= VoltType.NULL_TINYINT))
-                throw new PlanningErrorException("Constant value overflows/underflows TINYINT type.");
+        if ((integerType == VoltType.BIGINT || integerType == VoltType.TIMESTAMP) && value == VoltType.NULL_BIGINT) {
+            throw new PlanningErrorException("Constant value underflows BIGINT type.");
+        } else if (integerType == VoltType.INTEGER && (value > Integer.MAX_VALUE || value <= VoltType.NULL_INTEGER)) {
+            throw new PlanningErrorException("Constant value overflows/underflows INTEGER type.");
+        } else if (integerType == VoltType.SMALLINT && (value > Short.MAX_VALUE || value <= VoltType.NULL_SMALLINT)) {
+            throw new PlanningErrorException("Constant value overflows/underflows SMALLINT type.");
+        } else if (integerType == VoltType.TINYINT && (value > Byte.MAX_VALUE || value <= VoltType.NULL_TINYINT)) {
+            throw new PlanningErrorException("Constant value overflows/underflows TINYINT type.");
         }
     }
 
@@ -412,9 +382,10 @@ public class ConstantValueExpression extends AbstractValueExpression {
 
             m_valueType = columnType;
             m_valueSize = columnType.getLengthInBytesForFixedTypes();
-        }
-        else {
-            throw new NumberFormatException("NUMERIC constant value type must match a FLOAT, DECIMAL, or integral column, not " + columnType.toSQLString());
+        } else {
+            throw new NumberFormatException(
+                    "NUMERIC constant value type must match a FLOAT, DECIMAL, or integral column, not " +
+                            columnType.toSQLString());
         }
     }
 
@@ -447,10 +418,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
         int firstWildcardPos = patternString.  indexOf('%');
         // Indexable filters have only a trailing '%'.
         // NOTE: not bothering to check for silly synonym patterns with multiple trailing '%'s.
-        if (firstWildcardPos != length-1) {
-            return false;
-        }
-        return true;
+        return firstWildcardPos == length - 1;
     }
 
     @Override
@@ -466,7 +434,7 @@ public class ConstantValueExpression extends AbstractValueExpression {
                 // Convert the datetime value in its canonical internal form,
                 // currently a count of epoch microseconds,
                 // through TimeStampType into a timestamp string.
-                long micros = Long.valueOf(m_value);
+                long micros = Long.parseLong(m_value);
                 TimestampType ts = new TimestampType(micros);
                 return "'" + ts.toString() + "'";
             }

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -23,6 +23,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Table;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.types.ExpressionType;
 
 public class FunctionExpression extends AbstractExpression {
@@ -163,27 +164,21 @@ public class FunctionExpression extends AbstractExpression {
         // Validate that there are no children other than the argument list (mandatory even if empty)
         //
         if (m_left != null) {
-            throw new RuntimeException("ERROR: The left child expression '" + m_left + "' for '" + this + "' is not NULL");
+            throw new ValidationError("The left child expression '%s' for '%s' is not NULL",
+                    m_left, toString());
+        } else if (m_right != null) {
+            throw new ValidationError("The right child expression '%s' for '%s' is not NULL",
+                    m_right, toString());
+        } else if (m_args == null) {
+            throw new ValidationError("The function argument list for '%s' is NULL",
+                    toString());
+        } else if (m_name == null) {
+            throw new ValidationError("The function name for '%s' is NULL", toString());
+        } else if (m_resultTypeParameterIndex != NOT_PARAMETERIZED &&
+                (m_resultTypeParameterIndex < 0 || m_resultTypeParameterIndex >= m_args.size())) {
+                throw new ValidationError("The function parameter argument index '%d' for '%s' is out of bounds",
+                        m_resultTypeParameterIndex, toString());
         }
-
-        if (m_right != null) {
-            throw new RuntimeException("ERROR: The right child expression '" + m_right + "' for '" + this + "' is not NULL");
-        }
-
-        if (m_args == null) {
-            throw new RuntimeException("ERROR: The function argument list for '" + this + "' is NULL");
-        }
-
-        if (m_name == null) {
-            throw new RuntimeException("ERROR: The function name for '" + this + "' is NULL");
-        }
-        if (m_resultTypeParameterIndex != NOT_PARAMETERIZED) {
-            if (m_resultTypeParameterIndex < 0 || m_resultTypeParameterIndex >= m_args.size()) {
-                throw new RuntimeException("ERROR: The function parameter argument index '" +
-                        m_resultTypeParameterIndex + "' for '" + this + "' is out of bounds");
-            }
-        }
-
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -157,29 +157,29 @@ public class FunctionExpression extends AbstractExpression {
 
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
         //
         // Validate that there are no children other than the argument list (mandatory even if empty)
         //
         if (m_left != null) {
-            throw new Exception("ERROR: The left child expression '" + m_left + "' for '" + this + "' is not NULL");
+            throw new RuntimeException("ERROR: The left child expression '" + m_left + "' for '" + this + "' is not NULL");
         }
 
         if (m_right != null) {
-            throw new Exception("ERROR: The right child expression '" + m_right + "' for '" + this + "' is not NULL");
+            throw new RuntimeException("ERROR: The right child expression '" + m_right + "' for '" + this + "' is not NULL");
         }
 
         if (m_args == null) {
-            throw new Exception("ERROR: The function argument list for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The function argument list for '" + this + "' is NULL");
         }
 
         if (m_name == null) {
-            throw new Exception("ERROR: The function name for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The function name for '" + this + "' is NULL");
         }
         if (m_resultTypeParameterIndex != NOT_PARAMETERIZED) {
             if (m_resultTypeParameterIndex < 0 || m_resultTypeParameterIndex >= m_args.size()) {
-                throw new Exception("ERROR: The function parameter argument index '" +
+                throw new RuntimeException("ERROR: The function parameter argument index '" +
                         m_resultTypeParameterIndex + "' for '" + this + "' is out of bounds");
             }
         }
@@ -188,7 +188,7 @@ public class FunctionExpression extends AbstractExpression {
 
     @Override
     public boolean hasEqualAttributes(AbstractExpression obj) {
-        if (obj instanceof FunctionExpression == false) {
+        if (! (obj instanceof FunctionExpression)) {
             return false;
         }
         FunctionExpression expr = (FunctionExpression) obj;

--- a/src/frontend/org/voltdb/expressions/HashRangeExpression.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpression.java
@@ -50,17 +50,17 @@ public class HashRangeExpression extends AbstractValueExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         if ((m_right != null) || (m_left != null))
-            throw new Exception("ERROR: A Hash Range expression has child expressions for '" + this + "'");
+            throw new RuntimeException("ERROR: A Hash Range expression has child expressions for '" + this + "'");
 
        if (m_hashColumn == Integer.MIN_VALUE)
-           throw new Exception("ERROR: A Hash Range has no hash column set for '" + this + "'");
+           throw new RuntimeException("ERROR: A Hash Range has no hash column set for '" + this + "'");
 
        if (m_ranges == null) {
-           throw new Exception("ERROR: A Hash Range has no ranges set for '" + this + "'");
+           throw new RuntimeException("ERROR: A Hash Range has no ranges set for '" + this + "'");
        }
     }
 

--- a/src/frontend/org/voltdb/expressions/HashRangeExpression.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpression.java
@@ -24,6 +24,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.types.ExpressionType;
 
 import com.google_voltpatches.common.collect.ImmutableSortedMap;
@@ -53,14 +54,12 @@ public class HashRangeExpression extends AbstractValueExpression {
     public void validate() {
         super.validate();
 
-        if ((m_right != null) || (m_left != null))
-            throw new RuntimeException("ERROR: A Hash Range expression has child expressions for '" + this + "'");
-
-       if (m_hashColumn == Integer.MIN_VALUE)
-           throw new RuntimeException("ERROR: A Hash Range has no hash column set for '" + this + "'");
-
-       if (m_ranges == null) {
-           throw new RuntimeException("ERROR: A Hash Range has no ranges set for '" + this + "'");
+        if ((m_right != null) || (m_left != null)) {
+            throw new ValidationError("A Hash Range expression has child expressions for '%s'", toString());
+        } else if (m_hashColumn == Integer.MIN_VALUE) {
+            throw new ValidationError("A Hash Range has no hash column set for '%s'", toString());
+        } else if (m_ranges == null) {
+           throw new ValidationError("A Hash Range has no ranges set for '%s'", toString());
        }
     }
 
@@ -94,7 +93,7 @@ public class HashRangeExpression extends AbstractValueExpression {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof HashRangeExpression == false) {
+        if (! (obj instanceof HashRangeExpression)) {
             return false;
         }
         HashRangeExpression expr = (HashRangeExpression) obj;
@@ -106,14 +105,12 @@ public class HashRangeExpression extends AbstractValueExpression {
             return false;
         }
         if (m_ranges != null) { // Implying both sides non-null
-            if (m_ranges.equals(expr.m_ranges) == false) {
+            if (! m_ranges.equals(expr.m_ranges)) {
                 return false;
             }
         }
         if (m_hashColumn != Integer.MIN_VALUE) { // Implying both sides non-null
-            if (m_hashColumn != expr.m_hashColumn) {
-                return false;
-            }
+            return m_hashColumn == expr.m_hashColumn;
         }
         return true;
     }
@@ -139,8 +136,8 @@ public class HashRangeExpression extends AbstractValueExpression {
         stringer.key(Members.RANGES.name()).array();
         for (Map.Entry<Integer, Integer> e : m_ranges.entrySet()) {
             stringer.object();
-            stringer.keySymbolValuePair(Members.RANGE_START.name(), e.getKey().intValue());
-            stringer.keySymbolValuePair(Members.RANGE_END.name(), e.getValue().intValue());
+            stringer.keySymbolValuePair(Members.RANGE_START.name(), e.getKey());
+            stringer.keySymbolValuePair(Members.RANGE_END.name(), e.getValue());
             stringer.endObject();
         }
         stringer.endArray();

--- a/src/frontend/org/voltdb/expressions/HashRangeExpressionBuilder.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpressionBuilder.java
@@ -56,5 +56,5 @@ public class HashRangeExpressionBuilder {
     }
 
     /// Builder object that produces immutable maps.
-    private ImmutableSortedMap.Builder<Integer, Integer> m_builder = new ImmutableSortedMap.Builder<Integer, Integer>(Ordering.natural());
+    private ImmutableSortedMap.Builder<Integer, Integer> m_builder = new ImmutableSortedMap.Builder<>(Ordering.natural());
 }

--- a/src/frontend/org/voltdb/expressions/InComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/InComparisonExpression.java
@@ -18,6 +18,7 @@
 package org.voltdb.expressions;
 
 import org.voltdb.VoltType;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.types.ExpressionType;
 
 /**
@@ -43,20 +44,20 @@ public class InComparisonExpression extends ComparisonExpression {
         // Args list is not used by IN.
         //
         if (m_args != null) {
-            throw new RuntimeException("ERROR: Args list was not null for '" + this + "'");
+            throw new ValidationError("Args list was not null for '%s'", toString());
         }
         //
         // We always need both a left node and a right node
         //
         if (m_left == null) {
-            throw new RuntimeException("ERROR: The left node for '" + this + "' is NULL");
+            throw new ValidationError("The left node for '%s' is NULL", toString());
         } else if (m_right == null) {
-            throw new RuntimeException("ERROR: The right node for '" + this + "' is NULL");
+            throw new ValidationError("The right node for '%s' is NULL", toString());
         }
 
         // right needs to be vector or parameter
         if (!(m_right instanceof VectorValueExpression) && !(m_right instanceof ParameterValueExpression)) {
-            throw new RuntimeException("ERROR: The right node for '" + this + "' is not a list or a parameter");
+            throw new ValidationError("The right node for '%s' is not a list or a parameter", toString());
         }
     }
 
@@ -70,8 +71,7 @@ public class InComparisonExpression extends ComparisonExpression {
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         // First, make sure this node and its children have valid types.
         // This ignores the overall element type of the rhs.
         super.finalizeValueTypes();

--- a/src/frontend/org/voltdb/expressions/InComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/InComparisonExpression.java
@@ -37,26 +37,26 @@ public class InComparisonExpression extends ComparisonExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
         //
         // Args list is not used by IN.
         //
         if (m_args != null) {
-            throw new Exception("ERROR: Args list was not null for '" + this + "'");
+            throw new RuntimeException("ERROR: Args list was not null for '" + this + "'");
         }
         //
         // We always need both a left node and a right node
         //
         if (m_left == null) {
-            throw new Exception("ERROR: The left node for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The left node for '" + this + "' is NULL");
         } else if (m_right == null) {
-            throw new Exception("ERROR: The right node for '" + this + "' is NULL");
+            throw new RuntimeException("ERROR: The right node for '" + this + "' is NULL");
         }
 
         // right needs to be vector or parameter
         if (!(m_right instanceof VectorValueExpression) && !(m_right instanceof ParameterValueExpression)) {
-            throw new Exception("ERROR: The right node for '" + this + "' is not a list or a parameter");
+            throw new RuntimeException("ERROR: The right node for '" + this + "' is not a list or a parameter");
         }
     }
 

--- a/src/frontend/org/voltdb/expressions/OperatorExpression.java
+++ b/src/frontend/org/voltdb/expressions/OperatorExpression.java
@@ -17,9 +17,7 @@
 
 package org.voltdb.expressions;
 
-import org.hsqldb_voltpatches.FunctionForVoltDB;
 import org.voltdb.VoltType;
-import org.voltdb.exceptions.PlanningErrorException;
 import org.voltdb.types.ExpressionType;
 import org.voltdb.utils.VoltTypeUtil;
 
@@ -93,8 +91,7 @@ public class OperatorExpression extends AbstractExpression {
     }
 
     @Override
-    public void refineValueType(VoltType neededType, int neededSize)
-    {
+    public void refineValueType(VoltType neededType, int neededSize) {
         if (! needsRightExpression()) {
             return;
         }
@@ -122,8 +119,7 @@ public class OperatorExpression extends AbstractExpression {
         VoltType rightType = m_right.getValueType();
         if (leftType == VoltType.FLOAT || rightType == VoltType.FLOAT) {
             operandType = VoltType.FLOAT;
-        }
-        else if (operandType != VoltType.FLOAT) {
+        } else if (operandType != VoltType.FLOAT) {
             if (leftType == VoltType.DECIMAL || rightType == VoltType.DECIMAL) {
                 operandType = VoltType.DECIMAL;
             }
@@ -140,8 +136,7 @@ public class OperatorExpression extends AbstractExpression {
     }
 
     @Override
-    public void finalizeValueTypes()
-    {
+    public void finalizeValueTypes() {
         finalizeChildValueTypes();
         ExpressionType type = getExpressionType();
         if (m_right == null) {
@@ -207,7 +202,7 @@ public class OperatorExpression extends AbstractExpression {
         case OPERATOR_NOT:
         case OPERATOR_IS_NULL:
         case OPERATOR_EXISTS:
-            msg.append("operator '" + getExpressionType().symbol() +"'");
+            msg.append("operator '").append(getExpressionType().symbol()).append("'");
             return false;
         default:
             return true;

--- a/src/frontend/org/voltdb/expressions/OperatorExpression.java
+++ b/src/frontend/org/voltdb/expressions/OperatorExpression.java
@@ -151,8 +151,7 @@ public class OperatorExpression extends AbstractExpression {
                 m_valueSize = m_valueType.getLengthInBytesForFixedTypes();
             }
             return;
-        }
-        if (type == ExpressionType.OPERATOR_CASE_WHEN || type == ExpressionType.OPERATOR_ALTERNATIVE) {
+        } else if (type == ExpressionType.OPERATOR_CASE_WHEN || type == ExpressionType.OPERATOR_ALTERNATIVE) {
             assert(m_valueType != null);
             m_valueSize = m_valueType.getMaxLengthInBytes();
             return;

--- a/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
@@ -77,7 +77,7 @@ public class ParameterValueExpression extends AbstractValueExpression {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof ParameterValueExpression == false) {
+        if (! (obj instanceof ParameterValueExpression)) {
             return false;
         }
         ParameterValueExpression expr = (ParameterValueExpression) obj;
@@ -98,8 +98,7 @@ public class ParameterValueExpression extends AbstractValueExpression {
     }
 
     @Override
-    public void loadFromJSONObject(JSONObject obj) throws JSONException
-    {
+    public void loadFromJSONObject(JSONObject obj) throws JSONException {
         assert ! obj.isNull(Members.PARAM_IDX.name());
         m_paramIndex = obj.getInt(Members.PARAM_IDX.name());
     }
@@ -125,9 +124,7 @@ public class ParameterValueExpression extends AbstractValueExpression {
     @Override
     public void refineOperandType(VoltType columnType) {
         if (columnType == null) {
-            return;
-        }
-        if ((columnType == VoltType.FLOAT) || (columnType == VoltType.DECIMAL) || columnType.isBackendIntegerType()) {
+        } else if (columnType == VoltType.FLOAT || columnType == VoltType.DECIMAL || columnType.isBackendIntegerType()) {
             m_valueType = columnType;
             m_valueSize = columnType.getLengthInBytesForFixedTypes();
         } else if (m_valueType == null) {

--- a/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
@@ -53,16 +53,24 @@ public class RowSubqueryExpression extends AbstractSubqueryExpression {
     }
 
     @Override
+    public void finalizeValueTypes() {
+        super.finalizeValueTypes();
+        if (m_args != null) {
+            m_args.forEach(AbstractExpression::finalizeValueTypes);
+        }
+    }
+
+    @Override
     public String explain(String impliedTableName) {
-        String result = "(";
+        StringBuilder result = new StringBuilder("(");
         String connector = "";
         assert (m_args != null);
         for (AbstractExpression arg : m_args) {
-            result += connector + arg.explain(impliedTableName);
+            result.append(connector).append(arg.explain(impliedTableName));
             connector = ", ";
         }
-        result += ")";
-        return result;
+        result.append(")");
+        return result.toString();
     }
 
     // Recursively collect all TVE and aggregate expressions to be replaced with the corresponding

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -37,11 +37,12 @@ public class ScalarValueExpression extends AbstractValueExpression {
     @Override
     public boolean equals(Object obj) {
         assert(m_left != null);
-        if (obj instanceof ScalarValueExpression == false) {
+        if (! (obj instanceof ScalarValueExpression)) {
             return false;
+        } else {
+            ScalarValueExpression expr = (ScalarValueExpression) obj;
+            return m_left.equals(expr.getLeft());
         }
-        ScalarValueExpression expr = (ScalarValueExpression) obj;
-        return m_left.equals(expr.getLeft());
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -160,11 +160,11 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         if ((m_right != null) || (m_left != null))
-            throw new Exception("ERROR: A subquery expression has child expressions for '" + this + "'");
+            throw new RuntimeException("ERROR: A subquery expression has child expressions for '" + this + "'");
 
     }
 

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -28,6 +28,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.planner.AbstractParsedStmt;
 import org.voltdb.planner.CompiledPlan;
 import org.voltdb.planner.parseinfo.StmtSubqueryScan;
@@ -149,12 +150,9 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
 
     @Override
     public SelectSubqueryExpression clone() {
-        SelectSubqueryExpression clone = (SelectSubqueryExpression) super.clone();
+        final SelectSubqueryExpression clone = (SelectSubqueryExpression) super.clone();
         if (!m_allParameterIdxList.isEmpty()) {
-            clone.m_allParameterIdxList = new ArrayList<>();
-            for (Integer paramIdx : m_allParameterIdxList) {
-                clone.m_allParameterIdxList.add(new Integer(paramIdx.intValue()));
-            }
+            clone.m_allParameterIdxList = new ArrayList<>(m_allParameterIdxList);
         }
         return clone;
     }
@@ -162,10 +160,9 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
     @Override
     public void validate() {
         super.validate();
-
-        if ((m_right != null) || (m_left != null))
-            throw new RuntimeException("ERROR: A subquery expression has child expressions for '" + this + "'");
-
+        if (m_right != null || m_left != null) {
+            throw new ValidationError("A subquery expression has child expressions for '%s'", toString());
+        }
     }
 
     @Override
@@ -176,8 +173,7 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
         // by this subquery
         if (!m_allParameterIdxList.isEmpty()) {
             // Calculate the difference between two sets of parameters
-            Set<Integer> allParams = new HashSet<>();
-            allParams.addAll(m_allParameterIdxList);
+            final Set<Integer> allParams = new HashSet<>(m_allParameterIdxList);
             allParams.removeAll(getParameterIdxList());
             if (!allParams.isEmpty()) {
                 stringer.key(Members.OTHER_PARAM_IDX.name()).array();
@@ -209,18 +205,18 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
             // will be extracted into a separated line from the final explain string
             StringBuilder sb = new StringBuilder();
             m_subqueryNode.explainPlan_recurse(sb, "");
-            String result = "(" + SUBQUERY_TAG + m_subqueryId + " " + sb.toString()
-                    + SUBQUERY_TAG + m_subqueryId + "";
+            StringBuilder result = new StringBuilder("(" + SUBQUERY_TAG + m_subqueryId + " " + sb.toString()
+                    + SUBQUERY_TAG + m_subqueryId + "");
             if (m_args != null && ! m_args.isEmpty()) {
                 String connector = "\n on arguments (";
                 for (AbstractExpression arg : m_args) {
-                    result += connector + arg.explain(impliedTableName);
+                    result.append(connector).append(arg.explain(impliedTableName));
                     connector = ", ";
                 }
-                result += ")\n";
+                result.append(")\n");
             }
-            result +=")";
-            return result;
+            result.append(")");
+            return result.toString();
         } else {
             return "(Subquery: null)";
         }
@@ -253,17 +249,14 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
                 if (tve.getOrigStmtId() == parentStmt.getStmtId()) {
                     // TVE originates from the statement that this SubqueryExpression belongs to
                     addArgumentParameter(paramIdx, expr);
-                }
-                else {
+                } else {
                     // TVE originates from a statement above this parent. Move it up.
                     parentStmt.m_parameterTveMap.put(paramIdx, expr);
                 }
-            }
-            else if (expr instanceof AggregateExpression) {
+            } else if (expr instanceof AggregateExpression) {
                 // An aggregate expression is always from THIS parent statement.
                 addArgumentParameter(paramIdx, expr);
-            }
-            else {
+            } else {
                 // so far it should be either AggregateExpression or TupleValueExpression types
                 assert(false);
             }

--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -159,17 +159,17 @@ public class TupleValueExpression extends AbstractValueExpression {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         if ((m_right != null) || (m_left != null))
-            throw new Exception(
+            throw new RuntimeException(
                     "ERROR: A value expression has child expressions for '" +
                     this + "'");
 
         // Column Index
         if (m_columnIndex < 0) {
-            throw new Exception(
+            throw new RuntimeException(
                     "ERROR: Invalid column index '" + m_columnIndex +
                     "' for '" + this + "'");
         }

--- a/src/frontend/org/voltdb/expressions/VectorValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/VectorValueExpression.java
@@ -66,13 +66,13 @@ public class VectorValueExpression extends AbstractExpression {
 
     @Override
     public String explain(String impliedTableName) {
-        String result = "(";
+        StringBuilder result = new StringBuilder("(");
         String connector = "";
         for (AbstractExpression arg : m_args) {
-            result += connector + arg.explain(impliedTableName);
+            result.append(connector).append(arg.explain(impliedTableName));
             connector = ", ";
         }
-        result += ")";
-        return result;
+        result.append(")");
+        return result.toString();
     }
 }

--- a/src/frontend/org/voltdb/expressions/WindowFunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/WindowFunctionExpression.java
@@ -108,25 +108,16 @@ public class WindowFunctionExpression extends AbstractExpression {
     }
 
     public boolean hasSubqueryArgs() {
-        if (m_args != null) {
-            for (AbstractExpression arg : m_args) {
-                if (arg.hasSubquerySubexpression()) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return m_args != null && m_args.stream().anyMatch(AbstractExpression::hasSubquerySubexpression);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (super.equals(obj) && obj instanceof WindowFunctionExpression) {
             WindowFunctionExpression oWindow = (WindowFunctionExpression)obj;
-            if (m_orderByExpressions.equals(oWindow.getOrderByExpressions())
+            return m_orderByExpressions.equals(oWindow.getOrderByExpressions())
                     && m_orderByDirections.equals(oWindow.getOrderByDirections())
-                    && m_partitionByExpressions.equals(oWindow.getPartitionByExpressions())) {
-                return true;
-            }
+                    && m_partitionByExpressions.equals(oWindow.getPartitionByExpressions());
         }
         return false;
     }
@@ -180,22 +171,9 @@ public class WindowFunctionExpression extends AbstractExpression {
         if (super.hasAnySubexpressionOfClass(aeClass)) {
             return true;
         }
-        for (AbstractExpression pbexpr : m_partitionByExpressions) {
-            if (pbexpr.hasAnySubexpressionOfClass(aeClass)) {
-                return true;
-            }
-        }
-        for (AbstractExpression sortExpr : m_orderByExpressions) {
-            if (sortExpr.hasAnySubexpressionOfClass(aeClass)) {
-                return true;
-            }
-        }
-        for (AbstractExpression aggExpr : m_args) {
-            if (aggExpr.hasAnySubexpressionOfClass(aeClass)) {
-                return true;
-            }
-        }
-        return false;
+        return m_partitionByExpressions.stream().anyMatch(e -> e.hasAnySubexpressionOfClass(aeClass)) ||
+                m_orderByExpressions.stream().anyMatch(e -> e.hasAnySubexpressionOfClass(aeClass)) ||
+                m_args.stream().anyMatch(e -> e.hasAnySubexpressionOfClass(aeClass));
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -363,25 +363,25 @@ public abstract class AbstractParsedStmt {
     private static Map<String, XMLElementExpressionParser> m_exprParsers =
             new HashMap<String, XMLElementExpressionParser>() {{
                 put("value",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseValueExpression(element));
+                        AbstractParsedStmt::parseValueExpression);
                 put("vector",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseVectorExpression(element));
+                        AbstractParsedStmt::parseVectorExpression);
                 put("columnref",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseColumnRefExpression(element));
+                        AbstractParsedStmt::parseColumnRefExpression);
                 put("operation",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseOperationExpression(element));
+                        AbstractParsedStmt::parseOperationExpression);
                 put("aggregation",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseAggregationExpression(element));
+                        AbstractParsedStmt::parseAggregationExpression);
                 put("asterisk",
                         (AbstractParsedStmt stmt, VoltXMLElement element) -> null);
                 put("win_aggregation",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseWindowedAggregationExpression(element));
+                        AbstractParsedStmt::parseWindowedAggregationExpression);
                 put("function",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseFunctionExpression(element));
+                        AbstractParsedStmt::parseFunctionExpression);
                 put("tablesubquery",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseSubqueryExpression(element));
+                        AbstractParsedStmt::parseSubqueryExpression);
                 put("row",
-                        (AbstractParsedStmt stmt, VoltXMLElement element) -> stmt.parseRowExpression(element));
+                        AbstractParsedStmt::parseRowExpression);
 
             }};
 

--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -126,6 +126,15 @@ public class CompiledPlan {
         return nextId;
     }
 
+    public void validate() {
+        if (rootPlanGraph != null) {
+            rootPlanGraph.validate();
+        }
+        if (subPlanGraph != null) {
+            subPlanGraph.validate();
+        }
+    }
+
     /**
      * Mark the level of result determinism imposed by the statement, which can
      * save us from a difficult determination based on the plan graph.
@@ -163,8 +172,7 @@ public class CompiledPlan {
      * m_statementIsContentDeterministic is false we want to check this. This is
      * the one area in which content and limit-order determinism interact.
      */
-    public boolean hasDeterministicStatement()
-    {
+    public boolean hasDeterministicStatement() {
         return m_statementIsOrderDeterministic && isContentDeterministic();
     }
 
@@ -333,8 +341,7 @@ public class CompiledPlan {
     public String toString() {
         if (rootPlanGraph != null) {
             return "CompiledPlan: \n" + rootPlanGraph.toExplainPlanString();
-        }
-        else {
+        } else {
             return "CompiledPlan: [null plan graph]";
         }
     }

--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -126,13 +126,14 @@ public class CompiledPlan {
         return nextId;
     }
 
-    public void validate() {
+    public boolean validate() {     // the return type only serves to be used inside assert; failed validation throws.
         if (rootPlanGraph != null) {
             rootPlanGraph.validate();
         }
         if (subPlanGraph != null) {
             subPlanGraph.validate();
         }
+        return true;
     }
 
     /**

--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -196,7 +196,7 @@ public class CompiledPlan {
             total += subPlanGraph.findAllNodesOfType(PlanNodeType.SEQSCAN).size();
         }
         // add full index scans
-        ArrayList<AbstractPlanNode> indexScanNodes = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN);
+        List<AbstractPlanNode> indexScanNodes = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN);
         if (subPlanGraph != null) {
             indexScanNodes.addAll(subPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN));
         }
@@ -261,7 +261,7 @@ public class CompiledPlan {
         }
 
         BitSet ints = new BitSet();
-        ArrayList<AbstractPlanNode> ixscans = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN);
+        List<AbstractPlanNode> ixscans = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN);
         if (subPlanGraph != null) {
             ixscans.addAll(subPlanGraph.findAllNodesOfType(PlanNodeType.INDEXSCAN));
         }
@@ -271,7 +271,7 @@ public class CompiledPlan {
             setParamIndexes(ints, ixs.getBindings());
         }
 
-        ArrayList<AbstractPlanNode> ixcounts = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXCOUNT);
+        List<AbstractPlanNode> ixcounts = rootPlanGraph.findAllNodesOfType(PlanNodeType.INDEXCOUNT);
         if (subPlanGraph != null) {
             ixcounts.addAll(subPlanGraph.findAllNodesOfType(PlanNodeType.INDEXCOUNT));
         }

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -106,6 +106,17 @@ public class CorePlan {
     }
 
     public void validate() {
+        assert(aggregatorFragment != null);
+
+        // dml => !readonly
+        assert(! isReplicatedTableDML || ! readOnly);
+
+        // repdml => 2partplan
+        assert(! isReplicatedTableDML || collectorFragment != null);
+
+        // zero param types => null extracted params
+        // nonzero param types => param types and extracted params have same size
+        assert(parameterTypes != null);
         if (m_compiledPlan != null) {
             m_compiledPlan.validate();
         }

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -67,6 +67,7 @@ public class CorePlan {
      */
     private int partitioningParamIndex = -1;
     private Object partitioningParamValue = null;
+    private final CompiledPlan m_compiledPlan;
 
     /**
      * Constructor from QueryPlanner output.
@@ -75,6 +76,7 @@ public class CorePlan {
      * @param catalogHash  The sha-1 hash of the catalog this plan was generated against.
      */
     public CorePlan(CompiledPlan plan, byte[] catalogHash) {
+        m_compiledPlan = plan;
         aggregatorFragment = CompiledPlan.bytesForPlan(plan.rootPlanGraph, plan.getIsLargeQuery());
         collectorFragment = CompiledPlan.bytesForPlan(plan.subPlanGraph, plan.getIsLargeQuery());
 
@@ -103,6 +105,12 @@ public class CorePlan {
         readOnly = plan.isReadOnly();
     }
 
+    public void validate() {
+        if (m_compiledPlan != null) {
+            m_compiledPlan.validate();
+        }
+    }
+
     /***
      * Constructor, mainly for deserialization (but also testing)
      *
@@ -120,8 +128,8 @@ public class CorePlan {
                     boolean isReplicatedTableDML,
                     boolean isReadOnly,
                     VoltType[] paramTypes,
-                    byte[] catalogHash)
-    {
+                    byte[] catalogHash) {
+        m_compiledPlan = null;      // not reconstructing the CompiledPlan
         this.aggregatorFragment = aggregatorFragment;
         this.collectorFragment = collectorFragment;
         this.aggregatorHash = aggregatorHash;

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -116,10 +116,8 @@ public class CorePlan {
 
         // zero param types => null extracted params
         // nonzero param types => param types and extracted params have same size
-        assert(parameterTypes != null);
-        if (m_compiledPlan != null) {
-            m_compiledPlan.validate();
-        }
+        assert parameterTypes != null;
+        assert m_compiledPlan == null || m_compiledPlan.validate();
     }
 
     /***

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1058,7 +1058,7 @@ public class PlanAssembler {
             boolean mvFixInfoCoordinatorNeeded = true;
             boolean mvFixInfoEdgeCaseOuterJoin = false;
 
-            ArrayList<AbstractPlanNode> receivers = root.findAllNodesOfClass(AbstractReceivePlanNode.class);
+            List<AbstractPlanNode> receivers = root.findAllNodesOfClass(AbstractReceivePlanNode.class);
             if (receivers.size() == 1) {
                 // The subplan SHOULD be good to go, but just make sure that it doesn't
                 // scan a partitioned table except under the ReceivePlanNode that was just found.

--- a/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
@@ -141,7 +141,6 @@ public class PlannerRules {
             VoltLTableScanRule.INSTANCE,
             VoltLCalcRule.INSTANCE,
             VoltLAggregateRule.INSTANCE,
-            VoltLAggregateCalcMergeRule.INSTANCE,       // eliminate Calcite's SINGLE_VALUE aggregation
             // Joins
             VoltLJoinRule.INSTANCE,
 
@@ -187,7 +186,8 @@ public class PlannerRules {
 
     private static final RuleSet HEP_OUTER_JOIN = RuleSets.ofList(
             CalcMergeRule.INSTANCE,
-            VoltLJoinCommuteRule.INSTANCE_RIGHT_TO_LEFT
+            VoltLJoinCommuteRule.INSTANCE_RIGHT_TO_LEFT,
+            VoltLAggregateCalcMergeRule.INSTANCE       // eliminate Calcite's SINGLE_VALUE aggregation
     );
 
 

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateCalcMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateCalcMergeRule.java
@@ -21,9 +21,9 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
-import org.apache.calcite.rel.logical.LogicalAggregate;
-import org.apache.calcite.rel.logical.LogicalCalc;
 import org.apache.calcite.sql.SqlKind;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalAggregate;
+import org.voltdb.plannerv2.rel.logical.VoltLogicalCalc;
 
 import java.util.List;
 
@@ -35,7 +35,7 @@ public class VoltLAggregateCalcMergeRule extends RelOptRule {
     public static final VoltLAggregateCalcMergeRule INSTANCE = new VoltLAggregateCalcMergeRule();
 
     private VoltLAggregateCalcMergeRule() {
-        super(operand(LogicalAggregate.class, operand(LogicalCalc.class, none())));
+        super(operand(VoltLogicalAggregate.class, operand(VoltLogicalCalc.class, none())));
     }
     @Override
     public void onMatch(RelOptRuleCall call) {

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -61,7 +61,7 @@ public abstract class AbstractJoinPlanNode extends AbstractPlanNode implements I
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         if (m_preJoinPredicate != null) {

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -22,6 +22,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.catalog.Database;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.planner.AbstractParsedStmt;
 
@@ -54,7 +55,7 @@ public abstract class AbstractOperationPlanNode extends AbstractPlanNode {
 
         // All Operation nodes need to have a target table
         if (m_targetTableName == null) {
-            throw new RuntimeException("ERROR: The Target TableId is null for PlanNode '" + this + "'");
+            throw new ValidationError("The Target TableId is null for PlanNode '%s'", this);
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -49,12 +49,12 @@ public abstract class AbstractOperationPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // All Operation nodes need to have a target table
         if (m_targetTableName == null) {
-            throw new Exception("ERROR: The Target TableId is null for PlanNode '" + this + "'");
+            throw new RuntimeException("ERROR: The Target TableId is null for PlanNode '" + this + "'");
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -35,6 +35,7 @@ import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
 import org.voltdb.exceptions.PlanningErrorException;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.TupleValueExpression;
@@ -264,8 +265,9 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         //
         for (AbstractPlanNode child : m_children) {
             if (!child.m_parents.contains(this)) {
-                throw new RuntimeException("ERROR: The child PlanNode '" + child.toString() + "' does not " +
-                        "have its parent PlanNode '" + toString() + "' in its parents list");
+                throw new ValidationError(
+                        "The child PlanNode '%s' does not have its parent PlanNode '%s' in its parents list",
+                        child.toString(), toString());
             }
             child.validate();
         }
@@ -277,11 +279,14 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
             // Make sure that we're not attached to some kind of tree somewhere...
             //
             if (!node.m_children.isEmpty()) {
-                throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' has children inside of PlanNode '" + this + "'");
+                throw new ValidationError("The inline PlanNode '%s' has children inside of PlanNode '%s'",
+                        node, this);
             } else if (!node.m_parents.isEmpty()) {
-                throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' has parents inside of PlanNode '" + this + "'");
+                throw new ValidationError("The inline PlanNode '%s' has parents inside of PlanNode '%s'",
+                        node, this);
             } else if (!node.isInline()) {
-                throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' was not marked as inline for PlanNode '" + this + "'");
+                throw new ValidationError("The inline PlanNode '%s' was not marked as inline for PlanNode '%s'",
+                        node, this);
             } else if (!node.getInlinePlanNodes().isEmpty()) {
                 // NOTE: we support recursive inline nodes
                 //throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' has its own inline PlanNodes inside of PlanNode '" + this + "'");

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -283,7 +283,8 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
             } else if (!node.isInline()) {
                 throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' was not marked as inline for PlanNode '" + this + "'");
             } else if (!node.getInlinePlanNodes().isEmpty()) {
-                throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' has its own inline PlanNodes inside of PlanNode '" + this + "'");
+                // NOTE: we support recursive inline nodes
+                //throw new RuntimeException("ERROR: The inline PlanNode '" + node + "' has its own inline PlanNodes inside of PlanNode '" + this + "'");
             }
             node.validate();
         }

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -1063,7 +1063,7 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         Map<String, String> subqueries = new TreeMap<>();
         String fullSb = extractExplainedSubquries(fullExpalinString, subqueryPattern, subqueries);
         return subqueries.entrySet().stream().flatMap(q -> Stream.of(q.getKey(), q.getValue()))
-                .collect(Collectors.joining("\n", fullSb + "\n", ""));
+                .collect(Collectors.joining("\n", fullSb, ""));
     }
 
     private String extractExplainedSubquries(String explainedSubquery, Pattern pattern, Map<String, String> subqueries) {

--- a/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
@@ -48,9 +48,7 @@ public abstract class AbstractReceivePlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void getTablesAndIndexes(Map<String, StmtTargetTableScan> tablesRead,
-            Collection<String> indexes)
-    {
+    public void getTablesAndIndexes(Map<String, StmtTargetTableScan> tablesRead, Collection<String> indexes) {
         // ReceiveNode is a dead end. This method is not intended to cross fragments
         // even within a pre-fragmented plan tree.
     }

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -195,6 +195,9 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // so that the resolveColumnIndexes results
         // don't get bashed by other nodes or subsequent planner runs
         m_predicate = ExpressionUtil.cloneAndCombinePredicates(colExps);
+        if (m_predicate != null) {
+            m_predicate.finalizeValueTypes();
+        }
     }
 
     protected void setScanColumns(List<SchemaColumn> scanColumns) {

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -17,10 +17,8 @@
 
 package org.voltdb.plannodes;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,17 +80,14 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
 
     @Override
     public void getTablesAndIndexes(Map<String, StmtTargetTableScan> tablesRead,
-            Collection<String> indexes)
-    {
+            Collection<String> indexes) {
         if (m_tableScan != null) {
             if (m_tableScan instanceof StmtTargetTableScan) {
                 tablesRead.put(m_targetTableName, (StmtTargetTableScan)m_tableScan);
                 getTablesAndIndexesFromSubqueries(tablesRead, indexes);
-            }
-            else if (m_tableScan instanceof StmtSubqueryScan) {
+            } else if (m_tableScan instanceof StmtSubqueryScan) {
                 getChild(0).getTablesAndIndexes(tablesRead, indexes);
-            }
-            else {
+            } else {
                 // This is the only other choice.
                 assert(m_tableScan instanceof StmtCommonTableScan);
                 getTablesAndIndexesFromCommonTableQueries(tablesRead, indexes);
@@ -101,7 +96,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
     }
 
     protected void getTablesAndIndexesFromCommonTableQueries(Map<String, StmtTargetTableScan> tablesRead,
-                                                                      Collection<String> indexes) {
+                                                             Collection<String> indexes) {
         // Search the base and recursive plans.
         StmtCommonTableScan ctScan = (StmtCommonTableScan)m_tableScan;
         ctScan.getTablesAndIndexesFromCommonTableQueries(tablesRead, indexes);
@@ -116,8 +111,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         //
         if (m_targetTableName == null) {
             throw new Exception("ERROR: TargetTableName is null for PlanNode '" + toString() + "'");
-        }
-        if (m_targetTableAlias == null) {
+        } else if (m_targetTableAlias == null) {
             throw new Exception("ERROR: TargetTableAlias is null for PlanNode '" + toString() + "'");
         }
         //
@@ -128,10 +122,8 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             m_predicate.validate();
         }
         // All the schema columns better reference this table
-        for (SchemaColumn col : m_tableScanSchema)
-        {
-            if (!m_targetTableName.equals(col.getTableName()))
-            {
+        for (SchemaColumn col : m_tableScanSchema) {
+            if (!m_targetTableName.equals(col.getTableName())) {
                 throw new Exception("ERROR: The scan column: " + col.getColumnName() +
                                     " in table: " + m_targetTableName + " refers to " +
                                     " table: " + col.getTableName());
@@ -346,8 +338,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             m_outputSchema = proj.getOutputSchema().copyAndReplaceWithTVE();
             // It's just a cheap knock-off of the projection's
             m_hasSignificantOutputSchema = false;
-        }
-        else if (m_tableScanSchema.size() != 0) {
+        } else if (m_tableScanSchema.size() != 0) {
             // Order the scan columns according to the table schema
             // before we stick them in the projection output
             int difftor = 0;
@@ -369,8 +360,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             // a bit redundant but logically consistent
             m_outputSchema = projectionNode.getOutputSchema().copyAndReplaceWithTVE();
             m_hasSignificantOutputSchema = false; // It's just a cheap knock-off of the projection's
-        }
-        else {
+        } else {
             // We come here if m_tableScanSchema is empty.
             //
             // m_tableScanSchema might be empty for cases like
@@ -392,15 +382,13 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
             m_tableSchema = childNode.getOutputSchema();
             // step to transfer derived table schema to upper level
             m_tableSchema = m_tableSchema.replaceTableClone(getTargetTableAlias());
-        }
-        else if (isCommonTableScan()) {
+        } else if (isCommonTableScan()) {
             m_tableSchema = new NodeSchema();
             StmtCommonTableScan ctScan = (StmtCommonTableScan)m_tableScan;
             for (SchemaColumn col : ctScan.getOutputSchema()) {
                 m_tableSchema.addColumn(col.clone());
             }
-        }
-        else {
+        } else {
             m_tableSchema = new NodeSchema();
             CatalogMap<Column> cols =
                     db.getTables().getExact(m_targetTableName).getColumns();
@@ -448,11 +436,9 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // if there are any, in that order.
         if (ins != null) {
             m_outputSchema = ins.getOutputSchema().clone();
-        }
-        else if (proj != null) {
+        } else if (proj != null) {
             m_outputSchema = proj.getOutputSchema().clone();
-        }
-        else {
+        } else {
             m_outputSchema = m_preAggOutputSchema;
             // With no inline projection to define the output columns,
             // iterate through the output schema TVEs
@@ -526,8 +512,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void getScanNodeList_recurse(ArrayList<AbstractScanPlanNode> collected,
-            HashSet<AbstractPlanNode> visited) {
+    protected void getScanNodeList_recurse(List<AbstractScanPlanNode> collected, Set<AbstractPlanNode> visited) {
         if (visited.contains(this)) {
             assert(false): "do not expect loops in plangraph.";
             return;

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -104,15 +104,15 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
 
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
         //
         // TargetTableId
         //
         if (m_targetTableName == null) {
-            throw new Exception("ERROR: TargetTableName is null for PlanNode '" + toString() + "'");
+            throw new RuntimeException("ERROR: TargetTableName is null for PlanNode '" + toString() + "'");
         } else if (m_targetTableAlias == null) {
-            throw new Exception("ERROR: TargetTableAlias is null for PlanNode '" + toString() + "'");
+            throw new RuntimeException("ERROR: TargetTableAlias is null for PlanNode '" + toString() + "'");
         }
         //
         // Filter Expression
@@ -124,7 +124,7 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // All the schema columns better reference this table
         for (SchemaColumn col : m_tableScanSchema) {
             if (!m_targetTableName.equals(col.getTableName())) {
-                throw new Exception("ERROR: The scan column: " + col.getColumnName() +
+                throw new RuntimeException("ERROR: The scan column: " + col.getColumnName() +
                                     " in table: " + m_targetTableName + " refers to " +
                                     " table: " + col.getTableName());
             }

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -29,6 +29,7 @@ import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.ConstantValueExpression;
@@ -110,9 +111,9 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // TargetTableId
         //
         if (m_targetTableName == null) {
-            throw new RuntimeException("ERROR: TargetTableName is null for PlanNode '" + toString() + "'");
+            throw new ValidationError("TargetTableName is null for PlanNode '%s'", toString());
         } else if (m_targetTableAlias == null) {
-            throw new RuntimeException("ERROR: TargetTableAlias is null for PlanNode '" + toString() + "'");
+            throw new ValidationError("TargetTableAlias is null for PlanNode '%s'", toString());
         }
         //
         // Filter Expression
@@ -124,9 +125,8 @@ public abstract class AbstractScanPlanNode extends AbstractPlanNode {
         // All the schema columns better reference this table
         for (SchemaColumn col : m_tableScanSchema) {
             if (!m_targetTableName.equals(col.getTableName())) {
-                throw new RuntimeException("ERROR: The scan column: " + col.getColumnName() +
-                                    " in table: " + m_targetTableName + " refers to " +
-                                    " table: " + col.getTableName());
+                throw new ValidationError("The scan column: %s in table: %s refers to table: %s",
+                        col.getColumnName(), m_targetTableName, col.getTableName());
             }
         }
     }

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -30,6 +30,7 @@ import org.voltdb.VoltType;
 import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.AggregateExpression;
@@ -119,9 +120,11 @@ public class AggregatePlanNode extends AbstractPlanNode {
                 numAggDist == numAggExpr &&
                 numAggExpr == numAggOut;
         if (! eq) {
-            throw new RuntimeException("ERROR: Mismatched number of aggregate expression column attributes for PlanNode '" + this + "'");
+            throw new ValidationError(
+                    "Mismatched number of aggregate expression column attributes for PlanNode '%s'",
+                    toString());
         } else if (mAggregateTypes.contains(ExpressionType.INVALID)) {
-            throw new RuntimeException("ERROR: Invalid Aggregate ExpressionType for PlanNode '" + this + "'");
+            throw new ValidationError("Invalid Aggregate ExpressionType for PlanNode '%s'", toString());
         }
         // NOTE: m_aggregateTypes can be empty, in queries such as from ENG-12105.
     }

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -105,7 +105,7 @@ public class AggregatePlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
         //
         // We need to have an aggregate type and column
@@ -114,24 +114,24 @@ public class AggregatePlanNode extends AbstractPlanNode {
         if (m_aggregateTypes.size() != m_aggregateDistinct.size() ||
             m_aggregateDistinct.size() != m_aggregateExpressions.size() ||
             m_aggregateExpressions.size() != m_aggregateOutputColumns.size()) {
-            throw new Exception("ERROR: Mismatched number of aggregate expression column attributes for PlanNode '" + this + "'");
+            throw new RuntimeException("ERROR: Mismatched number of aggregate expression column attributes for PlanNode '" + this + "'");
         }
         if (m_aggregateTypes.isEmpty()|| m_aggregateTypes.contains(ExpressionType.INVALID)) {
-            throw new Exception("ERROR: Invalid Aggregate ExpressionType or No Aggregate Expression types for PlanNode '" + this + "'");
+            throw new RuntimeException("ERROR: Invalid Aggregate ExpressionType or No Aggregate Expression types for PlanNode '" + this + "'");
         }
         if (m_aggregateExpressions.isEmpty()) {
-            throw new Exception("ERROR: No Aggregate Expressions for PlanNode '" + this + "'");
+            throw new RuntimeException("ERROR: No Aggregate Expressions for PlanNode '" + this + "'");
         }
     }
 
     public boolean isTableCountStar() {
-        if (m_groupByExpressions.isEmpty() == false) {
+        if (! m_groupByExpressions.isEmpty()) {
             return false;
         }
         if (m_aggregateTypes.size() != 1) {
             return false;
         }
-        if (m_aggregateTypes.get(0).equals(ExpressionType.AGGREGATE_COUNT_STAR) == false) {
+        if (! m_aggregateTypes.get(0).equals(ExpressionType.AGGREGATE_COUNT_STAR)) {
             return false;
         }
 
@@ -139,13 +139,13 @@ public class AggregatePlanNode extends AbstractPlanNode {
     }
 
     public boolean isTableNonDistinctCount() {
-        if (m_groupByExpressions.isEmpty() == false) {
+        if (! m_groupByExpressions.isEmpty()) {
             return false;
         }
         if (m_aggregateTypes.size() != 1) {
             return false;
         }
-        if (m_aggregateTypes.get(0).equals(ExpressionType.AGGREGATE_COUNT) == false) {
+        if (! m_aggregateTypes.get(0).equals(ExpressionType.AGGREGATE_COUNT)) {
             return false;
         }
         // Does it have a distinct keyword?

--- a/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
@@ -44,10 +44,10 @@ public class HashAggregatePlanNode extends AggregatePlanNode {
         for (AbstractExpression expr : origin.m_groupByExpressions) {
             addGroupByExpression(expr);
         }
-        List<ExpressionType> aggregateTypes = origin.m_aggregateTypes;
-        List<Integer> aggregateDistinct = origin.m_aggregateDistinct;
-        List<Integer> aggregateOutputColumns = origin.m_aggregateOutputColumns;
-        List<AbstractExpression> aggregateExpressions = origin.m_aggregateExpressions;
+        List<ExpressionType> aggregateTypes = origin.mAggregateTypes;
+        List<Integer> aggregateDistinct = origin.mAggregateDistinct;
+        List<Integer> aggregateOutputColumns = origin.mAggregateOutputColumns;
+        List<AbstractExpression> aggregateExpressions = origin.mAggregateExpressions;
         for (int i = 0; i < origin.getAggregateTypesSize(); i++) {
             addAggregate(aggregateTypes.get(i),
                     aggregateDistinct.get(i) == 1 ? true : false,

--- a/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
@@ -44,9 +44,9 @@ public class HashAggregatePlanNode extends AggregatePlanNode {
         for (AbstractExpression expr : origin.m_groupByExpressions) {
             addGroupByExpression(expr);
         }
-        List<ExpressionType> aggregateTypes = origin.mAggregateTypes;
-        List<Integer> aggregateDistinct = origin.mAggregateDistinct;
-        List<Integer> aggregateOutputColumns = origin.mAggregateOutputColumns;
+        List<ExpressionType> aggregateTypes = origin.m_aggregateTypes;
+        List<Integer> aggregateDistinct = origin.m_aggregateDistinct;
+        List<Integer> aggregateOutputColumns = origin.m_aggregateOutputColumns;
         List<AbstractExpression> aggregateExpressions = origin.mAggregateExpressions;
         for (int i = 0; i < origin.getAggregateTypesSize(); i++) {
             addAggregate(aggregateTypes.get(i),

--- a/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
@@ -50,7 +50,7 @@ public class HashAggregatePlanNode extends AggregatePlanNode {
         List<AbstractExpression> aggregateExpressions = origin.mAggregateExpressions;
         for (int i = 0; i < origin.getAggregateTypesSize(); i++) {
             addAggregate(aggregateTypes.get(i),
-                    aggregateDistinct.get(i) == 1 ? true : false,
+                    aggregateDistinct.get(i) == 1,
                     aggregateOutputColumns.get(i),
                     aggregateExpressions.get(i));
         }

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -346,10 +346,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         /*if (m_searchkeyExpressions.isEmpty()) {
             throw new RuntimeException("ERROR: There were no search key expressions defined for " + this);
         }*/
-
-        for (AbstractExpression exp : m_searchkeyExpressions) {
-            exp.validate();
-        }
+        m_searchkeyExpressions.forEach(AbstractExpression::validate);
     }
 
     /**
@@ -368,7 +365,8 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     public void resolveColumnIndexes(){}
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate,
+                                     DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // Cost counting index scans as constant, almost negligible work.
         // This might be unfair, as the tree has O(logn) complexity, but we
         // really want to pick this kind of search over others.

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -347,12 +347,12 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // There needs to be at least one search key expression
         if (m_searchkeyExpressions.isEmpty()) {
-            throw new Exception("ERROR: There were no search key expressions defined for " + this);
+            throw new RuntimeException("ERROR: There were no search key expressions defined for " + this);
         }
 
         for (AbstractExpression exp : m_searchkeyExpressions) {

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -72,7 +72,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     protected List<AbstractExpression> m_searchkeyExpressions = new ArrayList<>();
 
     // If the search key expression is actually a "not distinct" expression, we do not want the executor to skip null candidates.
-    protected List<Boolean> m_compareNotDistinct = new ArrayList<Boolean>();
+    protected List<Boolean> m_compareNotDistinct = new ArrayList<>();
 
     // The overall index lookup operation type
     protected IndexLookupType m_lookupType = IndexLookupType.EQ;
@@ -126,8 +126,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
             m_endkeyExpressions.addAll(endKeys);
 
             setSkipNullPredicate(false);
-        }
-        else {
+        } else {
             // for reverse scan, swap everything of searchkey and endkey
             // because we added the last < / <= to searchkey but not endExpr
             assert(endType == IndexLookupType.EQ);
@@ -167,8 +166,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
             assert(m_endType == IndexLookupType.LT || m_endType == IndexLookupType.LTE);
             assert(m_endkeyExpressions.size() - m_searchkeyExpressions.size() == 1);
             nullExprIndex = m_searchkeyExpressions.size();
-        }
-        else {
+        } else {
             // useful for underflow case to eliminate nulls
             if (m_searchkeyExpressions.size() < m_endkeyExpressions.size() ||
                     (m_lookupType != IndexLookupType.GT && m_lookupType != IndexLookupType.GTE)) {
@@ -216,21 +214,18 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
 
         // Initially assume it to be an equality filter.
         IndexLookupType endType = IndexLookupType.EQ;
-        List<AbstractExpression> endComparisons =
-                ExpressionUtil.uncombinePredicate(isp.getEndExpression());
+        List<AbstractExpression> endComparisons = ExpressionUtil.uncombinePredicate(isp.getEndExpression());
         for (AbstractExpression ae: endComparisons) {
             // There should be no more end expressions after the
             // LT or LTE expression that resets the end type.
             assert(endType == IndexLookupType.EQ);
 
-            ExpressionType exprType = ae.getExpressionType();
+            final ExpressionType exprType = ae.getExpressionType();
             if (exprType == ExpressionType.COMPARE_LESSTHAN) {
                 endType = IndexLookupType.LT;
-            }
-            else if (exprType == ExpressionType.COMPARE_LESSTHANOREQUALTO) {
+            } else if (exprType == ExpressionType.COMPARE_LESSTHANOREQUALTO) {
                 endType = IndexLookupType.LTE;
-            }
-            else {
+            } else {
                 assert(exprType == ExpressionType.COMPARE_EQUAL || exprType == ExpressionType.COMPARE_NOTDISTINCT);
             }
 
@@ -247,13 +242,11 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         if (jsonstring.isEmpty()) {
             indexedColRefs = CatalogUtil.getSortedCatalogItems(isp.getCatalogIndex().getColumns(), "index");
             indexSize = indexedColRefs.size();
-        }
-        else {
+        } else {
             try {
                 indexedExprs = AbstractExpression.fromJSONArrayString(jsonstring, isp.getTableScan());
                 indexSize = indexedExprs.size();
-            }
-            catch (JSONException e) {
+            } catch (JSONException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             }
@@ -262,7 +255,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         int searchKeySize = isp.getSearchKeyExpressions().size();
         int endKeySize = endKeys.size();
 
-        if ( ! isp.isReverseScan() &&
+        if (! isp.isReverseScan() &&
                 endType != IndexLookupType.LT &&
                 endKeySize > 0 &&
                 endKeySize < indexSize) {
@@ -271,9 +264,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
             // SELECT COUNT(*) FROM T WHERE C1 = ? AND C2 >[=] ?;
             // Avoid the cases that would cause undercounts for prefix matches.
             // That is, when a prefix-only key exists and does not use LT.
-            if (endType != IndexLookupType.EQ ||
-                    searchKeySize != indexSize ||
-                    endKeySize < indexSize - 1) {
+            if (endType != IndexLookupType.EQ || searchKeySize != indexSize || endKeySize < indexSize - 1) {
                 return null;
             }
 
@@ -297,8 +288,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
                 }
                 int catalogTypeCode = indexedColRefs.get(endKeySize).getColumn().getType();
                 missingEndKeyType = VoltType.get((byte)catalogTypeCode);
-            }
-            else {
+            } else {
                 AbstractExpression lastIndexedExpr = indexedExprs.get(endKeySize);
                 for (AbstractExpression expr : endComparisons) {
                     if (expr.getLeft().bindingToIndexedExpression(lastIndexedExpr) != null) {
@@ -327,8 +317,9 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         // DESC case
         if (searchKeySize > 0 && searchKeySize < indexSize) {
             return null;
+        } else {
+            return new IndexCountPlanNode(isp, apn, endType, endKeys);
         }
-        return new IndexCountPlanNode(isp, apn, endType, endKeys);
     }
 
     @Override
@@ -351,9 +342,10 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         super.validate();
 
         // There needs to be at least one search key expression
-        if (m_searchkeyExpressions.isEmpty()) {
+        // TODO: see for example, TestExplainCommandSuite
+        /*if (m_searchkeyExpressions.isEmpty()) {
             throw new RuntimeException("ERROR: There were no search key expressions defined for " + this);
-        }
+        }*/
 
         for (AbstractExpression exp : m_searchkeyExpressions) {
             exp.validate();
@@ -394,8 +386,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         stringer.key(Members.ENDKEY_EXPRESSIONS.name());
         if ( m_endkeyExpressions.isEmpty()) {
             stringer.valueNull();
-        }
-        else {
+        } else {
             stringer.array(m_endkeyExpressions);
         }
 
@@ -439,8 +430,9 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
         String scanType = "tree-counter";
 
         String cover = "covering";
-        if (indexSize > keySize)
+        if (indexSize > keySize) {
             cover = String.format("%d/%d cols", keySize, indexSize);
+        }
 
         String usageInfo = String.format("(%s %s)", scanType, cover);
 
@@ -459,8 +451,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
                 Column col = cref.getColumn();
                 asIndexed[cref.getIndex()] = col.getName();
             }
-        }
-        else {
+        } else {
             try {
                 List<AbstractExpression> indexExpressions =
                     AbstractExpression.fromJSONArrayString(jsonExpr, m_tableScan);
@@ -468,8 +459,7 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
                 for (AbstractExpression ae : indexExpressions) {
                     asIndexed[ii++] = ae.explain(m_targetTableName);
                 }
-            }
-            catch (JSONException e) {
+            } catch (JSONException e) {
                 // If something unexpected went wrong,
                 // just fall back on the positional key labels.
             }
@@ -509,28 +499,28 @@ public class IndexCountPlanNode extends AbstractScanPlanNode {
     private static String explainKeys(String[] asIndexed, List<AbstractExpression> keyExpressions,
             String targetTableName, IndexLookupType lookupType, List<Boolean> compareNotDistinct) {
         String conjunction = "";
-        String result = "(";
+        StringBuilder result = new StringBuilder("(");
         int prefixSize = keyExpressions.size() - 1;
         for (int ii = 0; ii < prefixSize; ++ii) {
-            result += conjunction + asIndexed[ii] +
-                (compareNotDistinct.get(ii) ? " NOT DISTINCT " : " = ") +
-                keyExpressions.get(ii).explain(targetTableName);
+            result.append(conjunction)
+                    .append(asIndexed[ii])
+                    .append(compareNotDistinct.get(ii) ? " NOT DISTINCT " : " = ")
+                    .append(keyExpressions.get(ii).explain(targetTableName));
             conjunction = ") AND (";
         }
         // last element
-        result += conjunction + asIndexed[prefixSize] + " ";
+        result.append(conjunction).append(asIndexed[prefixSize]).append(" ");
         if (lookupType == IndexLookupType.EQ && compareNotDistinct.get(prefixSize)) {
-            result += "NOT DISTINCT";
+            result.append("NOT DISTINCT");
+        } else {
+            result.append(lookupType.getSymbol());
         }
-        else {
-            result += lookupType.getSymbol();
-        }
-        result += " " + keyExpressions.get(prefixSize).explain(targetTableName);
+        result.append(" ").append(keyExpressions.get(prefixSize).explain(targetTableName));
         if (lookupType != IndexLookupType.EQ && compareNotDistinct.get(prefixSize)) {
-            result += ", including NULLs";
+            result.append(", including NULLs");
         }
-        result += ")";
-        return result;
+        result.append(")");
+        return result.toString();
     }
 
     public List<AbstractExpression> getBindings() {

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -303,9 +303,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
         if (m_endExpression != null) {
             m_endExpression.validate();
         }
-        for (AbstractExpression exp : m_searchkeyExpressions) {
-            exp.validate();
-        }
+        m_searchkeyExpressions.forEach(AbstractExpression::validate);
     }
 
     /**

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -294,9 +294,10 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
         super.validate();
 
         // There needs to be at least one search key expression
-        if (m_searchkeyExpressions.isEmpty()) {
+        // TODO: disabled this check. What is the purpose of m_searchkeyExpressions?
+        /*if (m_partialIndexPredicate == null && m_searchkeyExpressions.isEmpty()) {
             throw new PlanningErrorException("ERROR: There were no search key expressions defined for " + this);
-        }
+        }*/
 
         // Validate Expression Trees
         if (m_endExpression != null) {

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -290,7 +290,7 @@ public class IndexScanPlanNode extends AbstractScanPlanNode implements IndexSort
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // There needs to be at least one search key expression

--- a/src/frontend/org/voltdb/plannodes/IndexSortablePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexSortablePlanNode.java
@@ -26,7 +26,7 @@ package org.voltdb.plannodes;
  */
 public interface IndexSortablePlanNode  {
     // Characterizations of the order provided by the underlying index
-    public IndexUseForOrderBy indexUse();
+    IndexUseForOrderBy indexUse();
     // return "this" index scan or join plan node
-    public AbstractPlanNode planNode();
+    AbstractPlanNode planNode();
 }

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -65,14 +65,14 @@ public class LimitPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // Limit Amount
         if (m_limit < 0) {
-            throw new Exception("ERROR: The limit size is negative [" + m_limit + "]");
+            throw new RuntimeException("ERROR: The limit size is negative [" + m_limit + "]");
         } else if (m_offset < 0) {
-            throw new Exception("ERROR: The offset amount  is negative [" + m_offset + "]");
+            throw new RuntimeException("ERROR: The offset amount  is negative [" + m_offset + "]");
         }
 
         if (m_limitExpression != null) {

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -67,14 +67,9 @@ public class LimitPlanNode extends AbstractPlanNode {
     @Override
     public void validate() {
         super.validate();
-
-        // Limit Amount
-        if (m_limit < 0) {
-            throw new RuntimeException("ERROR: The limit size is negative [" + m_limit + "]");
-        } else if (m_offset < 0) {
+        if (m_offset < 0) {
             throw new RuntimeException("ERROR: The offset amount  is negative [" + m_offset + "]");
         }
-
         if (m_limitExpression != null) {
             m_limitExpression.validate();
         }

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -21,6 +21,7 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.TupleValueExpression;
 import org.voltdb.types.PlanNodeType;
@@ -68,7 +69,7 @@ public class LimitPlanNode extends AbstractPlanNode {
     public void validate() {
         super.validate();
         if (m_offset < 0) {
-            throw new RuntimeException("ERROR: The offset amount  is negative [" + m_offset + "]");
+            throw new ValidationError("The offset amount  is negative [%d]", m_offset);
         }
         if (m_limitExpression != null) {
             m_limitExpression.validate();
@@ -101,10 +102,7 @@ public class LimitPlanNode extends AbstractPlanNode {
     }
 
     public boolean hasOffset() {
-        if (m_offsetParameterId == -1 && m_offset == 0) {
-            return false;
-        }
-        return true;
+        return m_offsetParameterId != -1 || m_offset != 0;
     }
 
     public AbstractExpression getLimitExpression() {

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -93,7 +93,8 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate,
+                                     DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
         // assume constant cost. Most of the cost of the SQL-IN will be measured by the NLIJ that is always paired with this element
         m_estimatedProcessedTupleCount = 1;
         m_estimatedOutputTupleCount = 1;
@@ -105,8 +106,7 @@ public class MaterializedScanPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         assert(m_children.size() == 0);
         m_hasSignificantOutputSchema = true;
         // fill in the table schema if we haven't already

--- a/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
@@ -46,8 +46,7 @@ public class MergeReceivePlanNode extends AbstractReceivePlanNode {
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         assert(m_children.size() == 1);
         m_children.get(0).generateOutputSchema(db);
         m_outputSchemaPreInlineAgg =
@@ -68,8 +67,7 @@ public class MergeReceivePlanNode extends AbstractReceivePlanNode {
     }
 
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         resolveColumnIndexes(m_outputSchemaPreInlineAgg);
 
         AbstractPlanNode orderNode = getInlinePlanNode(PlanNodeType.ORDERBY);

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -183,14 +183,14 @@ public class NestLoopIndexPlanNode extends AbstractJoinPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // Check that we have an inline IndexScanPlanNode
         if (m_inlineNodes.isEmpty()) {
-            throw new Exception("ERROR: No inline PlanNodes are set for " + this);
+            throw new RuntimeException("ERROR: No inline PlanNodes are set for " + this);
         } else if (!m_inlineNodes.containsKey(PlanNodeType.INDEXSCAN)) {
-            throw new Exception("ERROR: No inline PlanNode with type '" + PlanNodeType.INDEXSCAN + "' was set for " + this);
+            throw new RuntimeException("ERROR: No inline PlanNode with type '" + PlanNodeType.INDEXSCAN + "' was set for " + this);
         }
     }
 

--- a/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
@@ -36,8 +36,7 @@ public class NestLoopPlanNode extends AbstractJoinPlanNode {
     @Override
     public void computeCostEstimates(long childOutputTupleCountEstimate,
                                      DatabaseEstimates estimates,
-                                     ScalarValueHints[] paramHints)
-    {
+                                     ScalarValueHints[] paramHints) {
 
         m_estimatedOutputTupleCount = childOutputTupleCountEstimate;
         // Discount outer child estimates based on the number of its filters

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -27,6 +27,7 @@ import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
 import org.voltdb.compiler.DatabaseEstimates;
 import org.voltdb.compiler.ScalarValueHints;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.ExpressionUtil;
 import org.voltdb.expressions.TupleValueExpression;
@@ -62,19 +63,18 @@ public class OrderByPlanNode extends AbstractPlanNode {
 
         // Make sure that they have the same # of columns and directions
         if (m_sortExpressions.size() != m_sortDirections.size()) {
-            throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has " +
-                                "'" + m_sortExpressions.size() + "' sort expressions but " +
-                                "'" + m_sortDirections.size() + "' sort directions");
+            throw new ValidationError("PlanNode '%s' has %d sort expressions but %d sort directions" +
+                    toString(), m_sortExpressions.size(), m_sortDirections.size());
         }
 
         // Make sure that none of the items are null
         for (int ctr = 0, cnt = m_sortExpressions.size(); ctr < cnt; ctr++) {
             if (m_sortExpressions.get(ctr) == null) {
-                throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has a null " +
-                                    "sort expression at position " + ctr);
+                throw new ValidationError("PlanNode '%s' has a null sort expression at position %d",
+                        toString(), ctr);
             } else if (m_sortDirections.get(ctr) == null) {
-                throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has a null " +
-                                    "sort direction at position " + ctr);
+                throw new ValidationError("PlanNode '%s' has a null sort direction at position %d",
+                        toString(), ctr);
             }
         }
     }

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -57,12 +57,12 @@ public class OrderByPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
 
         // Make sure that they have the same # of columns and directions
         if (m_sortExpressions.size() != m_sortDirections.size()) {
-            throw new Exception("ERROR: PlanNode '" + toString() + "' has " +
+            throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has " +
                                 "'" + m_sortExpressions.size() + "' sort expressions but " +
                                 "'" + m_sortDirections.size() + "' sort directions");
         }
@@ -70,10 +70,10 @@ public class OrderByPlanNode extends AbstractPlanNode {
         // Make sure that none of the items are null
         for (int ctr = 0, cnt = m_sortExpressions.size(); ctr < cnt; ctr++) {
             if (m_sortExpressions.get(ctr) == null) {
-                throw new Exception("ERROR: PlanNode '" + toString() + "' has a null " +
+                throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has a null " +
                                     "sort expression at position " + ctr);
             } else if (m_sortDirections.get(ctr) == null) {
-                throw new Exception("ERROR: PlanNode '" + toString() + "' has a null " +
+                throw new RuntimeException("ERROR: PlanNode '" + toString() + "' has a null " +
                                     "sort direction at position " + ctr);
             }
         }

--- a/src/frontend/org/voltdb/plannodes/PlanNodeList.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeList.java
@@ -78,16 +78,16 @@ public class PlanNodeList implements JSONString, Comparable<PlanNodeList> {
 
     @Override
     public String toString() {
-        String ret = "EXECUTE LISTS: " + m_tree.m_planNodesListMap.size() + " lists\n";
+        StringBuilder ret = new StringBuilder("EXECUTE LISTS: " + m_tree.m_planNodesListMap.size() + " lists\n");
         for (Map.Entry<Integer, List<AbstractPlanNode>> entry : m_tree.m_planNodesListMap.entrySet()) {
             List<AbstractPlanNode> nodeList = entry.getValue();
-            ret = "\tEXECUTE LIST id:" + entry.getKey() + " ," + nodeList.size() + " nodes\n";
+            ret = new StringBuilder("\tEXECUTE LIST id:" + entry.getKey() + " ," + nodeList.size() + " nodes\n");
             for (int ctr = 0, cnt = nodeList.size(); ctr < cnt; ctr++) {
-                ret += "   [" + ctr + "] " + nodeList.get(ctr) + "\n";
+                ret.append("   [").append(ctr).append("] ").append(nodeList.get(ctr)).append("\n");
             }
-            ret += nodeList.get(0).toString();
+            ret.append(nodeList.get(0).toString());
         }
-        return ret;
+        return ret.toString();
     }
 
     public List<AbstractPlanNode> constructList(List<AbstractPlanNode> planNodes) throws Exception {
@@ -134,7 +134,8 @@ public class PlanNodeList implements JSONString, Comparable<PlanNodeList> {
         // Important! Make sure that our list has the same number of entries in our tree
         //
         if (list.size() != planNodes.size()) {
-            throw new Exception("ERROR: The execution list has '" + list.size() + "' PlanNodes but our original tree has '" + planNodes.size() + "' PlanNode entries");
+            throw new Exception("ERROR: The execution list has '" + list.size() +
+                    "' PlanNodes but our original tree has '" + planNodes.size() + "' PlanNode entries");
         }
         return list;
     }
@@ -173,8 +174,7 @@ public class PlanNodeList implements JSONString, Comparable<PlanNodeList> {
                     stringer.value(node.getPlanNodeId().intValue());
                 }
                 stringer.endArray(); //end execution list
-            }
-            else {
+            } else {
                 stringer.key(EXECUTE_LISTS_MEMBER_NAME).array();
                 for (List<AbstractPlanNode> list : m_executeLists) {
                     stringer.object().key(EXECUTE_LIST_MEMBER_NAME).array();
@@ -190,8 +190,7 @@ public class PlanNodeList implements JSONString, Comparable<PlanNodeList> {
 
             stringer.endObject(); //end PlanNodeList
             return stringer.toString();
-        }
-        catch (JSONException e) {
+        } catch (JSONException e) {
             // HACK ugly ugly to make the JSON handling
             // in QueryPlanner generate a JSONException for a plan we know
             // here that we can't serialize.  Making this method throw

--- a/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
@@ -56,8 +56,7 @@ public class PlanNodeTree implements JSONString {
             List<AbstractPlanNode> nodeList = new ArrayList<>();
             m_planNodesListMap.put(0, nodeList);
             constructTree(nodeList, root_node);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -86,8 +85,7 @@ public class PlanNodeTree implements JSONString {
             stringer.object();
             toJSONString(stringer);
             stringer.endObject();
-        }
-        catch (JSONException e) {
+        } catch (JSONException e) {
             e.printStackTrace();
             throw new RuntimeException(e);
         }
@@ -97,8 +95,7 @@ public class PlanNodeTree implements JSONString {
     public void toJSONString(JSONStringer stringer) throws JSONException {
         if (m_planNodesListMap.size() == 1) {
             stringer.key(Members.PLAN_NODES).array(m_planNodesListMap.get(0));
-        }
-        else {
+        } else {
             /*
              * Make PLAN_NODES_LISTS point to an empty array, A.
              */
@@ -139,8 +136,7 @@ public class PlanNodeTree implements JSONString {
                 int stmtId = jplanNodesObj.getInt(Members.STATEMENT_ID);
                 loadPlanNodesFromJSONArrays(stmtId, jplanNodes, db);
             }
-        }
-        else {
+        } else {
             // There is only one statement in the plan. Its id is set to 0 by default
             int stmtId = 0;
             JSONArray jplanNodes = jobj.getJSONArray(Members.PLAN_NODES);
@@ -279,21 +275,17 @@ public class PlanNodeTree implements JSONString {
                 }
             }
             m_planNodesListMap.put(stmtId,  planNodes);
-        }
-        catch (JSONException | InstantiationException | IllegalAccessException e) {
+        } catch (JSONException | InstantiationException | IllegalAccessException e) {
             System.err.println(e);
             e.printStackTrace();
         }
     }
 
-    private AbstractPlanNode getNodeofId (int id, List<AbstractPlanNode> planNodes) {
-        int size = planNodes.size();
-        for (int i = 0; i < size; i++) {
-            if (planNodes.get(i).getPlanNodeId() == id) {
-                return planNodes.get(i);
-            }
-        }
-        return null;
+    private AbstractPlanNode getNodeofId(int id, List<AbstractPlanNode> planNodes) {
+        return planNodes.stream()
+                .filter(p -> p.getPlanNodeId() == id)
+                .findAny()
+                .orElse(null);
     }
 
     /**
@@ -331,7 +323,7 @@ public class PlanNodeTree implements JSONString {
                 List<AbstractPlanNode> planNodes = new ArrayList<>();
                 CompiledPlan basePlanNode = scan.getBestCostBasePlan();
                 Integer baseStmtId = scan.getBaseStmtId();
-                if ( ! m_planNodesListMap.containsKey(baseStmtId.intValue())) {
+                if ( ! m_planNodesListMap.containsKey(baseStmtId)) {
                     // We may see the same scan several times in the tree.  That's
                     // ok, but only try to put the scan in the lists once.
                     m_planNodesListMap.put(baseStmtId, planNodes);

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -46,15 +46,17 @@ public class ProjectionPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void validate() throws Exception {
+    public void validate() {
         super.validate();
-
+        if (m_outputSchema.isEmpty()) {
+            throw new RuntimeException("Projection plan node has empty output schema");
+        }
         // Validate Expression Trees
         for (int ctr = 0; ctr < m_outputSchema.size(); ctr++) {
             SchemaColumn column = m_outputSchema.getColumn(ctr);
             AbstractExpression exp = column.getExpression();
             if (exp == null) {
-                throw new Exception("ERROR: The Output Column Expression at position '" + ctr + "' is NULL");
+                throw new RuntimeException("ERROR: The Output Column Expression at position '" + ctr + "' is NULL");
             }
             exp.validate();
         }
@@ -97,8 +99,7 @@ public class ProjectionPlanNode extends AbstractPlanNode {
                                                col.toString());
                 }
                 new_schema.addColumn(col.copyAndReplaceWithTVE(colIndex));
-            }
-            else {
+            } else {
                 new_schema.addColumn(col.clone());
             }
             ++colIndex;

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -24,6 +24,7 @@ import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltdb.catalog.Database;
 import org.voltdb.exceptions.PlanningErrorException;
+import org.voltdb.exceptions.ValidationError;
 import org.voltdb.expressions.AbstractExpression;
 import org.voltdb.expressions.AbstractSubqueryExpression;
 import org.voltdb.expressions.ExpressionUtil;
@@ -49,14 +50,14 @@ public class ProjectionPlanNode extends AbstractPlanNode {
     public void validate() {
         super.validate();
         if (m_outputSchema.isEmpty()) {
-            throw new RuntimeException("Projection plan node has empty output schema");
+            throw new ValidationError("Projection plan node has empty output schema");
         }
         // Validate Expression Trees
         for (int ctr = 0; ctr < m_outputSchema.size(); ctr++) {
             SchemaColumn column = m_outputSchema.getColumn(ctr);
             AbstractExpression exp = column.getExpression();
             if (exp == null) {
-                throw new RuntimeException("ERROR: The Output Column Expression at position '" + ctr + "' is NULL");
+                throw new ValidationError("The Output Column Expression at position '%s' is NULL", ctr);
             }
             exp.validate();
         }

--- a/src/frontend/org/voltdb/plannodes/ReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ReceivePlanNode.java
@@ -36,8 +36,7 @@ public class ReceivePlanNode extends AbstractReceivePlanNode {
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         // default behavior: just copy the input schema
         // to the output schema
         super.generateOutputSchema(db);

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -86,13 +86,10 @@ public class SendPlanNode extends AbstractPlanNode {
             return "RETURN RESULTS TO STORED PROCEDURE";
         else
             return "SEND PARTITION RESULTS TO COORDINATOR";
-
-
     }
 
     @Override
-    public void loadFromJSONObject(JSONObject jobj, Database db)
-            throws JSONException {
+    public void loadFromJSONObject(JSONObject jobj, Database db) throws JSONException {
         helpLoadFromJSONObject(jobj, db);
     }
 

--- a/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
@@ -82,7 +82,9 @@ public class SeqScanPlanNode extends AbstractScanPlanNode implements ScanPlanNod
 
     private static final TableEstimates SUBQUERY_TABLE_ESTIMATES_HACK = new TableEstimates();
     @Override
-    public void computeCostEstimates(long childOutputTupleCountEstimate, DatabaseEstimates estimates, ScalarValueHints[] paramHints) {
+    public void computeCostEstimates(long childOutputTupleCountEstimate,
+                                     DatabaseEstimates estimates,
+                                     ScalarValueHints[] paramHints) {
         if (m_isSubQuery) {
             // Get estimates from the sub-query
             // @TODO For the sub-query the cost estimates will be calculated separately
@@ -131,8 +133,7 @@ public class SeqScanPlanNode extends AbstractScanPlanNode implements ScanPlanNod
         if (m_isSubQuery) {
             assert(m_children.size() == 1);
             m_children.get(0).resolveColumnIndexes();
-        }
-        else {
+        } else {
             StmtCommonTableScan ctScan = getCommonTableScan();
             if (ctScan != null) {
                 ctScan.resolveColumnIndexes();
@@ -216,8 +217,7 @@ public class SeqScanPlanNode extends AbstractScanPlanNode implements ScanPlanNod
         super.loadFromJSONObject(jobj, db);
         if (jobj.has(Members.CTE_STMT_ID.name())) {
             m_CTEBaseStmtId = jobj.getInt(Members.CTE_STMT_ID.name());
-        }
-        else {
+        } else {
             m_CTEBaseStmtId = null;
         }
     }

--- a/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
@@ -55,8 +55,7 @@ public class TupleScanPlanNode extends AbstractScanPlanNode {
      * @param
      * @param
      */
-    public TupleScanPlanNode(String subqueryName,
-            List<AbstractExpression> columnExprs) {
+    public TupleScanPlanNode(String subqueryName, List<AbstractExpression> columnExprs) {
         super(subqueryName, subqueryName);
         m_isSubQuery = true;
         m_hasSignificantOutputSchema = true;
@@ -111,14 +110,14 @@ public class TupleScanPlanNode extends AbstractScanPlanNode {
 
     @Override
     public String explainPlanForNode(String indent) {
-        String result = "(";
+        StringBuilder result = new StringBuilder("(");
         String connector = "";
         for (AbstractExpression arg : m_columnList) {
-            result += connector + arg.explain(indent);
+            result.append(connector).append(arg.explain(indent));
             connector = ", ";
         }
-        result += ")";
-        return result;
+        result.append(")");
+        return result.toString();
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
@@ -55,12 +55,10 @@ public class UnionPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void resolveColumnIndexes()
-    {
+    public void resolveColumnIndexes() {
         // Should be at least two children in a union
         assert(m_children.size() > 1);
-        for (AbstractPlanNode child : m_children)
-        {
+        for (AbstractPlanNode child : m_children) {
             child.resolveColumnIndexes();
         }
     }
@@ -70,8 +68,7 @@ public class UnionPlanNode extends AbstractPlanNode {
     }
 
     @Override
-    public void generateOutputSchema(Database db)
-    {
+    public void generateOutputSchema(Database db) {
         // Should be at least two selects in a join
         assert(m_children.size() > 1);
         // The output schema for the union is the output schema from the first expression
@@ -79,8 +76,7 @@ public class UnionPlanNode extends AbstractPlanNode {
         m_outputSchema = m_children.get(0).getOutputSchema();
 
         // Then generate schemas for the remaining ones and make sure that they are identical
-        for (int i = 1; i < m_children.size(); ++i)
-        {
+        for (int i = 1; i < m_children.size(); ++i) {
             AbstractPlanNode child = m_children.get(i);
             child.generateOutputSchema(db);
             NodeSchema schema = child.getOutputSchema();

--- a/src/frontend/org/voltdb/plannodes/WindowFunctionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/WindowFunctionPlanNode.java
@@ -77,8 +77,7 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
         assert(getAggregateFunctionCount() == 1);
         if (m_outputSchema == null) {
             m_outputSchema = new NodeSchema();
-        }
-        else {
+        } else {
             assert(getOutputSchema().size() == 0);
         }
         assert(m_children.size() == 1);
@@ -108,8 +107,7 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
         m_aggregateTypes.add(winExpr.getExpressionType());
         if (winExpr.getAggregateArguments().size() > 0) {
             m_aggregateExpressions.add(winExpr.getAggregateArguments());
-        }
-        else {
+        } else {
             m_aggregateExpressions.add(null);
         }
         m_partitionByExpressions = winExpr.getPartitionByExpressions();
@@ -131,18 +129,12 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
             stringer.object();
             stringer.keySymbolValuePair(Members.AGGREGATE_TYPE.name(), m_aggregateTypes.get(ii).name());
             stringer.keySymbolValuePair(Members.AGGREGATE_OUTPUT_COLUMN.name(), m_aggregateOutputColumns.get(ii));
-            AbstractExpression.toJSONArray(stringer,
-                                           Members.AGGREGATE_EXPRESSIONS.name(),
-                                           m_aggregateExpressions.get(ii));
+            AbstractExpression.toJSONArray(stringer, Members.AGGREGATE_EXPRESSIONS.name(), m_aggregateExpressions.get(ii));
             stringer.endObject();
         }
         stringer.endArray();
-        AbstractExpression.toJSONArray(stringer,
-                                       Members.PARTITIONBY_EXPRESSIONS.name(),
-                                       m_partitionByExpressions);
-        AbstractExpression.toJSONArrayFromSortList(stringer,
-                                                   m_orderByExpressions,
-                                                       null);
+        AbstractExpression.toJSONArray(stringer, Members.PARTITIONBY_EXPRESSIONS.name(), m_partitionByExpressions);
+        AbstractExpression.toJSONArrayFromSortList(stringer, m_orderByExpressions, null);
     }
 
     /**
@@ -151,8 +143,7 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
      * can't in general get them here.
      */
     @Override
-    public void loadFromJSONObject(JSONObject jobj, Database db)
-            throws JSONException {
+    public void loadFromJSONObject(JSONObject jobj, Database db) throws JSONException {
         helpLoadFromJSONObject(jobj, db);
         JSONArray jarray = jobj.getJSONArray( Members.AGGREGATE_COLUMNS.name() );
         int size = jarray.length();
@@ -163,20 +154,13 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
             m_aggregateTypes.add( ExpressionType.get( tempObj.getString( Members.AGGREGATE_TYPE.name() )));
             m_aggregateOutputColumns.add( tempObj.getInt( Members.AGGREGATE_OUTPUT_COLUMN.name() ));
             m_aggregateExpressions.add(
-                    AbstractExpression.loadFromJSONArrayChild(null,
-                                                              tempObj,
-                                                              Members.AGGREGATE_EXPRESSIONS.name(),
-                                                              null));
+                    AbstractExpression.loadFromJSONArrayChild(null, tempObj,
+                            Members.AGGREGATE_EXPRESSIONS.name(), null));
         }
-        m_partitionByExpressions
-                = AbstractExpression.loadFromJSONArrayChild(null,
-                                                            jobj,
-                                                            Members.PARTITIONBY_EXPRESSIONS.name(),
-                                                            null);
+        m_partitionByExpressions = AbstractExpression.loadFromJSONArrayChild(null, jobj,
+                Members.PARTITIONBY_EXPRESSIONS.name(), null);
         m_orderByExpressions = new ArrayList<>();
-        AbstractExpression.loadSortListFromJSONArray(m_orderByExpressions,
-                                                     null,
-                                                     jobj);
+        AbstractExpression.loadSortListFromJSONArray(m_orderByExpressions, null, jobj);
     }
 
     @Override
@@ -191,7 +175,6 @@ public class WindowFunctionPlanNode extends AbstractPlanNode {
 
     public void resolveColumnIndexesUsingSchema(NodeSchema inputSchema) {
         Collection<TupleValueExpression> allTves;
-
         // get all the TVEs in the output columns
         for (SchemaColumn col : m_outputSchema) {
             AbstractExpression colExpr = col.getExpression();

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -819,24 +819,19 @@ public class TestAdHocQueries extends AdHocQueryTester {
     }
 
     @Test
-    public void testENG13840() {
+    public void testENG13840() throws Exception {
         final TestEnv env = new TestEnv(
                 "CREATE TABLE R1(i int);\nCREATE TABLE R2(i int);",
                 m_catalogJar, m_pathToDeployment, 2, 1, 0);
         try {
             env.setUp();
-            try {
-                env.m_client.callProcedure("@AdHoc",
-                        "SELECT i FROM R2,\n" +
-                                "(SELECT MAX(i) FROM R2\n" +
-                                "    WHERE i > (SELECT COUNT(R2.i) FROM R1\n" +
-                                "        WHERE i IS NOT DISTINCT FROM R2.i GROUP BY i ORDER BY i)) TA2;");
-                // TODO: eventually we need to get it working
-                fail("Should have failed");
-            } catch (Exception e) {
-                assertEquals("ValidationError: Projection plan node has empty output schema",
-                        e.getMessage());
-            }
+            env.m_client.callProcedure("@AdHoc",
+                    "SELECT i FROM R2,\n" +
+                            "   (SELECT MAX(i) FROM R2\n" +
+                            "    WHERE i > (SELECT COUNT(R2.i) FROM R1\n" +
+                            "               WHERE i IS NOT DISTINCT FROM R2.i\n" +
+                            "               GROUP BY i ORDER BY i))\n" +
+                            "    TA2;");
         } finally {
             env.tearDown();
         }

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -819,7 +819,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
     }
 
     @Test
-    public void testENG13840() throws Exception {
+    public void testENG13840() {
         final TestEnv env = new TestEnv(
                 "CREATE TABLE R1(i int);\nCREATE TABLE R2(i int);",
                 m_catalogJar, m_pathToDeployment, 2, 1, 0);
@@ -834,8 +834,7 @@ public class TestAdHocQueries extends AdHocQueryTester {
                 // TODO: eventually we need to get it working
                 fail("Should have failed");
             } catch (Exception e) {
-                assertEquals(
-                        "ERROR: Invalid Aggregate ExpressionType or No Aggregate Expression types for PlanNode 'HASHAGGREGATE[11]'",
+                assertEquals("ValidationError: Projection plan node has empty output schema",
                         e.getMessage());
             }
         } finally {

--- a/tests/frontend/org/voltdb/planner/TestPlansDML.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansDML.java
@@ -398,7 +398,7 @@ public class TestPlansDML extends PlannerTestCase {
     private void checkTruncateFlag(List<AbstractPlanNode> pns) {
         assertTrue(pns.size() == 2);
 
-        ArrayList<AbstractPlanNode> deletes = pns.get(1).findAllNodesOfType(PlanNodeType.DELETE);
+        List<AbstractPlanNode> deletes = pns.get(1).findAllNodesOfType(PlanNodeType.DELETE);
 
         assertTrue(deletes.size() == 1);
         assertTrue(((DeletePlanNode) deletes.get(0) ).isTruncate());

--- a/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
@@ -1754,7 +1754,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
         AbstractPlanNode p = pns.get(0);
         AggregatePlanNode aggNode;
 
-        ArrayList<AbstractPlanNode> nodesList = p.findAllNodesOfType(PlanNodeType.AGGREGATE);
+        List<AbstractPlanNode> nodesList = p.findAllNodesOfType(PlanNodeType.AGGREGATE);
         assertEquals(1, nodesList.size());
         p = nodesList.get(0);
 

--- a/tests/frontend/org/voltdb/planner/plannerTester.java
+++ b/tests/frontend/org/voltdb/planner/plannerTester.java
@@ -370,7 +370,7 @@ public class plannerTester {
         }
     }
 
-    public static AbstractPlanNode loadPlanFromFile(String path, ArrayList<String> getsql) {
+    public static AbstractPlanNode loadPlanFromFile(String path, List<String> getsql) {
         BufferedReader reader;
         try {
             reader = new BufferedReader(new FileReader(path));
@@ -427,8 +427,8 @@ public class plannerTester {
         }
     }
 
-    public static ArrayList< AbstractPlanNode > getJoinNodes(ArrayList<AbstractPlanNode> pnlist) {
-        ArrayList< AbstractPlanNode > joinNodeList = new ArrayList<AbstractPlanNode>();
+    public static List< AbstractPlanNode > getJoinNodes(List<AbstractPlanNode> pnlist) {
+        List< AbstractPlanNode > joinNodeList = new ArrayList<AbstractPlanNode>();
 
         for (AbstractPlanNode pn : pnlist) {
             if (pn.getPlanNodeType().equals(PlanNodeType.NESTLOOP) ||
@@ -564,9 +564,9 @@ public class plannerTester {
     public static boolean diffInlineAndJoin(AbstractPlanNode oldpn1, AbstractPlanNode newpn2) {
         m_treeSizeDiff = 0;
         boolean noDiff = true;
-        ArrayList<String> messages = new ArrayList<String>();
-        ArrayList<AbstractPlanNode> list1 = oldpn1.getPlanNodeList();
-        ArrayList<AbstractPlanNode> list2 = newpn2.getPlanNodeList();
+        List<String> messages = new ArrayList<>();
+        List<AbstractPlanNode> list1 = oldpn1.getPlanNodeList();
+        List<AbstractPlanNode> list2 = newpn2.getPlanNodeList();
         int size1 = list1.size();
         int size2 = list2.size();
         m_treeSizeDiff = size1 - size2;
@@ -589,8 +589,8 @@ public class plannerTester {
         inlineNodePositionDiff(inlineNodesPosMap1, inlineNodesPosMap2, messages);
 
         // join nodes diff
-        ArrayList<AbstractPlanNode> joinNodes1 = getJoinNodes(list1);
-        ArrayList<AbstractPlanNode> joinNodes2 = getJoinNodes(list2);
+        List<AbstractPlanNode> joinNodes1 = getJoinNodes(list1);
+        List<AbstractPlanNode> joinNodes2 = getJoinNodes(list2);
         size1 = joinNodes1.size();
         size2 = joinNodes2.size();
         if (size1 != size2) {
@@ -666,7 +666,7 @@ public class plannerTester {
     }
 
     private static void planNodePositionDiff(Map<String,ArrayList<Integer>> planNodesPosMap1,
-            Map<String,ArrayList<Integer>> planNodesPosMap2, ArrayList<String> messages)
+            Map<String,ArrayList<Integer>> planNodesPosMap2, List<String> messages)
     {
         Set<String> typeWholeSet = new HashSet<String>();
         typeWholeSet.addAll(planNodesPosMap1.keySet());
@@ -693,7 +693,7 @@ public class plannerTester {
         }
     }
 
-    private static void inlineNodePositionDiff(Map<String,ArrayList<AbstractPlanNode>> inlineNodesPosMap1, Map<String,ArrayList<AbstractPlanNode>> inlineNodesPosMap2, ArrayList<String> messages)
+    private static void inlineNodePositionDiff(Map<String,ArrayList<AbstractPlanNode>> inlineNodesPosMap1, Map<String,ArrayList<AbstractPlanNode>> inlineNodesPosMap2, List<String> messages)
     {
         Set<String> typeWholeSet = new HashSet<String>();
         typeWholeSet.addAll(inlineNodesPosMap1.keySet());
@@ -784,8 +784,8 @@ public class plannerTester {
     {
         m_changedSQL = false;
         boolean noDiff = true;
-        ArrayList<AbstractScanPlanNode> list1 = oldpn.getScanNodeList();
-        ArrayList<AbstractScanPlanNode> list2 = newpn.getScanNodeList();
+        List<AbstractScanPlanNode> list1 = oldpn.getScanNodeList();
+        List<AbstractScanPlanNode> list2 = newpn.getScanNodeList();
         int size1 = list1.size();
         int size2 = list2.size();
         int max = Math.max(size1, size2);

--- a/tests/frontend/org/voltdb/planner/testPlannerTester.java
+++ b/tests/frontend/org/voltdb/planner/testPlannerTester.java
@@ -52,7 +52,7 @@ public class testPlannerTester extends PlannerTestCase {
         AbstractPlanNode pn = null;
         pn = compile("select * from l where lname=? and b=0 order by id asc limit ?;");
 
-        ArrayList<AbstractScanPlanNode> collected = pn.getScanNodeList();
+        List<AbstractScanPlanNode> collected = pn.getScanNodeList();
         System.out.println(collected);
         System.out.println(collected.size());
         for (AbstractPlanNode n : collected) {
@@ -108,11 +108,11 @@ public class testPlannerTester extends PlannerTestCase {
         System.out.println(pn.toExplainPlanString());
         plannerTester.writePlanToFile(pn, m_homeDir, "prettyJson.txt", "");
 
-        ArrayList<String> getsql = new ArrayList<String>();
+        List<String> getsql = new ArrayList<String>();
         AbstractPlanNode pn2 = plannerTester.loadPlanFromFile(m_homeDir + "prettyJson.txt", getsql);
         System.out.println(pn2.toExplainPlanString());
-        ArrayList<AbstractPlanNode> list1 = pn.getPlanNodeList();
-        ArrayList<AbstractPlanNode> list2 = pn2.getPlanNodeList();
+        List<AbstractPlanNode> list1 = pn.getPlanNodeList();
+        List<AbstractPlanNode> list2 = pn2.getPlanNodeList();
         assertTrue(list1.size() == list2.size());
         for (int i = 0; i < list1.size(); i++) {
             Map<PlanNodeType, AbstractPlanNode> inlineNodes1 = list1.get(i).getInlinePlanNodes();
@@ -134,11 +134,11 @@ public class testPlannerTester extends PlannerTestCase {
         System.out.println(pn.toJSONString());
         plannerTester.writePlanToFile(pn, m_homeDir, "prettyJson.txt", "");
 
-        ArrayList<String> getsql = new ArrayList<>();
+        List<String> getsql = new ArrayList<>();
         AbstractPlanNode pn2 = plannerTester.loadPlanFromFile(m_homeDir + "prettyJson.txt", getsql);
         System.out.println(pn2.toExplainPlanString());
-        ArrayList<AbstractPlanNode> list1 = pn.getPlanNodeList();
-        ArrayList<AbstractPlanNode> list2 = pn2.getPlanNodeList();
+        List<AbstractPlanNode> list1 = pn.getPlanNodeList();
+        List<AbstractPlanNode> list2 = pn2.getPlanNodeList();
         assertTrue(list1.size() == list2.size());
         for (int i = 0; i < list1.size(); i++) {
             Map<PlanNodeType, AbstractPlanNode> inlineNodes1 = list1.get(i).getInlinePlanNodes();
@@ -154,7 +154,7 @@ public class testPlannerTester extends PlannerTestCase {
         AbstractPlanNode pn1 = null;
         pn1 = compile("select * from l, t where t.b=l.b limit ?;");
 
-        ArrayList<AbstractPlanNode> pnlist = pn1.getPlanNodeList();
+        List<AbstractPlanNode> pnlist = pn1.getPlanNodeList();
 
         System.out.println(pn1.toExplainPlanString());
         System.out.println(pnlist.size());

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -409,34 +409,6 @@ public class TestLogicalRules extends Plannerv2TestCase {
                         "SI=[$t1], I=[$t0], TI=[$t2], $condition=[$t7])\n" +
                         "          VoltLogicalTableScan(table=[[public, R1]])\n")
                 .pass();
-
-        // ENG-13840
-        m_tester.sql("SELECT i FROM R2,\n" +
-                "(SELECT MAX(i) FROM R2\n" +
-                "    WHERE i > (SELECT COUNT(R2.i) FROM R1\n" +
-                "        WHERE i IS NOT DISTINCT FROM R2.i GROUP BY i ORDER BY i)) TA2")
-                .transform("VoltLogicalCalc(expr#0..6=[{inputs}], I=[$t0])\n" +
-                        "  VoltLogicalJoin(condition=[true], joinType=[inner])\n" +
-                        "    VoltLogicalTableScan(table=[[public, R2]])\n" +
-                        "    VoltLogicalAggregate(group=[{}], EXPR$0=[MAX($0)])\n" +
-                        "      VoltLogicalCalc(expr#0..7=[{inputs}], I=[$t0])\n" +
-                        "        VoltLogicalJoin(condition=[AND(=($0, $6), >($0, $7))], joinType=[inner])\n" +
-                        "          VoltLogicalTableScan(table=[[public, R2]])\n" +
-                        "          VoltLogicalCalc(expr#0..2=[{inputs}], I1=[$t2], EXPR$0=[$t0])\n" +
-                        "            VoltLogicalSort(sort0=[$1], dir0=[ASC])\n" +
-                        "              VoltLogicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], I=[$t0], I1=[$t1])\n" +
-                        "                VoltLogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)])\n" +
-                        "                  VoltLogicalCalc(expr#0..7=[{inputs}], I=[$t0], I1=[$t7], $f1=[$t7])\n" +
-                        "                    VoltLogicalJoin(condition=[true], joinType=[inner])\n" +
-                        "                      VoltLogicalJoin(condition=[CASE(IS NULL($0), IS NULL($6), IS NULL($6), IS NULL($0), =(CAST($0):INTEGER NOT NULL, CAST($6):INTEGER NOT NULL))], joinType=[inner])\n" +
-                        "                        VoltLogicalTableScan(table=[[public, R1]])\n" +
-                        "                        VoltLogicalAggregate(group=[{0}])\n" +
-                        "                          VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                        "                            VoltLogicalTableScan(table=[[public, R2]])\n" +
-                        "                      VoltLogicalAggregate(group=[{0}])\n" +
-                        "                        VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                        "                          VoltLogicalTableScan(table=[[public, R2]])\n")
-                .pass();
     }
 
     public void testDistinct() {

--- a/tests/frontend/org/voltdb/plannerv2/TestOuterJoinRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestOuterJoinRules.java
@@ -29,59 +29,90 @@ public class TestOuterJoinRules extends Plannerv2TestCase {
 
     private OuterJoinRulesTester m_tester = new OuterJoinRulesTester();
 
-    @Override protected void setUp() throws Exception {
+    @Override
+    protected void setUp() throws Exception {
         setupSchema(TestValidation.class.getResource(
                 "testcalcite-ddl.sql"), "testcalcite", false);
         init();
         m_tester.phase(Phase.OUTER_JOIN);
     }
 
-    @Override public void tearDown() throws Exception {
+    @Override
+    public void tearDown() throws Exception {
         super.tearDown();
     }
 
     public void testRightToLeftJoin() {
         m_tester.sql("select R1.SI from R1 right join R2 on R1.I = R2.I")
-        .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t2])\n" +
-                   "  VoltLogicalJoin(condition=[=($1, $0)], joinType=[left])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R2]])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R1]])\n")
-        .pass();
+                .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t2])\n" +
+                        "  VoltLogicalJoin(condition=[=($1, $0)], joinType=[left])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R2]])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R1]])\n")
+                .pass();
     }
 
     public void testLeftJoin() {
         m_tester.sql("select R1.SI from R1 left join R2 on R1.I = R2.I")
-        .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
-                   "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[left])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R1]])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R2]])\n")
-        .pass();
+                .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
+                        "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[left])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R1]])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R2]])\n")
+                .pass();
     }
 
     public void testFullJoin() {
         m_tester.sql("select R1.SI from R1 full join R2 on R1.I = R2.I")
-        .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
-                   "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[full])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R1]])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R2]])\n")
-        .pass();
+                .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
+                        "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[full])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R1]])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R2]])\n")
+                .pass();
     }
 
     public void testInnerJoin() {
         m_tester.sql("select R1.SI from R1 inner join R2 on R1.I = R2.I")
-        .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
-                   "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[inner])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R1]])\n" +
-                   "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
-                   "      VoltLogicalTableScan(table=[[public, R2]])\n")
-        .pass();
+                .transform("VoltLogicalCalc(expr#0..2=[{inputs}], SI=[$t1])\n" +
+                        "  VoltLogicalJoin(condition=[=($0, $2)], joinType=[inner])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], proj#0..1=[{exprs}])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R1]])\n" +
+                        "    VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n" +
+                        "      VoltLogicalTableScan(table=[[public, R2]])\n")
+                .pass();
+    }
+
+    public void testENG13840() {
+        m_tester.sql("SELECT i FROM R2,\n"+
+                "(SELECT MAX(i) FROM R2\n"+
+                "    WHERE i > (SELECT COUNT(R2.i) FROM R1\n"+
+                "        WHERE i IS NOT DISTINCT FROM R2.i GROUP BY i ORDER BY i)) TA2")
+                .transform("VoltLogicalCalc(expr#0..6=[{inputs}], I=[$t0])\n"+
+                        "  VoltLogicalJoin(condition=[true], joinType=[inner])\n"+
+                        "    VoltLogicalTableScan(table=[[public, R2]])\n"+
+                        "    VoltLogicalAggregate(group=[{}], EXPR$0=[MAX($0)])\n"+
+                        "      VoltLogicalCalc(expr#0..7=[{inputs}], I=[$t0])\n"+
+                        "        VoltLogicalJoin(condition=[AND(=($0, $6), >($0, $7))], joinType=[inner])\n"+
+                        "          VoltLogicalTableScan(table=[[public, R2]])\n"+
+                        "          VoltLogicalCalc(expr#0..2=[{inputs}], I1=[$t2], EXPR$0=[$t0])\n"+
+                        "            VoltLogicalSort(sort0=[$1], dir0=[ASC])\n"+
+                        "              VoltLogicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2], I=[$t0], I1=[$t1])\n"+
+                        "                VoltLogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)])\n"+
+                        "                  VoltLogicalCalc(expr#0..7=[{inputs}], I=[$t0], I1=[$t7], $f1=[$t7])\n"+
+                        "                    VoltLogicalJoin(condition=[true], joinType=[inner])\n"+
+                        "                      VoltLogicalJoin(condition=[CASE(IS NULL($0), IS NULL($6), IS NULL($6), IS NULL($0), =(CAST($0):INTEGER NOT NULL, CAST($6):INTEGER NOT NULL))], joinType=[inner])\n"+
+                        "                        VoltLogicalTableScan(table=[[public, R1]])\n"+
+                        "                        VoltLogicalAggregate(group=[{0}])\n"+
+                        "                          VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n"+
+                        "                            VoltLogicalTableScan(table=[[public, R2]])\n"+
+                        "                      VoltLogicalAggregate(group=[{0}])\n"+
+                        "                        VoltLogicalCalc(expr#0..5=[{inputs}], I=[$t0])\n"+
+                        "                          VoltLogicalTableScan(table=[[public, R2]])\n")
+                .pass();
     }
 
 }


### PR DESCRIPTION
Added plan node validation step as part of AdHoc planning stage.
This effectively finds invalid plan and stops executing before it enters into EE.
Some refactories around the key changes, which are:
1. in `AdHocPlannedStatement`, when it is being validated; (added `validate` method for `CorePlan`.
2. there are several links of validations between `AbstractPlanNode` that is being exercised (was never exercised before); and `AbstractExpression`, which has been exercised. Since some types of plan nodes can contain expressions, and vice versa.
3. Also incorporated Mike's suggestions on moving `VoltLAggregateCalcMergeRule` to HEP planner rules, since we always want this Calcite planner transformation to happen.

The changes here not only try to stop crashing VoltDB which occurs in EE, by adding plan validation (enabled only in debug build); but also fixes this particular issue, by dropping unnecessary projection node that has empty output schema (thus empty output temp table).