### PR TITLE
Eng 18533 partitioned subquery join

### DIFF
--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -190,7 +190,7 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
             String colNameForParentQuery;
             if (matchedCol != null) {
                 colNameForParentQuery = matchedCol.getColumnAlias();
-            } else if ( ! getScanPartitioning().requiresTwoFragments()) {
+            } else if (! getScanPartitioning().requiresTwoFragments()) {
                 // single partition sub-query case can be single partition without
                 // including partition column in its display column list
                 colNameForParentQuery = partitionCol.getColumnName();
@@ -250,7 +250,6 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
      * send/receive pair to the subquery plan that is actually only suitable to
      * a stand-alone plan. This function distinguishes subqueries that should NOT
      * have a send/receive pair.
-     * @param root
      * @return true if there is no aspect to the plan that requires execution on the coordinator.
      */
     @Override
@@ -284,7 +283,9 @@ public class StmtSubqueryScan extends StmtEphemeralTableScan {
 
         // Now If query has LIMIT/OFFSET/DISTINCT on a replicated table column,
         // we should get rid of the receive node. I (--paul) don't know what this means.
-        if (selectStmt.hasLimitOrOffset() || selectStmt.hasDistinctWithGroupBy()) {
+        // This is reckless check whether a query needs to run on multiple fragments. It is too conservative/restrictive,
+        // and LIMIT/OFFSET condition does not make any sense.
+        if (selectStmt.hasDistinctWithGroupBy()) {
             return false;
         }
 

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -465,7 +465,18 @@ public class TestAdHocQueries extends AdHocQueryTester {
                                     "    ORDER BY metric) t2\n" +
                                     "ON t1.CUSTOM2=t2.CUSTOM2\n" +
                                     "ORDER BY t1.IMPRESSIONS;",
-                            new Object[][] {{1}, {9}}))
+                            new Object[][] {{1}, {9}}),
+                    Pair.of("SELECT t1.CUSTOM2, t1.IMPRESSIONS FROM (\n" +
+                            "    SELECT CLIENT_ID, CUSTOM2, sum(IMPRESSIONS) as IMPRESSIONS, cast(SUM(IMPRESSIONS) as decimal) AS metric\n" +
+                            "    FROM rpt_perf_breakdown WHERE CLIENT_ID = 1\n" +
+                            "    GROUP BY CLIENT_ID,CUSTOM2) t1\n" +
+                            "LEFT OUTER JOIN (\n" +
+                            "    SELECT CLIENT_ID, CUSTOM2, sum(IMPRESSIONS) as IMPRESSIONS, cast(SUM(IMPRESSIONS) as decimal) AS metric\n" +
+                            "    FROM rpt_perf_breakdown WHERE CLIENT_ID = 1\n" +
+                            "    GROUP BY CLIENT_ID, CUSTOM2\n" +
+                            "    ORDER BY metric ASC LIMIT 3) t2\n" +
+                            "ON t1.CUSTOM2=t2.CUSTOM2\n" +
+                            "ORDER BY t1.IMPRESSIONS;", new Object[][] {{"foox", 1}, {"foo", 9}}))
                     .forEach(queryAndResult -> {
                         final String query = queryAndResult.getFirst();
                         final Object[][] expected = queryAndResult.getSecond();

--- a/tests/sqlcoverage/SQLCoverageReport.py
+++ b/tests/sqlcoverage/SQLCoverageReport.py
@@ -96,7 +96,7 @@ AllExceptionTypes.extend(NonfatalExceptionTypes)
 def highlight(s, flag):
     if not isinstance(s, basestring):
         s = str(s)
-    return flag and "<span style=\"color: red\">%s</span>" % (s) or s
+    return flag and '<span style="color: red">%s*</span>' % (s) or s
 
 def as_html_unicode_string(s):
     if isinstance(s, list):

--- a/tests/sqlcoverage/template/include/advanced-select.sql
+++ b/tests/sqlcoverage/template/include/advanced-select.sql
@@ -153,3 +153,11 @@ SELECT @star FROM @fromtables Q38 WHERE CASE      Q38._variable[#arg @columntype
 SELECT @star FROM @fromtables Q39 WHERE CASE      Q39._variable[#arg @columntype] WHEN @comparableconstant THEN Q39._variable[#numone @columntype] @aftermath                              END @cmp (@comparableconstant@plus10)
 SELECT __[#numone]            Q40,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath ELSE   A.__[#arg] @aftermath END FROM @fromtables A WHERE @columnpredicate
 SELECT __[#arg]               Q41,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath                              END FROM @fromtables A WHERE @columnpredicate
+
+-- Test simple sub-queries, with and without LIMIT (see ENG-18533)
+{_maybelimit |= ""}
+{_maybelimit |= "LIMIT 10"}
+SELECT SUB.COL1 FROM \
+    (SELECT _variable[@columntype] COL1, @idcol PARTCOL FROM @fromtables ORDER BY COL1, PARTCOL _maybelimit) SUB, \
+    @fromtables Q42 \
+    WHERE Q42.@idcol = SUB.PARTCOL ORDER BY PARTCOL


### PR DESCRIPTION
2nd part of ENG-18533: (1st part in #6701)
Bug fix: remove how LIMIT/OFFSET determines whether a (sub-)query is a single-fragment or not.
There was no reason that LIMIT/OFFSET should play any role in determining if the query is SP/MP. But we had long taken it into consideration, and resulted in conservative decisions in many should-be plan-able situations. See updated tests for examples.
A straightforward one is:
Given `P` is partitioned on column `D0`, both queries should be planable, in presence or absence of `LIMIT`. But, we have long considered the first one to be cross-partition, but second one not.
`select PT_D1 from (select P_D1 as PT_D1, P_D0 as PT_D0 from P order by P_D1 limit 10) P_T, P where P.P_D0 = P_T.PT_D0;`
`select PT_D1 from (select P_D1 as PT_D1, P_D0 as PT_D0 from P order by P_D1) P_T, P where P.P_D0 = P_T.PT_D0;`

For what I could see, the mindset of initial implementation could have been: without LIMIT/OFFSET, the ORDER-BY in sub-query is redundant; but in their presence, we need the ORDER-BY, and there was some aggressive plan optimization that inlines ORDER-BY node on partitioned table, that prevents whole query to be considered plannable.

The plan for the first above query, with current changeset, is:

PROJECTION
  SEND
     RECEIVE

SEND
   INNER JOIN
       SEQSCAN P_T
           OBY-LIMIT
               SEQSCAN P
           OBY-LIMIT
               SEQSCAN P