### PR TITLE
ENG-18500: add a shutdown listener to print shutdown reason

### DIFF
--- a/tests/test_apps/genqa/src/genqa/ExportRabbitMQVerifier.java
+++ b/tests/test_apps/genqa/src/genqa/ExportRabbitMQVerifier.java
@@ -32,6 +32,8 @@ import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.QueueingConsumer;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
 
 import org.voltcore.logging.VoltLogger;
 
@@ -66,6 +68,12 @@ public class ExportRabbitMQVerifier {
         final Channel channel = connection.createChannel();
 
         try {
+            channel.addShutdownListener(new ShutdownListener() {		
+		@Override
+		public void shutdownCompleted(ShutdownSignalException cause) {
+                    log.info("shutdownCompleted, cause: " + cause.toString());
+		}
+            });
             channel.exchangeDeclare(m_exchangeName, "topic", true);
             String dataQueue = channel.queueDeclare().getQueue();
             channel.queueBind(dataQueue, m_exchangeName, "EXPORT_PARTITIONED_TABLE_RABBIT.#");
@@ -101,6 +109,7 @@ public class ExportRabbitMQVerifier {
                     success = false;
             }
         } finally {
+            log.info("tear down and close channel");
             tearDown(channel);
             channel.close();
             connection.close();


### PR DESCRIPTION
might help debugging som test failures

ran a series of rabbitmq server export tests.  None failed due to channel shutdown.  Clean shutdowns produced something like 
```
2019-11-12 22:26:36 INFO tear down and close channel
2019-11-12 22:26:36 INFO shutdownCompleted, cause: com.rabbitmq.client.ShutdownSignalException: clean channel shutdown; protocol method: #method<channel.close>(reply-code=200, reply-text=OK, class-id\
=0, method-id=0)
```