### PR TITLE
Ensure the file decoder unlocks the read/write lock on exception

### DIFF
--- a/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
+++ b/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
@@ -653,6 +653,8 @@ public class ExportToFileClient extends ExportClientBase {
                     throw new RestartBlockException("Fail to start the block", e.getCause(),true);
                 }
                 else {
+                    // Make sure to unlock
+                    m_batchLock.readLock().unlock();
                     throw new RuntimeException(e);
                 }
             }


### PR DESCRIPTION
I believe this lock-up was a a latent bug predating the latest changes