### PR TITLE
ENG-18453:

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -343,7 +343,7 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
         // Zero entry count means the segment is empty or corrupted, in both cases
         // the segment can be deleted.
         if (initialEntryCount == 0) {
-            reader.close();
+            reader.close(false);
             close();
             return Integer.MAX_VALUE;
         }
@@ -403,7 +403,7 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
             }
         }
         int entriesScanned = reader.readIndex();
-        reader.close();
+        reader.close(false);
 
         if (entriesTruncated == 0) {
             int entriesNotScanned = initialEntryCount - entriesScanned;
@@ -450,7 +450,7 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
 
             return entriesTruncated;
         } finally {
-            reader.purge();
+            reader.close();
         }
     }
 
@@ -466,7 +466,7 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
             }
             return 0;
         } finally {
-            reader.purge();
+            reader.close();
         }
     }
 
@@ -1076,12 +1076,12 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
 
         @Override
         public void close() throws IOException {
-            close(true);
+            close(false);
         }
 
         @Override
-        public void purge() throws IOException {
-            close(false);
+        public void closeAndSaveReaderState() throws IOException {
+            close(true);
         }
 
         private void close(boolean keep) throws IOException {

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -94,9 +94,10 @@ interface PBDSegmentReader<M> {
     public void close() throws IOException;
 
     /**
-     * Similar to {@link #close()} but this reader will not be returned from {@link PBDSegment#getReader(String)}
+     * Close this reader and release any resources. Different between this and {@link #close()} is that
+     * this keeps track of the closed reader. This call is used only internally when a reader is polling through segments.
      */
-    public void purge() throws IOException;
+    public void closeAndSaveReaderState() throws IOException;
 
     /**
      * Has this reader been closed.

--- a/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
+++ b/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
@@ -166,9 +166,6 @@ class PbdQuarantinedSegment<M> extends PBDSegment<M> {
         }
 
         @Override
-        public void purge() {}
-
-        @Override
         public BBContainer poll(OutputContainerFactory factory) {
             return null;
         }
@@ -189,11 +186,16 @@ class PbdQuarantinedSegment<M> extends PBDSegment<M> {
         }
 
         @Override
-        public void close() {}
-
-        @Override
         public boolean anyReadAndDiscarded() {
             return false;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public void closeAndSaveReaderState() {
         }
     };
 }

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -118,7 +118,7 @@ public class PersistentBinaryDeque<M> implements BinaryDeque<M> {
                         return null;
                     }
 
-                    segmentReader.close();
+                    segmentReader.closeAndSaveReaderState();
                     m_segment = m_segments.higherEntry(m_segment.segmentIndex()).getValue();
                     // push to PBD will rewind cursors. So, this cursor may have already opened this segment
                     segmentReader = m_segment.getReader(m_cursorId);

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -235,6 +235,31 @@ public class TestPersistentBinaryDeque {
     }
 
     @Test
+    public void testReopenReader() throws Exception {
+        System.out.println("Running testReopenReader");
+        int count = 10;
+        for (int ii = 0; ii < count; ii++) {
+            m_pbd.offer( DBBPool.wrapBB(getFilledBuffer(ii)) );
+        }
+
+        BinaryDequeReader<ExtraHeaderMetadata> reader = m_pbd.openForRead(CURSOR_ID);
+        assert(count >= 2);
+        // Read 2 and close and reopen
+        BBContainer cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        cont.discard();
+        cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY);
+        cont.discard();
+        m_pbd.closeCursor(CURSOR_ID);
+        reader = m_pbd.openForRead(CURSOR_ID);
+        int readCount = 0;
+        while((cont = reader.poll(PersistentBinaryDeque.UNSAFE_CONTAINER_FACTORY)) != null) {
+            cont.discard();
+            readCount++;
+        }
+        assertEquals(count, readCount);
+    }
+
+    @Test
     public void testTruncateFirstElement() throws Exception {
         System.out.println("Running testTruncateFirstElement");
         List<File> listing = getSortedDirectoryListing();


### PR DESCRIPTION
- Close or closeCursor at PBD level now gets rid of segment level readers completely. Removed purge method not that purge is the same as close.
- Added new closeAndSaveReaderState method to save closed cursors as a reader moves from a segment on the next and closes the cursor.