### PR TITLE
ENG-13113, make @ValidatePartitioning and @ExportControl restartable..

### DIFF
--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -435,9 +435,9 @@ public class SystemProcedureCatalog {
                         false, false, Restartability.NOT_APPLICABLE));
         builder.put("@ValidatePartitioning",
                 new Config("org.voltdb.sysprocs.ValidatePartitioning",
-                        false, true, false, 0, VoltType.INVALID,
+                        false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.NOT_DURABLE,
-                        false, true, Restartability.NOT_RESTARTABLE));
+                        false, true, Restartability.RESTARTABLE));
         builder.put("@GetHashinatorConfig",
                 new Config("org.voltdb.sysprocs.GetHashinatorConfig",
                         false, true,  false, 0, VoltType.INVALID,
@@ -630,7 +630,7 @@ public class SystemProcedureCatalog {
                 new Config("org.voltdb.sysprocs.ExportControl",
                         false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.NOT_DURABLE,
-                        false, true, Restartability.NOT_RESTARTABLE));
+                        false, true, Restartability.RESTARTABLE));
         builder.put("@MigrateRowsAcked_SP",
                 new Config("org.voltdb.sysprocs.MigrateRowsAcked_SP",
                         true, false, false, 0, VoltType.INVALID,

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1652,6 +1652,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     @Override
                     public void run() {
                         try {
+                            // Check again in case of multiple export release tasks are queued
+                            // because restarted @ExportControl transaction
+                            if (m_status != StreamStatus.BLOCKED) {
+                                return;
+                            }
                             if (isMaster() && m_pollTask != null) {
                                 long firstUnpolledSeqNo = m_firstUnpolledSeqNo;
                                 Pair<Long, Long> gap = m_gapTracker.getFirstGap(m_firstUnpolledSeqNo);


### PR DESCRIPTION
As read-write MP system procedure, @ValidatePartitioning needs to be restartable
to avoid corrupting task scoreboard, so does @ExportControl.

Change-Id: I0f911399517eba90568a2fc6d5d2706f3e0bf47b