### PR TITLE
Eng 18533 partitioned subquery join

### DIFF
--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 import com.google_voltpatches.common.base.Preconditions;
 import org.hsqldb_voltpatches.VoltXMLElement;
@@ -116,7 +117,7 @@ public abstract class AbstractParsedStmt {
     public final Database m_db;
 
     // Parent statement if any
-    public AbstractParsedStmt m_parentStmt = null;
+    public AbstractParsedStmt m_parentStmt;
     boolean m_isUpsert = false;
 
     // mark whether the statement's parent is UNION clause or not
@@ -141,6 +142,14 @@ public abstract class AbstractParsedStmt {
         m_parentStmt = parent;
         m_paramValues = paramValues;
         m_db = db;
+    }
+
+    /**
+     * Test if any parent statement satisfies the predicate.
+     * @return whether any parent statement satisfies the predicate
+     */
+    public boolean anyAncester(Predicate<AbstractParsedStmt> pred) {
+        return m_parentStmt != null && (pred.test(m_parentStmt) || m_parentStmt.anyAncester(pred));
     }
 
     public void setDDLIndexedTable(Table tbl) {

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -405,7 +405,7 @@ public class StatementPartitioning implements Cloneable {
                 StmtSubqueryScan subScan = (StmtSubqueryScan) tableScan;
                 subScan.promoteSinglePartitionInfo(valueEquivalence, eqSets);
                 CompiledPlan subqueryPlan = subScan.getBestCostPlan();
-                if (! subScan.canRunInOneFragment() ||
+                if (! subScan.canRunInOneFragment() ||  // NOTE: the receive-plan node check applies to multi-fragment only
                         subqueryPlan != null && subqueryPlan.rootPlanGraph.hasAnyNodeOfClass(AbstractReceivePlanNode.class)) {
                     if (subqueryHasReceiveNode) {
                         // Has found another subquery with receive node on the same level

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -77,7 +77,7 @@ import org.voltdb.plannodes.SchemaColumn;
  *
  * See the comment in SelectSubPlanAssembler.getSelectSubPlanForJoin
  */
-public class StatementPartitioning implements Cloneable{
+public class StatementPartitioning implements Cloneable {
     /**
      * This value is only meaningful if m_inferPartitioning is false.
      * It can be set true to force single-partition statement planning and
@@ -210,14 +210,7 @@ public class StatementPartitioning implements Cloneable{
      * @return      true or false
      */
     private static boolean isUsefulPartitioningExpression(AbstractExpression expr) {
-        if (expr instanceof ParameterValueExpression) {
-            return true;
-        }
-        if (expr instanceof ConstantValueExpression) {
-            return true;
-        }
-
-        return false;
+        return expr instanceof ParameterValueExpression || expr instanceof ConstantValueExpression;
     }
 
     /**
@@ -280,8 +273,8 @@ public class StatementPartitioning implements Cloneable{
      */
     public boolean isInferredSingle() {
         return m_inferPartitioning &&
-                (((m_countOfIndependentlyPartitionedTables == 0) && ! m_isDML)  ||
-                        (singlePartitioningExpression() != null));
+                ((m_countOfIndependentlyPartitionedTables == 0 && ! m_isDML)  ||
+                        singlePartitioningExpression() != null);
     }
 
     /**
@@ -289,15 +282,10 @@ public class StatementPartitioning implements Cloneable{
      */
     public boolean requiresTwoFragments() {
         if (m_inferPartitioning) {
-            if (isInferredSingle()) {
-                return false;
-            }
+            return !isInferredSingle();
         } else {
-            if (m_forceSP || (m_countOfPartitionedTables == 0)) {
-                return false;
-            }
+            return !m_forceSP && (m_countOfPartitionedTables != 0);
         }
-        return true;
     }
 
     /**
@@ -319,8 +307,9 @@ public class StatementPartitioning implements Cloneable{
     public AbstractExpression singlePartitioningExpressionForReport() {
         if (m_inferredExpression.size() == 1) {
             return m_inferredExpression.iterator().next();
+        } else {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -416,15 +405,14 @@ public class StatementPartitioning implements Cloneable{
                 StmtSubqueryScan subScan = (StmtSubqueryScan) tableScan;
                 subScan.promoteSinglePartitionInfo(valueEquivalence, eqSets);
                 CompiledPlan subqueryPlan = subScan.getBestCostPlan();
-                if (( ! subScan.canRunInOneFragment()) ||
-                        ((subqueryPlan != null) &&
-                         subqueryPlan.rootPlanGraph.hasAnyNodeOfClass(AbstractReceivePlanNode.class))) {
+                if (! subScan.canRunInOneFragment() ||
+                        subqueryPlan != null && subqueryPlan.rootPlanGraph.hasAnyNodeOfClass(AbstractReceivePlanNode.class)) {
                     if (subqueryHasReceiveNode) {
                         // Has found another subquery with receive node on the same level
                         // Not going to support this kind of subquery join with 2 fragment plan.
                         setJoinValid(false);
                         setJoinInvalidReason("This multipartition query is not plannable.  "
-                                             + "It has a subquery which cannot be single partition.");
+                                + "It has a subquery which cannot be single partition.");
                         // Still needs to count the independent partition tables
                         break;
                     }
@@ -438,18 +426,16 @@ public class StatementPartitioning implements Cloneable{
                         // Any process based on this subquery should require 1 fragment only.
                         continue;
                     }
-                } else {
-                    // this subquery partition table without receive node
+                } else { // this subquery partition table without receive node
                     hasPartitionedTableJoin = true;
                 }
-            } else {
-                // This table is a partition table
+            } else { // This table is a partition table
                 hasPartitionedTableJoin = true;
             }
 
             boolean unfiltered = true;
             for (AbstractExpression candidateColumn : valueEquivalence.keySet()) {
-                if ( ! (candidateColumn instanceof TupleValueExpression)) {
+                if (! (candidateColumn instanceof TupleValueExpression)) {
                     continue;
                 }
                 TupleValueExpression candidatePartitionKey = (TupleValueExpression) candidateColumn;
@@ -472,8 +458,9 @@ public class StatementPartitioning implements Cloneable{
         //* enable to debug */ System.out.println("DEBUG: analyze4MPAccess found: " + m_countOfIndependentlyPartitionedTables + " = " + eqSets.size() + " + " + unfilteredPartitionKeyCount);
         if (m_countOfIndependentlyPartitionedTables > 1) {
             setJoinValid(false);
-            setJoinInvalidReason("This query is not plannable.  "
-                                 + "The planner cannot guarantee that all rows would be in a single partition.");
+            setJoinInvalidReason(
+                    "This query is not plannable.  The planner cannot guarantee that all rows would be in a single partition.");
+
         }
 
         // This is the case that subquery with receive node join with another partition table
@@ -483,7 +470,7 @@ public class StatementPartitioning implements Cloneable{
             setJoinInvalidReason("This query is not plannable.  It has a subquery which needs cross-partition access.");
         }
 
-        if ((unfilteredPartitionKeyCount == 0) && (eqSets.size() == 1)) {
+        if (unfilteredPartitionKeyCount == 0 && eqSets.size() == 1) {
             for (Set<AbstractExpression> partitioningValues : eqSets) {
                 for (AbstractExpression constExpr : partitioningValues) {
                     if (constExpr instanceof TupleValueExpression) {
@@ -527,27 +514,14 @@ public class StatementPartitioning implements Cloneable{
 
     private static boolean canCoverPartitioningColumn(TupleValueExpression candidatePartitionKey,
             List<SchemaColumn> columnsNeedingCoverage) {
-        if (columnsNeedingCoverage == null)
+        if (columnsNeedingCoverage == null) {
             return false;
-
-        for (SchemaColumn col: columnsNeedingCoverage) {
-            String partitionedTableAlias = col.getTableAlias();
-            String columnNeedingCoverage = col.getColumnAlias();
-
-            assert(candidatePartitionKey.getTableAlias() != null);
-            if ( ! candidatePartitionKey.getTableAlias().equals(partitionedTableAlias)) {
-                continue;
-            }
-            String candidateColumnName = candidatePartitionKey.getColumnName();
-            if ( ! candidateColumnName.equals(columnNeedingCoverage)) {
-                continue;
-            }
-
-            // Maybe need more checkings
-            return true;
+        } else {
+            assert (candidatePartitionKey.getTableAlias() != null);
+            return columnsNeedingCoverage.stream()
+                    .anyMatch(col -> candidatePartitionKey.getTableAlias().equals(col.getTableAlias()) &&
+                            candidatePartitionKey.getColumnName().equals(col.getColumnAlias()));
         }
-
-        return false;
     }
 
     /**
@@ -557,9 +531,7 @@ public class StatementPartitioning implements Cloneable{
      * @param tableCacheList
      * @throws PlanningErrorException
      */
-    void analyzeTablePartitioning(Collection<StmtTableScan> collection)
-            throws PlanningErrorException
-    {
+    void analyzeTablePartitioning(Collection<StmtTableScan> collection) throws PlanningErrorException {
         m_countOfPartitionedTables = 0;
         // Do we have a need for a distributed scan at all?
         // Iterate over the tables to collect partition columns.

--- a/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
@@ -18,11 +18,8 @@
 package org.voltdb.planner.parseinfo;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Predicate;
 
-import com.google_voltpatches.common.collect.ImmutableSet;
-import org.voltcore.utils.Pair;
 import org.voltdb.expressions.*;
 import org.voltdb.planner.AbstractParsedStmt;
 import org.voltdb.planner.StmtEphemeralTableScan;
@@ -75,6 +72,14 @@ public class BranchNode extends JoinNode {
             newNode.m_whereExpr = m_whereExpr.clone();
         }
         return newNode;
+    }
+
+    public boolean hasChild(Predicate<JoinNode> pred) {
+        return pred.test(getLeftNode()) || pred.test(getRightNode());
+    }
+
+    public boolean allChildren(Predicate<JoinNode> pred) {
+        return pred.test(getLeftNode()) && pred.test(getRightNode());
     }
 
     public void setJoinType(JoinType joinType) {

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -90,13 +90,11 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
      */
     public void promoteSinglePartitionInfo(
             Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
-            Set< Set<AbstractExpression> > eqSets) {
+            Set<Set<AbstractExpression>> eqSets) {
         if (getScanPartitioning() == null) {
             throw new PlanningErrorException("Unsupported statement, subquery expressions are only supported for " +
                     "single partition procedures and AdHoc replicated tables.");
-        }
-        if (getScanPartitioning().getCountOfPartitionedTables() == 0 ||
-                getScanPartitioning().requiresTwoFragments()) {
+        } else if (getScanPartitioning().getCountOfPartitionedTables() == 0 || getScanPartitioning().requiresTwoFragments()) {
             return;
         }
 
@@ -110,11 +108,9 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             Set<AbstractExpression> values = null;
             if (valueEquivalence.containsKey(tveKey)) {
                 values = valueEquivalence.get(tveKey);
-            }
-            else if (valueEquivalence.containsKey(spExpr)) {
+            } else if (valueEquivalence.containsKey(spExpr)) {
                 values = valueEquivalence.get(spExpr);
-            }
-            else {
+            } else {
                 for (SchemaColumn otherCol: m_partitioningColumns) {
                     if (col != otherCol &&
                         valueEquivalence.containsKey(otherCol.getExpression())) {
@@ -135,7 +131,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
     // Because HashSet stored a legacy hashcode for the non-final object.
     private void updateEqualSets(Set<AbstractExpression> values,
             Map<AbstractExpression, Set<AbstractExpression>> valueEquivalence,
-            Set< Set<AbstractExpression> > eqSets,
+            Set<Set<AbstractExpression> > eqSets,
             AbstractExpression tveKey, AbstractExpression spExpr) {
         boolean hasLegacyValues = false;
         if (eqSets.contains(values)) {
@@ -179,7 +175,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             // Find whether the partition column is in output column list
             for (SchemaColumn outputCol: getOutputSchema()) {
                 AbstractExpression outputExpr = outputCol.getExpression();
-                if ( ! (outputExpr instanceof TupleValueExpression)) {
+                if (! (outputExpr instanceof TupleValueExpression)) {
                     continue;
                 }
 
@@ -194,13 +190,11 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             String colNameForParentQuery;
             if (matchedCol != null) {
                 colNameForParentQuery = matchedCol.getColumnAlias();
-            }
-            // single partition sub-query case can be single partition without
-            // including partition column in its display column list
-            else if ( ! getScanPartitioning().requiresTwoFragments()) {
+            } else if ( ! getScanPartitioning().requiresTwoFragments()) {
+                // single partition sub-query case can be single partition without
+                // including partition column in its display column list
                 colNameForParentQuery = partitionCol.getColumnName();
-            }
-            else {
+            } else {
                 continue;
             }
             partitionCol.reset(m_tableAlias, m_tableAlias,
@@ -216,12 +210,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
      */
     @Override
     public boolean getIsReplicated() {
-        for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
-            if ( ! tableScan.getIsReplicated()) {
-                return false;
-            }
-        }
-        return true;
+        return m_subqueryStmt.allScans().stream().allMatch(StmtTableScan::getIsReplicated);
     }
 
     public List<StmtTargetTableScan> getAllTargetTables() {
@@ -229,8 +218,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         for (StmtTableScan tableScan : m_subqueryStmt.allScans()) {
             if (tableScan instanceof StmtTargetTableScan) {
                 stmtTables.add((StmtTargetTableScan)tableScan);
-            }
-            else {
+            } else {
                 assert(tableScan instanceof StmtSubqueryScan);
                 StmtSubqueryScan subScan = (StmtSubqueryScan)tableScan;
                 stmtTables.addAll(subScan.getAllTargetTables());
@@ -287,9 +275,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         if (m_subqueryStmt instanceof ParsedUnionStmt) {
             // Union are just returned
             return false;
-        }
-
-        if ( ! (m_subqueryStmt instanceof ParsedSelectStmt)) {
+        } if (! (m_subqueryStmt instanceof ParsedSelectStmt)) {
             throw new PlanningErrorException("Unsupported subquery found in FROM clause:" +
                     m_subqueryStmt);
         }
@@ -322,11 +308,11 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             // If joined with a partitioned table in the parent query, it will
             // violate the partitioned table join criteria.
             // Detect case (1) to mark receive node.
-            if ( ! selectStmt.hasPartitionColumnInGroupby()) {
+            if (! selectStmt.hasPartitionColumnInGroupby()) {
                 return false;
             }
         }
-        if ( ! selectStmt.hasPartitionColumnInWindowFunctionExpression()) {
+        if (! selectStmt.hasPartitionColumnInWindowFunctionExpression()) {
             return false;
         }
 
@@ -361,9 +347,8 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
     /** Produce a tuple value expression for a column produced by this subquery */
     public TupleValueExpression getOutputExpression(int index) {
         SchemaColumn schemaCol = getSchemaColumn(index);
-        TupleValueExpression tve = new TupleValueExpression(getTableAlias(), getTableAlias(),
+        return new TupleValueExpression(getTableAlias(), getTableAlias(),
                 schemaCol.getColumnAlias(), schemaCol.getColumnAlias(), index);
-        return tve;
     }
 
     public String calculateContentDeterminismMessage() {
@@ -384,8 +369,9 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         // so we can return anything.
         if (plan != null) {
             return orderIsDeterministic && plan.isOrderDeterministic();
+        } else {
+            return orderIsDeterministic;
         }
-        return orderIsDeterministic;
     }
 
     @Override
@@ -413,9 +399,10 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         // null there is some error, so this computation is irrelevant.
         CompiledPlan scanBestPlan = getBestCostPlan();
         if (scanBestPlan != null) {
-            return hasSignificantOffsetOrLimit || ( ! scanBestPlan.isOrderDeterministic() && scanBestPlan.hasLimitOrOffset());
+            return hasSignificantOffsetOrLimit || (! scanBestPlan.isOrderDeterministic() && scanBestPlan.hasLimitOrOffset());
+        } else {
+            return hasSignificantOffsetOrLimit;
         }
-        return hasSignificantOffsetOrLimit;
     }
     public final CompiledPlan getBestCostPlan() {
         return m_bestCostPlan;

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -369,9 +369,8 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         // so we can return anything.
         if (plan != null) {
             return orderIsDeterministic && plan.isOrderDeterministic();
-        } else {
-            return orderIsDeterministic;
         }
+        return orderIsDeterministic;
     }
 
     @Override
@@ -400,9 +399,8 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
         CompiledPlan scanBestPlan = getBestCostPlan();
         if (scanBestPlan != null) {
             return hasSignificantOffsetOrLimit || (! scanBestPlan.isOrderDeterministic() && scanBestPlan.hasLimitOrOffset());
-        } else {
-            return hasSignificantOffsetOrLimit;
         }
+        return hasSignificantOffsetOrLimit;
     }
     public final CompiledPlan getBestCostPlan() {
         return m_bestCostPlan;

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -700,6 +700,10 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
         return m_children.get(index);
     }
 
+    public List<AbstractPlanNode> getChildren() {
+        return m_children;
+    }
+
     public void clearChildren() {
         m_children.clear();
     }

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -19,6 +19,7 @@ package org.voltdb.plannodes;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -122,6 +123,24 @@ public abstract class AbstractPlanNode implements JSONString, Comparable<Abstrac
      */
     protected AbstractPlanNode() {
         m_id = NEXT_PLAN_NODE_ID++;
+    }
+
+    /**
+     * Test if current node, or any children node, has the given property recursively
+     * @param pred predicate on a plan node
+     * @return if current node or any children node has the given property
+     */
+    public boolean anyChild(Predicate<AbstractPlanNode> pred) {
+        return pred.test(this) || m_children.stream().anyMatch(child -> child.anyChild(pred));
+    }
+
+    /**
+     * Test if current node as well as all children nodes, have the given property recursively
+     * @param pred predicate on a plan node
+     * @return if current node and all children nodes has the given property
+     */
+    public boolean allChild(Predicate<AbstractPlanNode> pred) {
+        return anyChild(pred.negate());
     }
 
     public int resetPlanNodeIds(int nextId) {

--- a/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
@@ -71,7 +71,7 @@ public class MergeReceivePlanNode extends AbstractReceivePlanNode {
         resolveColumnIndexes(m_outputSchemaPreInlineAgg);
 
         AbstractPlanNode orderNode = getInlinePlanNode(PlanNodeType.ORDERBY);
-        assert(orderNode != null && orderNode instanceof OrderByPlanNode);
+        assert(orderNode instanceof OrderByPlanNode);
         OrderByPlanNode opn = (OrderByPlanNode) orderNode;
         opn.resolveSortIndexesUsingSchema(m_outputSchemaPreInlineAgg);
 

--- a/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
@@ -776,7 +776,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
     private void checkHasComplexAgg(List<AbstractPlanNode> pns,
             boolean projectPushdown) {
         assertTrue(pns.size() > 0);
-        boolean isDistributed = pns.size() > 1 ? true: false;
+        boolean isDistributed = pns.size() > 1;
 
         if (projectPushdown) {
             assertTrue(isDistributed);
@@ -1177,7 +1177,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
         pns = compileToFragments(sql);
         checkMVReaggregateFeatureMergeReceive(pns, false,
                 -1, -1,
-                false, false, sortDirection);
+                sortDirection);
     }
 
     private void checkMVNoFix_NoAgg(
@@ -1744,9 +1744,8 @@ public class TestPlansGroupBy extends PlannerTestCase {
         AbstractExpression.restoreVerboseExplainForDebugging(asItWas);
     }
 
-    private void checkHavingClause(String sql,
-            boolean aggInline,
-            Object aggPostFilters) {
+    private void checkHavingClause(
+            String sql, boolean aggInline, Object aggPostFilters) {
         List<AbstractPlanNode> pns;
 
         pns = compileToFragments(sql);
@@ -1767,37 +1766,29 @@ public class TestPlansGroupBy extends PlannerTestCase {
         String aggNodeStr = aggNode.toExplainPlanString().toLowerCase();
 
         if (aggPostFilters != null) {
-            String[] aggFilterStrings = null;
+            final String[] aggFilterStrings;
             if (aggPostFilters instanceof String) {
                 aggFilterStrings = new String[] { (String) aggPostFilters };
-            }
-            else {
+            } else {
                 aggFilterStrings = (String[]) aggPostFilters;
             }
             for (String aggFilter : aggFilterStrings) {
                 assertTrue(aggNodeStr.contains(aggFilter.toLowerCase()));
             }
-        }
-        else {
+        } else {
             assertNull(aggNode.getPostPredicate());
         }
     }
 
     private void checkMVFix_reAgg_MergeReceive(
-            String sql,
-            int numGroupByOfReaggNode, int numAggsOfReaggNode,
-            SortDirectionType sortDirection) {
-        List<AbstractPlanNode> pns;
-
-        pns = compileToFragments(sql);
-        checkMVReaggregateFeatureMergeReceive(pns, true,
+            String sql, int numGroupByOfReaggNode, int numAggsOfReaggNode, SortDirectionType sortDirection) {
+        checkMVReaggregateFeatureMergeReceive(compileToFragments(sql), true,
                 numGroupByOfReaggNode, numAggsOfReaggNode,
-                false, false, sortDirection);
+                sortDirection);
 }
 
     private void checkMVFix_reAgg(
-            String sql,
-            int numGroupByOfReaggNode, int numAggsOfReaggNode) {
+            String sql, int numGroupByOfReaggNode, int numAggsOfReaggNode) {
         checkMVReaggreateFeature(sql, true,
                 -1, -1,
                 numGroupByOfReaggNode, numAggsOfReaggNode,
@@ -1821,10 +1812,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
             int numGroupByOfTopAggNode, int numAggsOfTopAggNode,
             int numGroupByOfReaggNode, int numAggsOfReaggNode,
             boolean aggPushdown, boolean aggInline) {
-        List<AbstractPlanNode> pns;
-
-        pns = compileToFragments(sql);
-        checkMVReaggregateFeature(pns, needFix,
+        checkMVReaggregateFeature(compileToFragments(sql), needFix,
                 numGroupByOfTopAggNode, numAggsOfTopAggNode,
                 numGroupByOfReaggNode, numAggsOfReaggNode,
                 aggPushdown, aggInline);
@@ -1835,8 +1823,6 @@ public class TestPlansGroupBy extends PlannerTestCase {
             boolean needFix,
             int numGroupByOfReaggNode,
             int numAggsOfReaggNode,
-            boolean aggPushdown,
-            boolean aggInline,
             SortDirectionType sortDirection) {
 
         assertEquals(2, pns.size());
@@ -1853,11 +1839,9 @@ public class TestPlansGroupBy extends PlannerTestCase {
 
         if (needFix) {
             assertNotNull(reAggNode);
-
             assertEquals(numGroupByOfReaggNode, reAggNode.getGroupByExpressionsSize());
             assertEquals(numAggsOfReaggNode, reAggNode.getAggregateTypesSize());
-        }
-        else {
+        } else {
             assertNull(reAggNode);
         }
 
@@ -1867,12 +1851,11 @@ public class TestPlansGroupBy extends PlannerTestCase {
 
         assertTrue(p instanceof IndexScanPlanNode);
         assertEquals(sortDirection, ((IndexScanPlanNode)p).getSortDirection());
-
     }
 
     // topNode, reAggNode
-    private void checkMVReaggregateFeature(List<AbstractPlanNode> pns,
-            boolean needFix,
+    private void checkMVReaggregateFeature(
+            List<AbstractPlanNode> pns, boolean needFix,
             int numGroupByOfTopAggNode, int numAggsOfTopAggNode,
             int numGroupByOfReaggNode, int numAggsOfReaggNode,
             boolean aggPushdown, boolean aggInline) {
@@ -1894,7 +1877,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
         if (p instanceof OrderByPlanNode) {
             p = p.getChild(0);
         }
-        HashAggregatePlanNode reAggNode = null;
+        HashAggregatePlanNode reAggNode;
 
         List<AbstractPlanNode> nodes = p.findAllNodesOfClass(AbstractReceivePlanNode.class);
         assertEquals(1, nodes.size());
@@ -1929,12 +1912,11 @@ public class TestPlansGroupBy extends PlannerTestCase {
         //
         // Hash top aggregate node
         //
-        AggregatePlanNode topAggNode = null;
+        AggregatePlanNode topAggNode;
         if (p instanceof AbstractJoinPlanNode) {
             // Inline aggregation with join
             topAggNode = AggregatePlanNode.getInlineAggregationNode(p);
-        }
-        else {
+        } else {
             assertTrue(p instanceof AggregatePlanNode);
             topAggNode = (AggregatePlanNode) p;
             p = p.getChild(0);
@@ -1963,8 +1945,7 @@ public class TestPlansGroupBy extends PlannerTestCase {
             assertTrue(!needFix);
             if (aggInline) {
                 assertNotNull(AggregatePlanNode.getInlineAggregationNode(p));
-            }
-            else {
+            } else {
                 assertTrue(p instanceof AggregatePlanNode);
                 p = p.getChild(0);
             }
@@ -1972,10 +1953,8 @@ public class TestPlansGroupBy extends PlannerTestCase {
 
         if (needFix) {
             assertTrue(p instanceof AbstractScanPlanNode);
-        }
-        else {
-            assertTrue(p instanceof AbstractScanPlanNode ||
-                    p instanceof AbstractJoinPlanNode);
+        } else {
+            assertTrue(p instanceof AbstractScanPlanNode || p instanceof AbstractJoinPlanNode);
         }
 
     }


### PR DESCRIPTION
When we did order-by micro-optimization, we used to combine order-by
with send/receive into a merge-receive node. When this happens inside a
sub-query, it would complain that the query is cross-partition, even if
the upper-level query can be plannable.

The fix is to perform this optimization only when the current plan node is on replicated table only.