### PR TITLE
ENG-18491: fix export timestamp calculation by ensuring calculating o…

### DIFF
--- a/src/ee/common/UniqueId.hpp
+++ b/src/ee/common/UniqueId.hpp
@@ -69,6 +69,8 @@ public:
     // Timestamp excluding the counter
     static int64_t ts(UniqueId uid) {
         int64_t time = uid >> (COUNTER_BITS + PARTITIONID_BITS);
+        // Ensure microseconds
+        time *= 1000;
         time += VOLT_EPOCH;
         return time;
     }


### PR DESCRIPTION
…n microseconds

Bug has been with us for a long time and nobody noticed. I checked the JUnits this morning and no regressions appeared subsequent to this fix.