### PR TITLE
ENG-18536: remove old kafka property

### DIFF
--- a/tests/test_apps/kafkaimporter/pounder10.groovy
+++ b/tests/test_apps/kafkaimporter/pounder10.groovy
@@ -83,7 +83,7 @@ def kconf = [
     (VALUE_SERIALIZER_CLASS_CONFIG):StringSerializer.class.name,
     (BOOTSTRAP_SERVERS_CONFIG):opts.b,
     (COMPRESSION_TYPE_CONFIG):opts.c,
-    (BLOCK_ON_BUFFER_FULL_CONFIG):true,
+    (MAX_BLOCK_MS_CONFIG):60000,
     (ACKS_CONFIG):'all',
     (RETRIES_CONFIG):4
 ]


### PR DESCRIPTION
replace kafka BLOCK_ON_BUFFER_FULL_CONFIG with MAX_BLOCK_MS_CONFIG.

c096962f05 brought along a new kafka client library which no longer supports the former property