### PR TITLE
really close the read cursors on PBD segments

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -83,20 +83,10 @@ interface PBDSegmentReader<M> {
     public void rewindReadOffset(int byBytes);
 
     /**
-     * Reopen a previously closed reader. Re-opened reader still keeps the original read offset.
-     */
-    public void reopen() throws IOException;
-
-    /**
      * Close this reader and release any resources. {@link PBDSegment#getReader(String)} will still return this reader
      * until the segment is closed.
      */
     public void close() throws IOException;
-
-    /**
-     * Similar to {@link #close()} but this reader will not be returned from {@link PBDSegment#getReader(String)}
-     */
-    public void purge() throws IOException;
 
     /**
      * Has this reader been closed.

--- a/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
+++ b/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
@@ -153,9 +153,6 @@ class PbdQuarantinedSegment<M> extends PBDSegment<M> {
         public void rewindReadOffset(int byBytes) {}
 
         @Override
-        public void reopen() {}
-
-        @Override
         public long readOffset() {
             return 0;
         }
@@ -164,9 +161,6 @@ class PbdQuarantinedSegment<M> extends PBDSegment<M> {
         public int readIndex() {
             return 0;
         }
-
-        @Override
-        public void purge() {}
 
         @Override
         public BBContainer poll(OutputContainerFactory factory) {


### PR DESCRIPTION
The removed feature is apparently unused and gets in the way of implementing a seek() method.