### PR TITLE
ENG-18568: disable SSL host name verification for kafka client

### DIFF
--- a/tests/test_apps/kafkaimporter/kafkaloader10-SSL.props
+++ b/tests/test_apps/kafkaimporter/kafkaloader10-SSL.props
@@ -8,3 +8,5 @@ fetch.max.wait.ms=10000
 security.protocol=SSL
 ssl.truststore.location=apprunner-keystore
 ssl.truststore.password=password
+# disable server host name verification
+ssl.endpoint.identification.algorithm=


### PR DESCRIPTION
The new client (commit  c096962f05) library tightened up certificate validation