### PR TITLE
Allow kipling port to be set in deployment

### DIFF
--- a/src/frontend/org/voltcore/utils/PortGenerator.java
+++ b/src/frontend/org/voltcore/utils/PortGenerator.java
@@ -21,13 +21,18 @@ import org.voltdb.VoltDB;
 import org.voltdb.utils.MiscUtils;
 
 public class PortGenerator {
+    private static int portOffset = 100; // Shift ports away from defaults for testing
     private int nextPort = 12000;
-    private static int portOffset = 100;    // Shift ports away from defaults for testing
-    private int nextCport = VoltDB.DEFAULT_PORT+portOffset;
-    private int nextAport = VoltDB.DEFAULT_ADMIN_PORT+portOffset;
+    private int nextCport;
+    private int nextAport;
+    private int nextKport;
 
     final int MIN_STATIC_PORT = 10000;
     final int MAX_STATIC_PORT = 49151;
+
+    public PortGenerator() {
+        reset();
+    }
 
     public synchronized void setNext(int port) {
         nextPort = port;
@@ -72,8 +77,19 @@ public class PortGenerator {
         throw new RuntimeException("Exhausted all possible http ports");
     }
 
+    public synchronized int nextKipling() {
+        while (nextCport <= MAX_STATIC_PORT) {
+            int port = nextKport++;
+            if (MiscUtils.isBindable(port)) {
+                return port;
+            }
+        }
+        throw new RuntimeException("Exhausted all possible kipling ports");
+    }
+
     public synchronized void reset() {
-        nextCport = VoltDB.DEFAULT_PORT+portOffset;
-        nextAport = VoltDB.DEFAULT_ADMIN_PORT+portOffset;
+        nextCport = VoltDB.DEFAULT_PORT + portOffset;
+        nextAport = VoltDB.DEFAULT_ADMIN_PORT + portOffset;
+        nextKport = VoltDB.DEFAULT_KIPLING_PORT + portOffset;
     }
 }

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -351,7 +351,7 @@ public class VoltDB {
 
         public String m_recoveredPartitions = "";
 
-        public HostAndPort m_kiplingInterface = HostAndPort.fromParts("", DEFAULT_KIPLING_PORT);
+        public HostAndPort m_kiplingHostPort = null;
 
         public int getZKPort() {
             return MiscUtils.getPortFromHostnameColonPort(m_zkInterface, org.voltcore.common.Constants.DEFAULT_ZK_PORT);
@@ -709,9 +709,8 @@ public class VoltDB {
                     m_exporterVersion = ExporterVersion.E2;
                 } else if (arg.equalsIgnoreCase("e3")) {
                     m_exporterVersion = ExporterVersion.E3;
-                } else if (arg.equalsIgnoreCase("kiplingInterface")) {
-                    m_kiplingInterface = MiscUtils.getHostAndPortFromHostnameColonPort(args[++i].trim(),
-                            VoltDB.DEFAULT_KIPLING_PORT);
+                } else if (arg.equalsIgnoreCase("kiplingHostPort")) {
+                    m_kiplingHostPort = HostAndPort.fromString(args[++i].trim());
                 } else {
                     System.err.println("FATAL: Unrecognized option to VoltDB: " + arg);
                     referToDocAndExit();

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -397,6 +397,14 @@
 
   <xs:complexType name="kiplingType">
     <xs:attribute name="enabled" type="xs:boolean" default="false" />
+    <xs:attribute name="port" default="9092">
+      <xs:simpleType>
+        <xs:restriction base="xs:int">
+          <xs:minInclusive value="1"/>
+          <xs:maxExclusive value="65536"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
     <xs:attribute name="threadCount" default="20">
       <xs:simpleType>
         <xs:restriction base="xs:int">

--- a/src/frontend/org/voltdb/utils/CommandLine.java
+++ b/src/frontend/org/voltdb/utils/CommandLine.java
@@ -144,7 +144,7 @@ public class CommandLine extends VoltDB.Configuration
             }
         }
         cl.m_missingHostCount = m_missingHostCount;
-        cl.m_kiplingInterface = m_kiplingInterface;
+        cl.m_kiplingHostPort = m_kiplingHostPort;
 
         return cl;
     }
@@ -534,8 +534,8 @@ public class CommandLine extends VoltDB.Configuration
         m_vemTag = tag;
     }
 
-    public CommandLine setKiplingInterface(HostAndPort kiplingInterface) {
-        m_kiplingInterface = kiplingInterface;
+    public CommandLine setKiplingHostPort(HostAndPort kiplingInterface) {
+        m_kiplingHostPort = kiplingInterface;
         return this;
     }
 
@@ -818,9 +818,9 @@ public class CommandLine extends VoltDB.Configuration
             cmdline.add("e3");
         }
 
-        if (m_kiplingInterface != null) {
-            cmdline.add("kiplingInterface");
-            cmdline.add(m_kiplingInterface.toString());
+        if (m_kiplingHostPort != null) {
+            cmdline.add("kiplingHostPort");
+            cmdline.add(m_kiplingHostPort.toString());
         }
 
         return cmdline;

--- a/tests/frontend/org/voltdb/LocalClustersTestBase.java
+++ b/tests/frontend/org/voltdb/LocalClustersTestBase.java
@@ -61,6 +61,7 @@ import org.voltdb.regressionsuites.LocalCluster;
 import org.voltdb.test.utils.RandomTestRule;
 import org.voltdb.utils.VoltFile;
 
+import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableMap;
 
 public class LocalClustersTestBase extends JUnit4LocalClusterTest {
@@ -173,6 +174,24 @@ public class LocalClustersTestBase extends JUnit4LocalClusterTest {
 
     protected void cleanupAfterTest() {
         m_cleanupAfterTest = true;
+    }
+
+    /**
+     * Configure a clusters and corresponding client. A cluster will be created with the results of the constructed
+     * cluster and client are stored in {@link #CLUSTERS_AND_CLIENTS}
+     * <p>
+     * If cluster with {@code config} is already running it will be left running and just the schema will be added to
+     * the running clusters. The creation of clusters can be forced by calling {@link #shutdownAllClustersAndClients()}
+     * prior to calling this method.
+     *
+     * @param config                Cluster configuration
+     * @param partitionedTableCount number of partitioned tables to create
+     * @param replicatedTableCount  number of replicated tables to create
+     * @throws Exception if an error occurs
+     */
+    protected void configureClusterAndClient(ClusterConfiguration config, int partitionedTableCount,
+            int replicatedTableCount) throws Exception {
+        configureClustersAndClients(ImmutableList.of(config), partitionedTableCount, replicatedTableCount);
     }
 
     /**

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -65,6 +65,7 @@ import org.voltdb.utils.CommandLine;
 import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
+import com.google_voltpatches.common.net.HostAndPort;
 
 /**
  * Implementation of a VoltServerConfig for a multi-process
@@ -488,6 +489,9 @@ public class LocalCluster extends VoltServerConfig {
             m_compiled = m_initialCatalog != null;
             templateCmdLine.pathToDeployment(builder.getPathToDeployment());
             m_voltdbroot = builder.getPathToVoltRoot().getAbsolutePath();
+            if (builder.getKiplingConfiguration().isEnabled()) {
+                templateCmdLine.setKiplingHostPort(HostAndPort.fromHost(""));
+            }
         }
         return m_compiled;
     }
@@ -650,6 +654,10 @@ public class LocalCluster extends VoltServerConfig {
             assert(proc != null);
             cmdln.m_ipcPort = proc.port();
         }
+        if (cmdln.m_kiplingHostPort != null) {
+            cmdln.m_kiplingHostPort = cmdln.m_kiplingHostPort.withDefaultPort(portGenerator.nextKipling());
+        }
+
         if (m_target == BackendTarget.NATIVE_EE_IPC) {
             cmdln.m_ipcPort = portGenerator.next();
         }
@@ -1161,6 +1169,10 @@ public class LocalCluster extends VoltServerConfig {
                 int portNoToRejoin = m_cmdLines.get(0).internalPort();
                 cmdln.leader(":" + portNoToRejoin);
                 cmdln.enableAdd(true);
+            }
+
+            if (cmdln.m_kiplingHostPort != null) {
+                cmdln.m_kiplingHostPort = cmdln.m_kiplingHostPort.withDefaultPort(portGenerator.nextKipling());
             }
 
             // If local directories are being cleared

--- a/tests/frontend/org/voltdb/regressionsuites/PortGeneratorForTest.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PortGeneratorForTest.java
@@ -37,6 +37,7 @@ public class PortGeneratorForTest extends PortGenerator {
         public int nJMXPort = -1;
         public int nInternalPort = -1;
         public int nHttp = -1;
+        public int nKipling = -1;
 
         public int nextInternalPort() {
             return nInternalPort;
@@ -92,6 +93,14 @@ public class PortGeneratorForTest extends PortGenerator {
 
         public void setHttp(int nc) {
             nHttp = nc;
+        }
+
+        public int nextKipling() {
+            return nKipling;
+        }
+
+        public void setKipling(int nc) {
+            nKipling = nc;
         }
     }
 
@@ -160,5 +169,16 @@ public class PortGeneratorForTest extends PortGenerator {
             }
         }
         return super.next();
+    }
+
+    @Override
+    public int nextKipling() {
+        if (pprovider != null) {
+            int rport = pprovider.nextKipling();
+            if (rport != -1) {
+                return rport;
+            }
+        }
+        return super.nextKipling();
     }
 }


### PR DESCRIPTION
Allow the kipling port to be able to be set in both the deployment and
commandline. Update LocalCluster to handle when kipling is enabled and run each
host on a different kipling port