### PR TITLE
ENG-18585: Include system tables in snapshot and restore

### DIFF
--- a/src/ee/common/HiddenColumn.cpp
+++ b/src/ee/common/HiddenColumn.cpp
@@ -33,4 +33,19 @@ NValue HiddenColumn::getDefaultValue(HiddenColumn::Type columnType) {
     }
 }
 
+const char *HiddenColumn::getName(HiddenColumn::Type columnType) {
+    switch (columnType) {
+    case HiddenColumn::MIGRATE_TXN:
+        return "migrate_column";
+    case HiddenColumn::XDCR_TIMESTAMP:
+        return "dr_clusterid_timestamp";
+    case HiddenColumn::VIEW_COUNT:
+        return "count_star";
+    default:
+        // Unsupported hidden column type passed in
+        vassert(false);
+        return "UNKNOWN";
+    }
+}
+
 }

--- a/src/ee/common/HiddenColumn.h
+++ b/src/ee/common/HiddenColumn.h
@@ -39,6 +39,11 @@ public:
      * Get the default NValue for the given hidden column type
      */
     static NValue getDefaultValue(Type type);
+
+    /**
+     * Get the name of the hidden column
+     */
+    static const char *getName(Type type);
 };
 
 }

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -488,6 +488,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
             m_isLowestSite = true;
         }
 
+        int getSnapshotSchema(CatalogId tableId, HiddenColumnFilter::Type hiddenColumnFilterType);
+
         /**
          * Activate a table stream of the specified type for the specified table.
          * Returns true on success and false on failure

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -56,6 +56,7 @@
 #include "storage/TupleBlock.h"
 #include "storage/ExportTupleStream.h"
 #include "common/ThreadLocalPool.h"
+#include "common/HiddenColumnFilter.h"
 
 #include <vector>
 #include <string>
@@ -197,6 +198,8 @@ class Table {
 
     void serializeToWithoutTotalSize(SerializeOutput& serialOutput);
 
+    void serializeColumnHeaderTo(SerializeOutput& serialOutput, HiddenColumnFilter::Type hiddenColumnFilter);
+
     void serializeColumnHeaderTo(SerializeOutput& serialOutput);
 
     /*
@@ -336,6 +339,8 @@ protected:
     virtual void initializeWithColumns(TupleSchema* schema, std::vector<std::string> const& columnNames,
           bool ownsTupleSchema, int32_t compactionThreshold = 95);
     bool checkNulls(TableTuple& tuple) const;
+
+    void serializeColumnHeaderTo(SerializeOutput& serialOutput, HiddenColumnFilter *hiddenColumnFilter);
 
     // ------------------------------------------------------------------
     // DATA

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -951,6 +951,19 @@ SHAREDLIB_JNIEXPORT jboolean JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeS
 
 /*
  * Class:     org_voltdb_jni_ExecutionEngine
+ * Method:    nativeGetSnapshotSchema
+ * Signature: (JIB)I
+ */
+SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeGetSnapshotSchema(
+        JNIEnv *env, jobject obj, jlong engine_ptr, jint tableId, jbyte schemaFilterType)
+{
+    VoltDBEngine *engine = castToEngine(engine_ptr);
+    voltdb::HiddenColumnFilter::Type hiddenColumnFilter = static_cast<voltdb::HiddenColumnFilter::Type>(schemaFilterType);
+    return engine->getSnapshotSchema(tableId, hiddenColumnFilter);
+}
+
+/*
+ * Class:     org_voltdb_jni_ExecutionEngine
  * Method:    nativeActivateTableStream
  * Signature: (JIIIJ[B)Z
  */

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -413,13 +413,19 @@ Java_org_voltdb_jni_ExecutionEngine_nativeUpdateCatalog(
 }
 
 /**
- * This method is called to initially load table data.
+ * This method is called to initially load table data from a heap array
  * @param pointer the VoltDBEngine pointer
  * @param table_id catalog ID of the table
  * @param serialized_table the table data to be loaded
+ * @param txnId ID of current transaction
+ * @param spHandle for this sp transaction
+ * @param lastCommittedSpHandle spHandle which was most recently committed
+ * @param uniqueId for this transaction
+ * @param undoToken for this transaction
+ * @param callerId ID for LoadTableCaller enum
 */
 SHAREDLIB_JNIEXPORT jint JNICALL
-Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable (
+Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable__JI_3BJJJJJB (
     JNIEnv *env, jobject obj, jlong engine_ptr, jint table_id,
     jbyteArray serialized_table, jlong txnId, jlong spHandle, jlong lastCommittedSpHandle,
     jlong uniqueId, jlong undoToken, jbyte callerId)
@@ -455,6 +461,58 @@ Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable (
             engine->resetReusedResultOutputBuffer();
             e.serialize(engine->getExceptionOutputSerializer());
         }
+    } catch (const FatalException &e) {
+        topend->crashVoltDB(e);
+    }
+
+    return org_voltdb_jni_ExecutionEngine_ERRORCODE_ERROR;
+}
+
+/**
+ * This method is called to initially load table data from a direct byte buffer
+ * @param engine_ptr the VoltDBEngine pointer
+ * @param table_id catalog ID of the table
+ * @param serialized_table the table data to be loaded as a direct byte buffer
+ * @param txnId ID of current transaction
+ * @param spHandle for this sp transaction
+ * @param lastCommittedSpHandle spHandle which was most recently committed
+ * @param uniqueId for this transaction
+ * @param undoToken for this transaction
+ * @param callerId ID for LoadTableCaller enum
+*/
+SHAREDLIB_JNIEXPORT jint JNICALL
+Java_org_voltdb_jni_ExecutionEngine_nativeLoadTable__JILjava_nio_ByteBuffer_2JJJJJB (
+    JNIEnv *env, jobject obj, jlong engine_ptr, jint table_id,
+    jobject serialized_table, jlong txnId, jlong spHandle, jlong lastCommittedSpHandle,
+    jlong uniqueId, jlong undoToken, jbyte callerId)
+{
+    VoltDBEngine *engine = castToEngine(engine_ptr);
+    Topend *topend = static_cast<JNITopend*>(engine->getTopend())->updateJNIEnv(env);
+    if (engine == NULL) {
+        return org_voltdb_jni_ExecutionEngine_ERRORCODE_ERROR;
+    }
+
+    engine->resetReusedResultOutputBuffer();
+
+    //JNIEnv pointer can change between calls, must be updated
+    updateJNILogProxy(engine);
+    VOLT_DEBUG("loading table %d in C++ on thread %d", table_id, ThreadLocalPool::getThreadPartitionId());
+
+    char *bytes = static_cast<char *>(env->GetDirectBufferAddress(serialized_table));
+    jlong length = env->GetDirectBufferCapacity(serialized_table);
+    VOLT_DEBUG("deserializing %d bytes on thread %d", (int) length, ThreadLocalPool::getThreadPartitionId());
+    ReferenceSerializeInputBE serialize_in(bytes, length);
+
+    try {
+        bool success = engine->loadTable(table_id, serialize_in, txnId, spHandle, lastCommittedSpHandle, uniqueId,
+                undoToken, LoadTableCaller::get(static_cast<LoadTableCaller::Id>(callerId)));
+        VOLT_DEBUG("deserialized table");
+
+        if (success)
+            return org_voltdb_jni_ExecutionEngine_ERRORCODE_SUCCESS;
+    } catch (const SerializableEEException &e) {
+        engine->resetReusedResultOutputBuffer();
+        e.serialize(engine->getExceptionOutputSerializer());
     } catch (const FatalException &e) {
         topend->crashVoltDB(e);
     }

--- a/src/frontend/org/voltdb/CSVSnapshotFilter.java
+++ b/src/frontend/org/voltdb/CSVSnapshotFilter.java
@@ -35,16 +35,18 @@ public class CSVSnapshotFilter implements SnapshotDataFilter {
     private int m_lastNumCharacters = 64 * 1024;
 
     public CSVSnapshotFilter(
-            VoltTable vt,
+            byte[] schemaBytes,
             char delimiter,
             char fullDelimiters[]) {
+        VoltTable vt = PrivateVoltTableFactory.createVoltTableFromSchemaBytes(schemaBytes);
+
         m_columnTypes = new ArrayList<VoltType>(vt.getColumnCount());
         for (int ii = 0; ii < vt.getColumnCount(); ii++) {
             m_columnTypes.add(vt.getColumnType(ii));
         }
         m_fullDelimiters = fullDelimiters;
         m_delimiter = delimiter;
-        m_schemaBytes = PrivateVoltTableFactory.getSchemaBytes(vt);
+        m_schemaBytes = schemaBytes;
     }
 
     @Override

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -148,7 +148,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             final int numPartitions,
             final boolean isReplicated,
             final List<Integer> partitionIds,
-            final VoltTable schemaTable,
+            final byte[] schemaBytes,
             final long txnId,
             final long timestamp) throws IOException {
         this(
@@ -160,7 +160,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
                 numPartitions,
                 isReplicated,
                 partitionIds,
-                schemaTable,
+                schemaBytes,
                 txnId,
                 timestamp,
                 new int[] { 0, 0, 0, 2 });
@@ -175,7 +175,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             final int numPartitions,
             final boolean isReplicated,
             final List<Integer> partitionIds,
-            final VoltTable schemaTable,
+            final byte[] schemaBytes,
             final long txnId,
             final long timestamp,
             int version[]
@@ -236,9 +236,6 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
         container.b().position(4);
         container.b().putInt(container.b().remaining() - 4);
         container.b().position(0);
-
-        final byte schemaBytes[];
-        schemaBytes = PrivateVoltTableFactory.getSchemaBytes(schemaTable);
 
         final PureJavaCrc32 crc = new PureJavaCrc32();
         ByteBuffer aggregateBuffer = ByteBuffer.allocate(container.b().remaining() + schemaBytes.length);

--- a/src/frontend/org/voltdb/PrivateVoltTableFactory.java
+++ b/src/frontend/org/voltdb/PrivateVoltTableFactory.java
@@ -32,6 +32,14 @@ public abstract class PrivateVoltTableFactory {
         return new VoltTable();
     }
 
+    public static VoltTable createVoltTableFromSchemaBytes(byte[] schema) {
+        ByteBuffer buffer = ByteBuffer.allocate(schema.length + 4);
+        buffer.put(schema);
+        buffer.putInt(0);
+        buffer.rewind();
+        return createVoltTableFromBuffer(buffer, false);
+    }
+
     public static VoltTable createVoltTableFromBuffer(ByteBuffer backing, boolean readOnly) {
         return new VoltTable(backing, readOnly);
     }

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -854,11 +854,8 @@ SnapshotCompletionInterest, Promotable
             // you will not be able to find those snapshotted views in the snapshot.
             // Here, we will make an exception for those "optional tables" which are the view tables
             // that can be snapshotted in V8.2 or later. If they are not in the snapshot it's OK.
-            Pair<Set<String>, Set<String>> ret = CatalogUtil.getSnapshotableTableNamesFromInMemoryJar(jarfile);
-            Set<String> fullTableNames = ret.getFirst();
-            Set<String> optionalTableNames = ret.getSecond();
-            digestTableNames.forEach(tableName -> fullTableNames.remove(tableName));
-            optionalTableNames.forEach(tableName -> fullTableNames.remove(tableName));
+            Set<String> fullTableNames = SnapshotUtil.getRequiredSnapshotableTableNames(jarfile);
+            fullTableNames.removeAll(digestTableNames);
             // If there are still "normal" tables apart from the snapshotted tables and
             // optionally snapshotted views, we have no choice but fail the restore.
             if (! fullTableNames.isEmpty()) {

--- a/src/frontend/org/voltdb/SiteSnapshotConnection.java
+++ b/src/frontend/org/voltdb/SiteSnapshotConnection.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
 
-import org.voltcore.utils.Pair;
 import org.voltdb.sysprocs.saverestore.HiddenColumnFilter;
 import org.voltdb.sysprocs.saverestore.SnapshotRequestConfig;
 
@@ -44,10 +43,9 @@ public interface SiteSnapshotConnection
 
     public default void populateSnapshotSchemas(SnapshotRequestConfig config) {
         for (SnapshotTableInfo table : config.tables) {
-            Pair<byte[], Integer> schema = getSnapshotSchema(table.getTableId(), config.getHiddenColumnFilter());
-            table.setSchema(schema.getFirst(), schema.getSecond());
+            populateSnapshotSchema(table, config.getHiddenColumnFilter());
         }
     }
 
-    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter filter);
+    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter);
 }

--- a/src/frontend/org/voltdb/SiteSnapshotConnection.java
+++ b/src/frontend/org/voltdb/SiteSnapshotConnection.java
@@ -21,7 +21,9 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
 
+import org.voltcore.utils.Pair;
 import org.voltdb.sysprocs.saverestore.HiddenColumnFilter;
+import org.voltdb.sysprocs.saverestore.SnapshotRequestConfig;
 
 /**
  * Defines the interface between a site and the snapshot
@@ -39,4 +41,13 @@ public interface SiteSnapshotConnection
 
     public void startSnapshotWithTargets(Collection<SnapshotDataTarget> targets);
     public HashSet<Exception> completeSnapshotWork() throws InterruptedException;
+
+    public default void populateSnapshotSchemas(SnapshotRequestConfig config) {
+        for (SnapshotTableInfo table : config.tables) {
+            Pair<byte[], Integer> schema = getSnapshotSchema(table.getTableId(), config.getHiddenColumnFilter());
+            table.setSchema(schema.getFirst(), schema.getSecond());
+        }
+    }
+
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter filter);
 }

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -502,7 +502,7 @@ public class SnapshotSaveAPI
     {
         // TRAIL [SnapSave:4]  - 3.1 [1 site/host] Create snapshot write plan.
         // Normal @SnapshotSave calls should go with NativeSnapshotWritePlan.
-        SnapshotWritePlan plan;
+        SnapshotWritePlan<?> plan;
         if (format == SnapshotFormat.NATIVE) {
             plan = new NativeSnapshotWritePlan();
         }
@@ -520,9 +520,12 @@ public class SnapshotSaveAPI
         }
         file_path = SnapshotUtil.getRealPath(SnapshotPathType.valueOf(pathType), file_path);
 
+        plan.setConfiguration(context, jsData);
+
+        context.getSiteSnapshotConnection().populateSnapshotSchemas(plan.getConfiguration());
+
         final Callable<Boolean> deferredSetup = plan.createSetup(file_path, pathType, file_nonce, txnId,
-                partitionTransactionIds, jsData, context, result, extraSnapshotData,
-                tracker, hashinatorData, timestamp);
+                partitionTransactionIds, context, result, extraSnapshotData, tracker, hashinatorData, timestamp);
         m_deferredSetupFuture =
                 VoltDB.instance().submitSnapshotIOWork(
                         new DeferredSnapshotSetup(plan, deferredSetup, txnId, partitionTransactionIds));

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -499,14 +499,14 @@ public class SnapshotSiteProcessor {
             SNAP_LOG.debug("Examining SnapshotTableTask: " + task);
 
             // Add the task to the task list for the given table
-            m_snapshotTableTasks.put(task.m_table.getRelativeIndex(), task);
+            m_snapshotTableTasks.put(task.m_tableInfo.getTableId(), task);
 
             // Make sure there is a predicate object for each table, the predicate could contain
             // empty expressions. So activateTableStream() doesn't have to do a null check.
-            SnapshotPredicates predicates = tablesAndPredicates.get(task.m_table.getRelativeIndex());
+            SnapshotPredicates predicates = tablesAndPredicates.get(task.m_tableInfo.getTableId());
             if (predicates == null) {
-                predicates = new SnapshotPredicates(task.m_table.getRelativeIndex());
-                tablesAndPredicates.put(task.m_table.getRelativeIndex(), predicates);
+                predicates = new SnapshotPredicates(task.m_tableInfo.getTableId());
+                tablesAndPredicates.put(task.m_tableInfo.getTableId(), predicates);
             }
 
             predicates.addPredicate(task.m_predicate, task.m_deleteTuples);
@@ -556,7 +556,7 @@ public class SnapshotSiteProcessor {
              * is responsible for closing the data target. Done in a separate
              * thread so the EE can continue working.
              */
-            if (tableTask.m_table.getIsreplicated() &&
+            if (tableTask.m_tableInfo.isReplicated() &&
                 tableTask.m_target.getFormat().canCloseEarly()) {
                 final Thread terminatorThread =
                     new Thread("Replicated SnapshotDataTarget terminator ") {

--- a/src/frontend/org/voltdb/SnapshotTableInfo.java
+++ b/src/frontend/org/voltdb/SnapshotTableInfo.java
@@ -1,0 +1,111 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.util.Arrays;
+
+import org.voltdb.catalog.Table;
+
+/**
+ * Class used to describe a table that can be involved in a snapshot. This is basically to have a single class that can
+ * be used to describe a catalog or system table.
+ */
+public class SnapshotTableInfo {
+    private final String m_name;
+    private final int m_tableId;
+    private final boolean m_replicated;
+    private byte[] m_schema;
+    private int m_partitionColumn;
+
+    /**
+     * Construct an instance from a catalog table
+     *
+     * @param table Catalog table
+     */
+    public SnapshotTableInfo(Table table) {
+        this(table.getTypeName(), table.getRelativeIndex(), table.getIsreplicated());
+    }
+
+    public SnapshotTableInfo(String name, int tableId, boolean replicated) {
+        m_name = name;
+        m_tableId = tableId;
+        m_replicated = replicated;
+    }
+
+    /**
+     * Set the schema and partition column for this table. As retrieved from the EE
+     *
+     * @param schema          Schema of table including any hidden columns included in snapshot
+     * @param partitionColumn Index of partition column if this is not a replicated table
+     */
+    public synchronized void setSchema(byte[] schema, int partitionColumn) {
+        if (m_schema == null) {
+            m_schema = schema;
+            m_partitionColumn = partitionColumn;
+        } else {
+            assert m_partitionColumn == partitionColumn && Arrays.equals(m_schema, schema) : "Schema for " + m_name
+                    + " does not match " + Arrays.toString(m_schema) + " vs " + Arrays.toString(schema) + " and "
+                    + m_partitionColumn + " vs " + partitionColumn;
+        }
+    }
+
+    /**
+     * @return The name of the table
+     */
+    public String getName() {
+        return m_name;
+    }
+
+    /**
+     * @return The ID/relative index of the table
+     */
+    public int getTableId() {
+        return m_tableId;
+    }
+
+    /**
+     * @return {@code true} if this table is replicated
+     */
+    public boolean isReplicated() {
+        return m_replicated;
+    }
+
+    /**
+     * @return The schema of this table as a byte array
+     * @throws IllegalStateException If {@link #setSchema(byte[], int)} has not been called yet
+     */
+    public synchronized byte[] getSchema() throws IllegalStateException {
+        if (m_schema == null) {
+            throw new IllegalStateException("schema not set");
+        }
+        return m_schema;
+    }
+
+    /**
+     * Return value is only valid if {@link #isReplicated()} returns {@code false}
+     *
+     * @return The index of the partition column
+     * @throws IllegalStateException If {@link #setSchema(byte[], int)} has not been called yet
+     */
+    public synchronized int getPartitionColumn() throws IllegalStateException {
+        if (m_schema == null) {
+            throw new IllegalStateException("schema not set");
+        }
+        return m_partitionColumn;
+    }
+}

--- a/src/frontend/org/voltdb/SnapshotTableInfo.java
+++ b/src/frontend/org/voltdb/SnapshotTableInfo.java
@@ -29,6 +29,7 @@ public class SnapshotTableInfo {
     private final String m_name;
     private final int m_tableId;
     private final boolean m_replicated;
+    private final boolean m_systemTable;
     private byte[] m_schema;
     private int m_partitionColumn;
 
@@ -38,13 +39,24 @@ public class SnapshotTableInfo {
      * @param table Catalog table
      */
     public SnapshotTableInfo(Table table) {
-        this(table.getTypeName(), table.getRelativeIndex(), table.getIsreplicated());
+        this(table.getTypeName(), table.getRelativeIndex(), table.getIsreplicated(), false);
     }
 
-    public SnapshotTableInfo(String name, int tableId, boolean replicated) {
+    /**
+     * Construct an instance for a system table
+     *
+     * @param name    of table
+     * @param tableId ID of the table
+     */
+    public SnapshotTableInfo(String name, int tableId) {
+        this(name, tableId, false, true);
+    }
+
+    private SnapshotTableInfo(String name, int tableId, boolean replicated, boolean systemTable) {
         m_name = name;
         m_tableId = tableId;
         m_replicated = replicated;
+        m_systemTable = systemTable;
     }
 
     /**
@@ -83,6 +95,13 @@ public class SnapshotTableInfo {
      */
     public boolean isReplicated() {
         return m_replicated;
+    }
+
+    /**
+     * @return {@code true} if this is a system table
+     */
+    public boolean isSystemTable() {
+        return m_systemTable;
     }
 
     /**

--- a/src/frontend/org/voltdb/SnapshotTableTask.java
+++ b/src/frontend/org/voltdb/SnapshotTableTask.java
@@ -17,7 +17,6 @@
 
 package org.voltdb;
 
-import org.voltdb.catalog.Table;
 import org.voltdb.expressions.AbstractExpression;
 
 /**
@@ -26,7 +25,7 @@ import org.voltdb.expressions.AbstractExpression;
  */
 public class SnapshotTableTask
 {
-    public final Table m_table;
+    public final SnapshotTableInfo m_tableInfo;
     public final SnapshotDataFilter m_filters[];
     public final AbstractExpression m_predicate;
     public final boolean m_deleteTuples;
@@ -34,12 +33,12 @@ public class SnapshotTableTask
     volatile SnapshotDataTarget m_target;
 
     public SnapshotTableTask(
-            final Table table,
+            final SnapshotTableInfo table,
             final SnapshotDataFilter filters[],
             final AbstractExpression predicate,
             final boolean deleteTuples)
     {
-        m_table = table;
+        m_tableInfo = table;
         m_filters = filters;
         m_predicate = predicate;
         m_deleteTuples = deleteTuples;
@@ -69,10 +68,8 @@ public class SnapshotTableTask
     @Override
     public String toString()
     {
-        return ("SnapshotTableTask for " + m_table.getTypeName() +
-                " replicated " + m_table.getIsreplicated() +
-                ", delete " + m_deleteTuples +
-                ", for target "+ m_target);
+        return "SnapshotTableTask for " + m_tableInfo.getName() + " replicated " + m_tableInfo.isReplicated()
+                + ", delete " + m_deleteTuples + ", for target " + m_target;
     }
 }
 

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -33,8 +33,8 @@ import org.voltdb.catalog.Table;
 import org.voltdb.messaging.RejoinMessage;
 import org.voltdb.rejoin.StreamSnapshotSink.RestoreWork;
 import org.voltdb.rejoin.TaskLog;
+import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.utils.CachedByteBufferAllocator;
-import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.ProClass;
 
 import com.google_voltpatches.common.util.concurrent.SettableFuture;
@@ -146,7 +146,7 @@ public abstract class JoinProducerBase extends SiteTasker {
     }
 
     protected boolean shouldAddToViewsToPause(Database db, Table table) {
-        return CatalogUtil.isSnapshotablePersistentTableView(db, table);
+        return SnapshotUtil.isSnapshotablePersistentTableView(db, table);
     }
 
     protected void initListOfViewsToPause() {

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1069,6 +1069,11 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 extraSnapshotData);
     }
 
+    @Override
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter filter) {
+        return m_ee.getSnapshotSchema(tableId, filter);
+    }
+
     /*
      * Do snapshot work exclusively until there is no more. Also blocks
      * until the syncing and closing of snapshot data targets has completed.

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -60,6 +60,7 @@ import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.SnapshotDataTarget;
 import org.voltdb.SnapshotFormat;
 import org.voltdb.SnapshotSiteProcessor;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.SnapshotTableTask;
 import org.voltdb.StartAction;
 import org.voltdb.StatsAgent;
@@ -1070,8 +1071,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter filter) {
-        return m_ee.getSnapshotSchema(tableId, filter);
+    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter) {
+        Pair<byte[], Integer> result = m_ee.getSnapshotSchema(table.getTableId(), filter);
+        table.setSchema(result.getFirst(), result.getSecond());
     }
 
     /*

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -608,6 +608,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /*
      * Interface frontend invokes to communicate to CPP execution engine.
      */
+    public abstract Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter);
 
     public abstract boolean activateTableStream(final int tableId,
                                                 TableStreamType type,
@@ -1135,6 +1136,14 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @return true for success false for failure
      */
     protected native boolean nativeSetLogLevels(long pointer, long logLevels);
+
+    /**
+     * @param pointer          Pointer to an engine instance
+     * @param tableId          ID of the table whose schema is being retrieved
+     * @param schemaFilterType Type of filter to apply to schema
+     * @return error code indicating status of execution
+     */
+    protected native int nativeGetSnapshotSchema(long pointer, int tableId, byte schemaFilterType);
 
     /**
      * Active a table stream of the specified type for a table.

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -1026,10 +1026,27 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             long spHandle, long lastCommittedSpHandle, long uniqueId, long undoToken, byte callerId);
 
     /**
+     * This method is called to initially load table data from a direct byte buffer
+     *
+     * @param pointer               the VoltDBEngine pointer
+     * @param table_id              catalog ID of the table
+     * @param serializedTable       the table data to be loaded
+     * @param txnId                 ID of the transaction
+     * @param spHandle              SP handle for this transaction
+     * @param lastCommittedSpHandle Most recently committed SP Handled
+     * @param uniqueId              Unique ID for the transaction
+     * @param undoToken             token for undo quantum where changes should be logged.
+     * @param callerId              ID of the caller who is invoking load table
+     */
+    protected native int nativeLoadTable(long pointer, int table_id, ByteBuffer serializedTable, long txnId,
+            long spHandle, long lastCommittedSpHandle, long uniqueId, long undoToken, byte callerId);
+
+    /**
      * Executes multiple plan fragments with the given parameter sets and gets the results.
-     * @param pointer the VoltDBEngine pointer
+     *
+     * @param pointer         the VoltDBEngine pointer
      * @param planFragmentIds ID of the plan fragment to be executed.
-     * @param inputDepIds list of input dependency ids or null if no deps expected
+     * @param inputDepIds     list of input dependency ids or null if no deps expected
      * @return error code
      */
     protected native int nativeExecutePlanFragments(

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1553,6 +1553,11 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean activateTableStream(
             int tableId,
             TableStreamType streamType,

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -612,6 +612,18 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     @Override
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter)
+            throws EEException {
+        m_nextDeserializer.clear();
+        checkErrorCode(nativeGetSnapshotSchema(pointer, tableId, hiddenColumnFilter.getId()));
+        try {
+            return Pair.of(m_nextDeserializer.readVarbinary(), m_nextDeserializer.readInt());
+        } catch (IOException e) {
+            throw new EEException(ERRORCODE_WRONG_SERIALIZED_BYTES);
+        }
+    }
+
+    @Override
     public boolean activateTableStream(int tableId, TableStreamType streamType,
                                        HiddenColumnFilter hiddenColumnFilter,
                                        long undoQuantumToken,

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -187,6 +187,11 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter) {
+        return Pair.of(new byte[0], -1);
+    }
+
+    @Override
     public boolean activateTableStream(int tableId, TableStreamType type, HiddenColumnFilter hiddenColumnFilter,
             long undoQuantumToken, byte[] predicates) {
         return false;

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.Mailbox;
@@ -42,6 +44,7 @@ import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.SnapshotDataTarget;
 import org.voltdb.SnapshotFormat;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.VoltDB;
 import org.voltdb.utils.CompressionService;
 
@@ -75,7 +78,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     final static int DATA_HEADER_BYTES = contentOffset + 4 + 4;
 
     // schemas for all the tables on this partition
-    private final Map<Integer, Pair<Boolean, byte[]>> m_schemas = new HashMap<>();
+    private final Map<Integer, Pair<Boolean, byte[]>> m_schemas;
     // HSId of the destination mailbox
     private final long m_destHSId;
     private final Set<Long> m_otherDestHostHSIds;
@@ -103,19 +106,21 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     private final AtomicBoolean m_closed = new AtomicBoolean(false);
 
     public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
-                                    byte[] hashinatorConfig, Map<Integer, Pair<Boolean, byte[]>> schemas,
-                                    SnapshotSender sender, StreamSnapshotAckReceiver ackReceiver)
+            byte[] hashinatorConfig, List<SnapshotTableInfo> tables, SnapshotSender sender,
+            StreamSnapshotAckReceiver ackReceiver)
     {
-        this(HSId, lowestDestSite, allDestHostHSIds, hashinatorConfig, schemas, DEFAULT_WRITE_TIMEOUT_MS, sender, ackReceiver);
+        this(HSId, lowestDestSite, allDestHostHSIds, hashinatorConfig, tables, DEFAULT_WRITE_TIMEOUT_MS, sender,
+                ackReceiver);
     }
 
     public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
-                                    byte[] hashinatorConfig, Map<Integer, Pair<Boolean, byte[]>> schemas,
-                                    long writeTimeout, SnapshotSender sender, StreamSnapshotAckReceiver ackReceiver)
+            byte[] hashinatorConfig, List<SnapshotTableInfo> tables, long writeTimeout, SnapshotSender sender,
+            StreamSnapshotAckReceiver ackReceiver)
     {
         super();
         m_targetId = m_totalSnapshotTargetCount.getAndIncrement();
-        m_schemas.putAll(schemas);
+        m_schemas = tables.stream().collect(
+                Collectors.toMap(SnapshotTableInfo::getTableId, t -> Pair.of(t.isReplicated(), t.getSchema())));
         m_destHSId = HSId;
         m_replicatedTableTarget = lowestDestSite;
         m_otherDestHostHSIds = new HashSet<>(allDestHostHSIds);

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
@@ -18,9 +18,11 @@
 package org.voltdb.sysprocs;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.TreeSet;
 
 import org.voltdb.SnapshotFormat;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 
 /**
@@ -55,21 +57,21 @@ public class SnapshotRegistry {
         private final HashMap< String, Table> tables = new HashMap< String, Table>();
 
         private Snapshot(long txnId, long timeStarted, int hostId, String path, String nonce,
-                SnapshotFormat format, org.voltdb.catalog.Table tables[]) {
+                SnapshotFormat format, List<SnapshotTableInfo> tables) {
             this.txnId = txnId;
             this.timeStarted = timeStarted;
             this.path = path;
             this.nonce = nonce;
             timeFinished = 0;
             synchronized (this.tables) {
-                for (org.voltdb.catalog.Table table : tables) {
+                for (SnapshotTableInfo table : tables) {
                     String filename =
                         SnapshotUtil.constructFilenameForTable(
                                 table,
                                 nonce,
                                 format,
                                 hostId);
-                    this.tables.put(table.getTypeName(), new Table(table.getTypeName(), filename));
+                    this.tables.put(table.getName(), new Table(table.getName(), filename));
                 }
             }
             result = false;
@@ -154,7 +156,7 @@ public class SnapshotRegistry {
             String path,
             String nonce,
             SnapshotFormat format,
-            org.voltdb.catalog.Table tables[]) {
+            List<SnapshotTableInfo> tables) {
         final Snapshot s = new Snapshot(txnId, System.currentTimeMillis(),
                 hostId, path, nonce, format, tables);
 

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1900,12 +1900,12 @@ public class SnapshotRestore extends VoltSystemProcedure {
 
         for (Table table : m_database.getTables()) {
             if (savedTableNames.contains(table.getTypeName())) {
-                if (CatalogUtil.isSnapshotablePersistentTableView(m_database, table)) {
+                if (SnapshotUtil.isSnapshotablePersistentTableView(m_database, table)) {
                     // If the table is a snapshotted persistent table view, we will try to
                     // temporarily disable its maintenance job to boost restore performance.
                     commaSeparatedViewNamesToDisable.append(table.getTypeName()).append(",");
                 } else if (table.getMaterializer() != null
-                        && !CatalogUtil.isSnapshotableStreamedTableView(m_database, table)) {
+                        && !SnapshotUtil.isSnapshotableStreamedTableView(m_database, table)) {
                     SNAP_LOG.info("Skipping restore of " + table.getTypeName()
                             + " which normally would not be in a snapshot for the current schema");
                     /*

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -67,7 +67,8 @@ public class ValidatePartitioning extends VoltSystemProcedure {
             final VoltTable results = constructPartitioningResultsTable();
             List<Integer> tableIds = new ArrayList<Integer>();
             List<String> tableNames = new ArrayList<String>();
-            for (SnapshotTableInfo t : SnapshotUtil.getTablesToSave(context.getDatabase(), t -> !t.getIsreplicated())) {
+            for (SnapshotTableInfo t : SnapshotUtil.getTablesToSave(context.getDatabase(), t -> !t.getIsreplicated(),
+                    true)) {
                 tableIds.add(t.getTableId());
                 tableNames.add(t.getName());
             }

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -25,14 +25,14 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.TheHashinator;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.Table;
-import org.voltdb.utils.CatalogUtil;
+import org.voltdb.sysprocs.saverestore.SnapshotUtil;
 import org.voltdb.utils.VoltTableUtil;
 
 import com.google_voltpatches.common.primitives.Longs;
@@ -67,9 +67,9 @@ public class ValidatePartitioning extends VoltSystemProcedure {
             final VoltTable results = constructPartitioningResultsTable();
             List<Integer> tableIds = new ArrayList<Integer>();
             List<String> tableNames = new ArrayList<String>();
-            for (Table t : CatalogUtil.getSnapshotableTables(context.getDatabase(), false).getFirst()) {
-                tableIds.add(t.getRelativeIndex());
-                tableNames.add(t.getTypeName());
+            for (SnapshotTableInfo t : SnapshotUtil.getTablesToSave(context.getDatabase(), t -> !t.getIsreplicated())) {
+                tableIds.add(t.getTableId());
+                tableNames.add(t.getName());
             }
             long mispartitionedCounts[] = context.getSiteProcedureConnection().validatePartitioning(
                     Longs.toArray(tableIds), (byte[])params.toArray()[0]);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/CsvSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/CsvSnapshotRequestConfig.java
@@ -33,4 +33,10 @@ class CsvSnapshotRequestConfig extends SnapshotRequestConfig {
         // CSV snapshots never include hidden columns
         return HiddenColumnFilter.ALL;
     }
+
+    @Override
+    protected boolean includeSystemTables() {
+        // CSV snapshots never include system tables
+        return false;
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/CsvSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/CsvSnapshotRequestConfig.java
@@ -17,26 +17,20 @@
 
 package org.voltdb.sysprocs.saverestore;
 
+import org.json_voltpatches.JSONObject;
+import org.voltdb.catalog.Database;
+
 /**
- * Enum to describe any schema filtering which is to be performed during a snapshot.
- * <p>
- * Must be in sync with EE enum of the same name
+ * Snapshot request configuration which is for CSV snapshots to enforce exclusion of all hidden columns
  */
-public enum HiddenColumnFilter {
-    /** Do not include any hidden columns */
-    ALL(0),
-    /** Perform no filtering */
-    NONE(1),
-    /** Exclude the hidden migrate column from the snapshot */
-    EXCLUDE_MIGRATE(2);
-
-    private final byte m_id;
-
-    private HiddenColumnFilter(int id) {
-        m_id = (byte) id;
+class CsvSnapshotRequestConfig extends SnapshotRequestConfig {
+    CsvSnapshotRequestConfig(JSONObject jsData, Database catalogDatabase) {
+        super(jsData, catalogDatabase);
     }
 
-    public byte getId() {
-        return m_id;
+    @Override
+    public HiddenColumnFilter getHiddenColumnFilter() {
+        // CSV snapshots never include hidden columns
+        return HiddenColumnFilter.ALL;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotRequestConfig.java
@@ -26,8 +26,8 @@ import java.util.SortedMap;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Table;
 
 import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.ImmutableSortedMap;
@@ -54,7 +54,7 @@ public class IndexSnapshotRequestConfig extends SnapshotRequestConfig {
 
     public final Collection<PartitionRanges> partitionRanges;
 
-    public IndexSnapshotRequestConfig(List<Table> tables, Collection<PartitionRanges> partitionRanges)
+    public IndexSnapshotRequestConfig(List<SnapshotTableInfo> tables, Collection<PartitionRanges> partitionRanges)
     {
         super(tables);
         this.partitionRanges = ImmutableList.copyOf(partitionRanges);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -31,10 +31,10 @@ import java.util.TreeSet;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.Pair;
 import org.voltdb.ParameterSet;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltSystemProcedure.SynthesizedPlanFragment;
 import org.voltdb.VoltTableRow;
-import org.voltdb.catalog.Table;
 import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.sysprocs.SysProcFragmentId;
 
@@ -123,20 +123,12 @@ public class PartitionedTableSaveFileState extends TableSaveFileState
 
     @Override
     public SynthesizedPlanFragment[]
-    generateRestorePlan(Table catalogTable, SiteTracker st)
+            generateRestorePlan(SnapshotTableInfo table, SiteTracker st)
     {
-        SynthesizedPlanFragment[] restore_plan = null;
         LOG.info("Total partitions for Table: " + getTableName() + ": " +
                  getTotalPartitions());
-        if (!catalogTable.getIsreplicated())
-        {
-            restore_plan = generatePartitionedToPartitionedPlan(st);
-        }
-        else
-        {
-            restore_plan = generatePartitionedToReplicatedPlan(st);
-        }
-        return restore_plan;
+        return table.isReplicated() ? generatePartitionedToReplicatedPlan(st)
+                : generatePartitionedToPartitionedPlan(st);
     }
 
     private void checkSiteConsistency(VoltTableRow row) throws IOException

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
@@ -24,9 +24,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.voltdb.ParameterSet;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.VoltSystemProcedure.SynthesizedPlanFragment;
 import org.voltdb.VoltTableRow;
-import org.voltdb.catalog.Table;
 import org.voltdb.dtxn.SiteTracker;
 import org.voltdb.sysprocs.SysProcFragmentId;
 
@@ -68,18 +68,12 @@ public class ReplicatedTableSaveFileState extends TableSaveFileState {
     }
 
     @Override public SynthesizedPlanFragment[]
-    generateRestorePlan(Table catalogTable, SiteTracker st) {
+            generateRestorePlan(SnapshotTableInfo table, SiteTracker st) {
         for (int hostId : m_hostsWithThisTable) {
             m_sitesWithThisTable.addAll(st.getSitesForHost(hostId));
         }
 
-        SynthesizedPlanFragment[] restore_plan = null;
-        if (catalogTable.getIsreplicated()) {
-            restore_plan = generateReplicatedToReplicatedPlan(st);
-        } else {
-            restore_plan = generateReplicatedToPartitionedPlan(st);
-        }
-        return restore_plan;
+        return table.isReplicated() ? generateReplicatedToReplicatedPlan(st) : generateReplicatedToPartitionedPlan(st);
     }
 
     private void checkSiteConsistency(VoltTableRow row) throws IOException {

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotRequestConfig.java
@@ -18,7 +18,6 @@
 package org.voltdb.sysprocs.saverestore;
 
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Set;
 
 import org.json_voltpatches.JSONArray;
@@ -26,11 +25,12 @@ import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.logging.VoltLogger;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Table;
 
 import com.google_voltpatches.common.base.Joiner;
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.Sets;
 
 public class SnapshotRequestConfig {
@@ -41,10 +41,10 @@ public class SnapshotRequestConfig {
     public static final String JKEY_SCHEMA_BUILDER = "schemaBuilder";
 
     public final boolean emptyConfig;
-    public final Table[] tables;
+    public final List<SnapshotTableInfo> tables;
     public final Integer newPartitionCount;
     public final String truncationRequestId;
-    public final HiddenColumnFilter hiddenColumnFilter;
+    private final HiddenColumnFilter hiddenColumnFilter;
 
     public static HiddenColumnFilter getHiddenColumnFilter(JSONObject jsonObject) {
         if (jsonObject != null) {
@@ -59,16 +59,16 @@ public class SnapshotRequestConfig {
     /**
      * @param tables    Tables to snapshot, cannot be null.
      */
-    public SnapshotRequestConfig(List<Table> tables) {
+    public SnapshotRequestConfig(List<SnapshotTableInfo> tables) {
         this(Preconditions.checkNotNull(tables), (Integer) null);
     }
 
-    public SnapshotRequestConfig(List<Table> tables, HiddenColumnFilter schemaFilterType) {
+    public SnapshotRequestConfig(List<SnapshotTableInfo> tables, HiddenColumnFilter schemaFilterType) {
         this(Preconditions.checkNotNull(tables), null, schemaFilterType);
     }
 
     public SnapshotRequestConfig(int newPartitionCount) {
-        this((Table[]) null, Integer.valueOf(newPartitionCount), HiddenColumnFilter.NONE);
+        this(null, Integer.valueOf(newPartitionCount), HiddenColumnFilter.NONE);
     }
 
     public SnapshotRequestConfig(int newPartitionCount, Database catalogDatabase) {
@@ -76,16 +76,11 @@ public class SnapshotRequestConfig {
                 HiddenColumnFilter.NONE);
     }
 
-    protected SnapshotRequestConfig(List<Table> tables, Integer newPartitionCount) {
-        this(tables.toArray(new Table[tables.size()]), newPartitionCount, HiddenColumnFilter.NONE);
+    protected SnapshotRequestConfig(List<SnapshotTableInfo> tables, Integer newPartitionCount) {
+        this(tables, newPartitionCount, HiddenColumnFilter.NONE);
     }
 
-    protected SnapshotRequestConfig(List<Table> tables, Integer newPartitionCount,
-            HiddenColumnFilter schemaFilterType) {
-        this(tables.toArray(new Table[tables.size()]), newPartitionCount, schemaFilterType);
-    }
-
-    private SnapshotRequestConfig(Table[] tables, Integer newPartitionCount,
+    protected SnapshotRequestConfig(List<SnapshotTableInfo> tables, Integer newPartitionCount,
             HiddenColumnFilter schemaFilterType) {
         emptyConfig = false;
         this.tables = tables;
@@ -110,12 +105,11 @@ public class SnapshotRequestConfig {
         }
     }
 
-    private static Table[] getTablesToInclude(JSONObject jsData,
+    private static List<SnapshotTableInfo> getTablesToInclude(JSONObject jsData,
                                               Database catalogDatabase)
     {
-        final List<Table> tables = SnapshotUtil.getTablesToSave(catalogDatabase);
-        Set<String> tableNamesToInclude = null;
-        Set<String> tableNamesToExclude = null;
+        Set<String> tableNamesToInclude;
+        Set<String> tableNamesToExclude;
 
         if (jsData != null) {
             JSONArray tableNames = jsData.optJSONArray(JKEY_TABLES);
@@ -131,6 +125,8 @@ public class SnapshotRequestConfig {
                         SNAP_LOG.warn("Unable to parse tables to include for snapshot", e);
                     }
                 }
+            } else {
+                tableNamesToInclude = null;
             }
 
             JSONArray excludeTableNames = jsData.optJSONArray("skiptables");
@@ -146,23 +142,24 @@ public class SnapshotRequestConfig {
                         SNAP_LOG.warn("Unable to parse tables to exclude for snapshot", e);
                     }
                 }
+            } else {
+                tableNamesToExclude = null;
             }
+        } else {
+            tableNamesToExclude = null;
+            tableNamesToInclude = null;
         }
 
+        final List<SnapshotTableInfo> tables;
         if (tableNamesToInclude != null && tableNamesToInclude.isEmpty()) {
             // Stream snapshot may specify empty snapshot sometimes.
-            tables.clear();
+            return ImmutableList.of();
         } else if (tableNamesToInclude != null || tableNamesToExclude != null) {
-            ListIterator<Table> iter = tables.listIterator();
-            while (iter.hasNext()) {
-                Table table = iter.next();
-                if ((tableNamesToInclude != null && !tableNamesToInclude.remove(table.getTypeName())) ||
-                    (tableNamesToExclude != null && tableNamesToExclude.remove(table.getTypeName()))) {
-                    // If the table index is not in the list to include or
-                    // is in the list to exclude, remove it
-                    iter.remove();
-                }
-            }
+            tables = SnapshotUtil.getTablesToSave(catalogDatabase,
+                    t -> (tableNamesToInclude == null || tableNamesToInclude.remove(t.getTypeName()))
+                            && (tableNamesToExclude == null || !tableNamesToExclude.remove(t.getTypeName())));
+        } else {
+            tables =  SnapshotUtil.getTablesToSave(catalogDatabase);
         }
 
         if (tableNamesToInclude != null && !tableNamesToInclude.isEmpty()) {
@@ -176,7 +173,7 @@ public class SnapshotRequestConfig {
                     Joiner.on(", ").join(tableNamesToExclude));
         }
 
-        return tables.toArray(new Table[tables.size()]);
+        return tables;
     }
 
     public void toJSONString(JSONStringer stringer) throws JSONException
@@ -184,14 +181,18 @@ public class SnapshotRequestConfig {
         if (tables != null) {
             stringer.key(JKEY_TABLES);
             stringer.array();
-            for (Table table : tables) {
-                stringer.value(table.getTypeName());
+            for (SnapshotTableInfo table : tables) {
+                stringer.value(table.getName());
             }
             stringer.endArray();
         }
         if (newPartitionCount != null) {
             stringer.keySymbolValuePair(JKEY_NEW_PARTITION_COUNT, newPartitionCount.longValue());
         }
-        stringer.keySymbolValuePair(JKEY_SCHEMA_BUILDER, hiddenColumnFilter.name());
+        stringer.keySymbolValuePair(JKEY_SCHEMA_BUILDER, getHiddenColumnFilter().name());
+    }
+
+    public HiddenColumnFilter getHiddenColumnFilter() {
+        return hiddenColumnFilter;
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
 import org.json_voltpatches.JSONArray;
@@ -70,6 +71,7 @@ import org.voltdb.SnapshotDaemon;
 import org.voltdb.SnapshotDaemon.ForwardClientException;
 import org.voltdb.SnapshotFormat;
 import org.voltdb.SnapshotInitiationInfo;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.StoredProcedureInvocation;
 import org.voltdb.TableType;
 import org.voltdb.VoltDB;
@@ -77,7 +79,6 @@ import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
@@ -162,7 +163,7 @@ public class SnapshotUtil {
         String path,
         String pathType,
         String nonce,
-        List<Table> tables,
+        List<SnapshotTableInfo> tables,
         int hostId,
         Map<Integer, Long> partitionTransactionIds,
         ExtensibleSnapshotDigestData extraSnapshotData,
@@ -194,7 +195,7 @@ public class SnapshotUtil {
                 stringer.keySymbolValuePair(JSON_NEW_PARTITION_COUNT, newPartitionCount);
                 stringer.key("tables").array();
                 for (int ii = 0; ii < tables.size(); ii++) {
-                    stringer.value(tables.get(ii).getTypeName());
+                    stringer.value(tables.get(ii).getName());
                 }
                 stringer.endArray();
 
@@ -1205,7 +1206,7 @@ public class SnapshotUtil {
      * @param fileNonce
      * @param hostId
      */
-    public static final String constructFilenameForTable(Table table,
+    public static final String constructFilenameForTable(SnapshotTableInfo table,
                                                          String fileNonce,
                                                          SnapshotFormat format,
                                                          int hostId)
@@ -1217,8 +1218,8 @@ public class SnapshotUtil {
 
         StringBuilder filename_builder = new StringBuilder(fileNonce);
         filename_builder.append("-");
-        filename_builder.append(table.getTypeName());
-        if (!table.getIsreplicated())
+        filename_builder.append(table.getName());
+        if (!table.isReplicated())
         {
             filename_builder.append("-host_");
             filename_builder.append(hostId);
@@ -1227,7 +1228,7 @@ public class SnapshotUtil {
         return filename_builder.toString();
     }
 
-    public static final File constructFileForTable(Table table,
+    public static final File constructFileForTable(SnapshotTableInfo table,
             String filePath,
             String fileNonce,
             SnapshotFormat format,
@@ -1267,10 +1268,13 @@ public class SnapshotUtil {
         return (nonce + ".jar");
     }
 
-    public static final List<Table> getTablesToSave(Database database) {
-        CatalogMap<Table> all_tables = database.getTables();
-        ArrayList<Table> my_tables = new ArrayList<Table>();
-        for (Table table : all_tables) {
+    public static final List<SnapshotTableInfo> getTablesToSave(Database database) {
+        return getTablesToSave(database, t -> true);
+    }
+
+    public static final List<SnapshotTableInfo> getTablesToSave(Database database, Predicate<Table> predicate) {
+        ArrayList<SnapshotTableInfo> tables = new ArrayList<>();
+        for (Table table : database.getTables()) {
             // STREAM tables are not included in the snapshot.
             if (TableType.isStream(table.getTabletype())) {
                 continue;
@@ -1278,12 +1282,14 @@ public class SnapshotUtil {
             // If the table is a view and it shouldn't be included into the snapshot, skip.
             if (table.getMaterializer() != null
                     && ! CatalogUtil.isSnapshotableStreamedTableView(database, table)
-                    && ! CatalogUtil.isSnapshotablePersistentTableView(database, table)) {
+                    && !CatalogUtil.isSnapshotablePersistentTableView(database, table)) {
                 continue;
             }
-            my_tables.add(table);
+            if (predicate.test(table)) {
+                tables.add(new SnapshotTableInfo(table));
+            }
         }
-        return my_tables;
+        return tables;
     }
 
     public static File[] retrieveRelevantFiles(String filePath,

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -1338,7 +1338,7 @@ public class SnapshotUtil {
     public static Set<String> getRequiredSnapshotableTableNames(InMemoryJarfile jarFile) {
         Database database = CatalogUtil.getDatabaseFrom(jarFile);
         // Snapshotable persistent table views are considered optional. ENG-11578, ENG-14145
-        return getTablesToSave(database, t -> !isSnapshotablePersistentTableView(database, t)).stream()
+        return getTablesToSave(database, t -> !isSnapshotablePersistentTableView(database, t), false).stream()
                 .map(SnapshotTableInfo::getName)
                 .collect(Collectors.toSet());
     }
@@ -1354,14 +1354,33 @@ public class SnapshotUtil {
     public static final List<SnapshotTableInfo> getPartitionedNormalTablesToSave(Database database) {
         return getTablesToSave(database,
                 t -> !t.getIsreplicated()
-                        && (t.getMaterializer() == null || TableType.isStream(t.getMaterializer().getTabletype())));
+                        && (t.getMaterializer() == null || TableType.isStream(t.getMaterializer().getTabletype())),
+                true);
     }
 
+    /**
+     * @param database from which to retrieve tables
+     * @return All tables and system tables which are eligible to be snapshotted
+     */
     public static final List<SnapshotTableInfo> getTablesToSave(Database database) {
-        return getTablesToSave(database, t -> true);
+        return getTablesToSave(database, t -> true, st -> true);
     }
 
-    public static final List<SnapshotTableInfo> getTablesToSave(Database database, Predicate<Table> predicate) {
+    public static final List<SnapshotTableInfo> getTablesToSave(Database database, Predicate<Table> predicate,
+            boolean includeSystemTables) {
+        return getTablesToSave(database, predicate, t -> includeSystemTables);
+    }
+
+    /**
+     * Create a list of {@link SnapshotTableInfo} that have been selected for a snapshot
+     *
+     * @param database             from which to retrieve tables
+     * @param tablePredicate       Predicate to apply to all tables from {@code database}
+     * @param systemTablePredicate Predicate to apply to {@link SystemTable}s
+     * @return List of tables selected for a snapshot
+     */
+    public static final List<SnapshotTableInfo> getTablesToSave(Database database, Predicate<Table> tablePredicate,
+            Predicate<SystemTable> systemTablePredicate) {
         ArrayList<SnapshotTableInfo> tables = new ArrayList<>();
         for (Table table : database.getTables()) {
             // STREAM tables are not included in the snapshot.
@@ -1374,10 +1393,17 @@ public class SnapshotUtil {
                     && !isSnapshotablePersistentTableView(database, table)) {
                 continue;
             }
-            if (predicate.test(table)) {
+            if (tablePredicate.test(table)) {
                 tables.add(new SnapshotTableInfo(table));
             }
         }
+
+        for (SystemTable table : SystemTable.values()) {
+            if (systemTablePredicate.test(table)) {
+                tables.add(table.getTableInfo());
+            }
+        }
+
         return tables;
     }
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -49,6 +49,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
 import org.json_voltpatches.JSONArray;
@@ -79,12 +80,14 @@ import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
+import org.voltdb.catalog.Column;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.common.Constants;
 import org.voltdb.settings.NodeSettings;
 import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.InMemoryJarfile;
 import org.voltdb.utils.VoltFile;
 
 import com.google_voltpatches.common.base.Throwables;
@@ -194,8 +197,8 @@ public class SnapshotUtil {
                 stringer.keySymbolValuePair("timestampString", SnapshotUtil.formatHumanReadableDate(timestamp));
                 stringer.keySymbolValuePair(JSON_NEW_PARTITION_COUNT, newPartitionCount);
                 stringer.key("tables").array();
-                for (int ii = 0; ii < tables.size(); ii++) {
-                    stringer.value(tables.get(ii).getName());
+                for (SnapshotTableInfo table : tables) {
+                    stringer.value(table.getName());
                 }
                 stringer.endArray();
 
@@ -1005,8 +1008,8 @@ public class SnapshotUtil {
              * Summarize what was inconsistent/consistent
              */
             if (!inconsistent) {
-                for (int ii = 0; ii < snapshot.m_digests.size(); ii++) {
-                    pw.println(indentString + snapshot.m_digests.get(ii).getPath());
+                for (File element : snapshot.m_digests) {
+                    pw.println(indentString + element.getPath());
                 }
             } else {
                 pw.println(indentString + "Not all digests are consistent");
@@ -1030,8 +1033,8 @@ public class SnapshotUtil {
             pw.print(indentString + "Tables: ");
             int ii = 0;
 
-            for (int jj = 0; jj < snapshot.m_digestTables.size(); jj++) {
-                for (String table : snapshot.m_digestTables.get(jj)) {
+            for (Set<String> element : snapshot.m_digestTables) {
+                for (String table : element) {
                     digestTablesSeen.add(table);
                 }
             }
@@ -1268,6 +1271,92 @@ public class SnapshotUtil {
         return (nonce + ".jar");
     }
 
+    /**
+     * Test if a table is a persistent table view and should be included in the snapshot.
+     *
+     * @param db    The database catalog
+     * @param table The table to test.</br>
+     * @return If the table is a persistent table view that should be snapshotted.
+     */
+    public static boolean isSnapshotablePersistentTableView(Database db, Table table) {
+        Table materializer = table.getMaterializer();
+        if (materializer == null) {
+            // Return false if it is not a materialized view.
+            return false;
+        }
+        if (CatalogUtil.isStream(db, materializer)) {
+            // The view source table should not be a streamed table.
+            return false;
+        }
+        if (!table.getIsreplicated() && table.getPartitioncolumn() == null) {
+            // If the view table is implicitly partitioned (maybe was not in snapshot),
+            // its maintenance is not turned off during the snapshot restore process.
+            // Let it take care of its own data by itself.
+            // Do not attempt to restore data for it.
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Test if a table is a streamed table view and should be included in the snapshot.
+     *
+     * @param db    The database catalog
+     * @param table The table to test.</br>
+     * @return If the table is a streamed table view that should be snapshotted.
+     */
+    public static boolean isSnapshotableStreamedTableView(Database db, Table table) {
+        Table materializer = table.getMaterializer();
+        if (materializer == null) {
+            // Return false if it is not a materialized view.
+            return false;
+        }
+        if (!CatalogUtil.isStream(db, materializer)) {
+            // Test if the view source table is a streamed table.
+            return false;
+        }
+        // Non-partitioned export table are not allowed so it should not get here.
+        Column sourcePartitionColumn = materializer.getPartitioncolumn();
+        if (sourcePartitionColumn == null) {
+            return false;
+        }
+        // Make sure the partition column is present in the view.
+        // Export table views are special, we use column names to match..
+        Column pc = table.getColumns().get(sourcePartitionColumn.getName());
+        if (pc == null) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get all required snapshotable tables from an in-memory catalog jar file.
+     *
+     * @param jarFile a in-memory catalog jar file
+     * @return {@link Set} of table names which must be included in a snapshot for it to be valid
+     */
+    public static Set<String> getRequiredSnapshotableTableNames(InMemoryJarfile jarFile) {
+        Database database = CatalogUtil.getDatabaseFrom(jarFile);
+        // Snapshotable persistent table views are considered optional. ENG-11578, ENG-14145
+        return getTablesToSave(database, t -> !isSnapshotablePersistentTableView(database, t)).stream()
+                .map(SnapshotTableInfo::getName)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Get all normal tables from the catalog. A normal table is one that's NOT a materialized view, nor an export
+     * table. For the lack of a better name, I call it normal.
+     *
+     * @param catalog      Catalog database
+     * @param isReplicated true to return only replicated tables, false to return all partitioned tables
+     * @return A list of tables
+     */
+    public static final List<SnapshotTableInfo> getPartitionedNormalTablesToSave(Database database) {
+        return getTablesToSave(database,
+                t -> !t.getIsreplicated()
+                        && (t.getMaterializer() == null || TableType.isStream(t.getMaterializer().getTabletype())));
+    }
+
     public static final List<SnapshotTableInfo> getTablesToSave(Database database) {
         return getTablesToSave(database, t -> true);
     }
@@ -1281,8 +1370,8 @@ public class SnapshotUtil {
             }
             // If the table is a view and it shouldn't be included into the snapshot, skip.
             if (table.getMaterializer() != null
-                    && ! CatalogUtil.isSnapshotableStreamedTableView(database, table)
-                    && !CatalogUtil.isSnapshotablePersistentTableView(database, table)) {
+                    && !isSnapshotableStreamedTableView(database, table)
+                    && !isSnapshotablePersistentTableView(database, table)) {
                 continue;
             }
             if (predicate.test(table)) {

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
@@ -26,8 +26,8 @@ import org.json_voltpatches.JSONArray;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.json_voltpatches.JSONStringer;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Table;
 
 import com.google_voltpatches.common.collect.ArrayListMultimap;
 import com.google_voltpatches.common.collect.ImmutableList;
@@ -70,7 +70,7 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
      * @param streams            Stream configurations
      * @param shouldTruncate     true to also generate a truncation snapshot
      */
-    public StreamSnapshotRequestConfig(List<Table> tables,
+    public StreamSnapshotRequestConfig(List<SnapshotTableInfo> tables,
                                        List<Stream> streams,
                                        boolean shouldTruncate)
     {
@@ -80,7 +80,7 @@ public class StreamSnapshotRequestConfig extends SnapshotRequestConfig {
         this.shouldTruncate = shouldTruncate;
     }
 
-    public StreamSnapshotRequestConfig(List<Table> tables, int newPartitionCount, List<Stream> streams,
+    public StreamSnapshotRequestConfig(List<SnapshotTableInfo> tables, int newPartitionCount, List<Stream> streams,
             boolean shouldTruncate) {
         super(tables, newPartitionCount);
 

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SystemTable.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SystemTable.java
@@ -16,7 +16,11 @@
  */
 package org.voltdb.sysprocs.saverestore;
 
+import java.util.Map;
+
 import org.voltdb.SnapshotTableInfo;
+
+import com.google_voltpatches.common.collect.ImmutableSortedMap;
 
 /**
  * Enum of all of the system tables defined in the EE. The IDs have to be kept in sync between here and
@@ -28,8 +32,29 @@ public enum SystemTable {
     KIPLING_GROUP_MEMBER_PROTOCOL(-3, "_KIPLING_GROUP_MEMBER_PROTOCOL"),
     KIPLING_GROUP_OFFSET(-4, "_KIPLING_GROUP_OFFSET");
 
+    private static final Map<String, SystemTable> s_nameToTable;
+
     private final int m_id;
     private final String m_name;
+
+    static {
+        // Use case insensitive order to allow case insensitive lookups
+        ImmutableSortedMap.Builder<String, SystemTable> builder = ImmutableSortedMap
+                .orderedBy(String.CASE_INSENSITIVE_ORDER);
+        for (SystemTable st : values()) {
+            builder.put(st.getName(), st);
+        }
+        s_nameToTable = builder.build();
+    }
+
+    /**
+     * @param name of system table
+     * @return {@link SnapshotTableInfo} for {@code name} or {@code null} if the system table does not exist
+     */
+    public static SnapshotTableInfo getTableInfo(String name) {
+        SystemTable table = s_nameToTable.get(name);
+        return table == null ? null : table.getTableInfo();
+    }
 
     SystemTable(int id, String name) {
         m_id = id;

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SystemTable.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SystemTable.java
@@ -1,0 +1,50 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.sysprocs.saverestore;
+
+import org.voltdb.SnapshotTableInfo;
+
+/**
+ * Enum of all of the system tables defined in the EE. The IDs have to be kept in sync between here and
+ * SystemTableFactory.h but the the names do not need to be the same.
+ */
+public enum SystemTable {
+    KIPLING_GROUP(-1, "_KIPLING_GROUP"),
+    KIPLING_GROUP_MEMBER(-2, "_KIPLING_GROUP_MEMBER"),
+    KIPLING_GROUP_MEMBER_PROTOCOL(-3, "_KIPLING_GROUP_MEMBER_PROTOCOL"),
+    KIPLING_GROUP_OFFSET(-4, "_KIPLING_GROUP_OFFSET");
+
+    private final int m_id;
+    private final String m_name;
+
+    SystemTable(int id, String name) {
+        m_id = id;
+        m_name = name;
+    }
+
+    public int getId() {
+        return m_id;
+    }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public SnapshotTableInfo getTableInfo() {
+        return new SnapshotTableInfo(m_name, m_id);
+    }
+}

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
@@ -17,6 +17,7 @@
 
 package org.voltdb.sysprocs.saverestore;
 
+import java.io.Closeable;
 import java.io.EOFException;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
@@ -55,7 +56,7 @@ import org.voltdb.utils.PosixAdvise;
  * as well as a byte to that is set once the file is completely written and synced.
  * A VoltTable header describing the schema follows the JSON blob.
  */
-public class TableSaveFile
+public class TableSaveFile implements Closeable
 {
 
     public static enum ChecksumType {
@@ -386,6 +387,7 @@ public class TableSaveFile
         return m_timestamp;
     }
 
+    @Override
     public void close() throws IOException {
         Thread chunkReader;
         synchronized (this) {
@@ -778,7 +780,9 @@ public class TableSaveFile
                         TableSaveFile.this.notifyAll();
                     }
                 } finally {
-                    if (c != null) c.discard();
+                    if (c != null) {
+                        c.discard();
+                    }
                 }
             }
             fileInputBufferC.discard();
@@ -1041,7 +1045,9 @@ public class TableSaveFile
                         TableSaveFile.this.notifyAll();
                     }
                 } finally {
-                    if (c != null) c.discard();
+                    if (c != null) {
+                        c.discard();
+                    }
                 }
             }
             fileInputBufferC.discard();

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
@@ -19,9 +19,9 @@ package org.voltdb.sysprocs.saverestore;
 
 import java.io.IOException;
 
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.VoltSystemProcedure.SynthesizedPlanFragment;
 import org.voltdb.VoltTableRow;
-import org.voltdb.catalog.Table;
 import org.voltdb.dtxn.SiteTracker;
 
 public abstract class TableSaveFileState
@@ -42,8 +42,7 @@ public abstract class TableSaveFileState
         m_consistencyResult = "Table: " + m_tableName + " not yet processed";
     }
 
-    abstract public SynthesizedPlanFragment[]
-    generateRestorePlan(Table catalogTable, SiteTracker st);
+    abstract public SynthesizedPlanFragment[] generateRestorePlan(SnapshotTableInfo tableInfo, SiteTracker st);
 
     String getTableName()
     {

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -46,7 +46,6 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -64,7 +63,6 @@ import javax.xml.validation.SchemaFactory;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop_voltpatches.util.PureJavaCrc32;
 import org.apache.hadoop_voltpatches.util.PureJavaCrc32C;
 import org.apache.zookeeper_voltpatches.CreateMode;
 import org.apache.zookeeper_voltpatches.KeeperException;
@@ -165,7 +163,6 @@ import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
 import com.google_voltpatches.common.collect.Maps;
-import com.google_voltpatches.common.collect.Sets;
 
 /**
  *
@@ -412,62 +409,6 @@ public abstract class CatalogUtil {
             if (ExpressionType.get(c.getAggregatetype()) == ExpressionType.AGGREGATE_COUNT_STAR) {
                 return false;
             }
-        }
-        return true;
-    }
-
-    /**
-     * Test if a table is a persistent table view and should be included in the snapshot.
-     * @param db The database catalog
-     * @param table The table to test.</br>
-     * @return If the table is a persistent table view that should be snapshotted.
-     */
-    public static boolean isSnapshotablePersistentTableView(Database db, Table table) {
-        Table materializer = table.getMaterializer();
-        if (materializer == null) {
-            // Return false if it is not a materialized view.
-            return false;
-        }
-        if (CatalogUtil.isStream(db, materializer)) {
-            // The view source table should not be a streamed table.
-            return false;
-        }
-        if (! table.getIsreplicated() && table.getPartitioncolumn() == null) {
-            // If the view table is implicitly partitioned (maybe was not in snapshot),
-            // its maintenance is not turned off during the snapshot restore process.
-            // Let it take care of its own data by itself.
-            // Do not attempt to restore data for it.
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Test if a table is a streamed table view and should be included in the snapshot.
-     * @param db The database catalog
-     * @param table The table to test.</br>
-     * @return If the table is a streamed table view that should be snapshotted.
-     */
-    public static boolean isSnapshotableStreamedTableView(Database db, Table table) {
-        Table materializer = table.getMaterializer();
-        if (materializer == null) {
-            // Return false if it is not a materialized view.
-            return false;
-        }
-        if (! CatalogUtil.isStream(db, materializer)) {
-            // Test if the view source table is a streamed table.
-            return false;
-        }
-        // Non-partitioned export table are not allowed so it should not get here.
-        Column sourcePartitionColumn = materializer.getPartitioncolumn();
-        if (sourcePartitionColumn == null) {
-            return false;
-        }
-        // Make sure the partition column is present in the view.
-        // Export table views are special, we use column names to match..
-        Column pc = table.getColumns().get(sourcePartitionColumn.getName());
-        if (pc == null) {
-            return false;
         }
         return true;
     }
@@ -2787,108 +2728,15 @@ public abstract class CatalogUtil {
     }
 
     /**
-     * Get all snapshot-able table names from an in-memory catalog jar file.
-     * A snapshot-able table is one that's neither an export table nor an implicitly partitioned view.
-     * @param jarfile a in-memory catalog jar file
-     * @return A pair of two string sets.</br>
-     *         The first set contains a complete list of names of snapshot-able tables.</br>
-     *         The second set contains a list of names of optional
-     *         <strong>single persistent table views</strong> without which the snapshot
-     *         is still considered as complete (ENG-11578, ENG-14145).
+     * Create a {@link Database} instance from {@code jarFile}
+     *
+     * @param jarFile which has a catalog file
+     * @return {@link Database} generated from {@code jarFile}
      */
-    public static Pair<Set<String>, Set<String>>
-    getSnapshotableTableNamesFromInMemoryJar(InMemoryJarfile jarfile) {
-        Set<String> fullTableNames = new HashSet<>();
-        Set<String> optionalTableNames = new HashSet<>();
+    public static Database getDatabaseFrom(InMemoryJarfile jarFile) {
         Catalog catalog = new Catalog();
-        catalog.execute(getSerializedCatalogStringFromJar(jarfile));
-        Database db = getDatabase(catalog);
-        Pair<List<Table>, Set<String>> ret;
-
-        ret = getSnapshotableTables(db, true);
-        ret.getFirst().forEach(table -> fullTableNames.add(table.getTypeName()));
-        optionalTableNames.addAll(ret.getSecond());
-
-        ret = getSnapshotableTables(db, false);
-        ret.getFirst().forEach(table -> fullTableNames.add(table.getTypeName()));
-        optionalTableNames.addAll(ret.getSecond());
-
-        return new Pair<Set<String>, Set<String>>(fullTableNames, optionalTableNames);
-    }
-
-    /**
-     * Get all snapshot-able tables from the catalog. A snapshot-able table is one
-     * that's neither an export table nor an implicitly partitioned view.
-     * @param catalog         Catalog database
-     * @param isReplicated    true to return only replicated tables,
-     *                        false to return all partitioned tables
-     * @return A pair that contains a complete list of snapshot-able tables and a list
-     *         of names of optional <strong>single persistent table views</strong> without
-     *         which the snapshot is still considered as complete (ENG-11578, ENG-14145).
-     */
-    public static Pair<List<Table>, Set<String>>
-    getSnapshotableTables(Database catalog, boolean isReplicated) {
-        List<Table> tables = new ArrayList<>();
-        Set<String> optionalTableNames = new HashSet<>();
-        for (Table table : catalog.getTables()) {
-            if (table.getIsreplicated() != isReplicated) {
-                // We handle replicated tables and partitioned tables separately.
-                continue;
-            }
-            if (isStream(catalog, table)) {
-                // Streamed tables are not considered as "normal" tables here.
-                continue;
-            }
-            if (table.getMaterializer() != null) {
-                if (isSnapshotablePersistentTableView(catalog, table)) {
-                    // Some persistent table views are added to the snapshot starting from
-                    // V8.2, they are since then considered as "normal" tables, too.
-                    // But their presence in the snapshot is not compulsory for backward
-                    // compatibility reasons.
-                    optionalTableNames.add(table.getTypeName());
-                }
-                else if (! isSnapshotableStreamedTableView(catalog, table)) {
-                    continue;
-                }
-            }
-            tables.add(table);
-        }
-        return new Pair<List<Table>, Set<String>>(tables, optionalTableNames);
-    }
-
-    /**
-     * Get all normal tables from the catalog. A normal table is one that's NOT a materialized
-     * view, nor an export table. For the lack of a better name, I call it normal.
-     * @param catalog         Catalog database
-     * @param isReplicated    true to return only replicated tables,
-     *                        false to return all partitioned tables
-     * @return A list of tables
-     */
-    public static List<Table> getNormalTables(Database catalog, boolean isReplicated) {
-        List<Table> tables = new ArrayList<>();
-        for (Table table : catalog.getTables()) {
-            if ((table.getIsreplicated() == isReplicated) &&
-                    table.getMaterializer() == null &&
-                    !CatalogUtil.isStream(catalog, table)) {
-                tables.add(table);
-                continue;
-            }
-            //Handle views which are on STREAM only partitioned STREAM allow view and must have partition
-            //column as part of view.
-            if ((table.getMaterializer() != null) && !isReplicated
-                    && (CatalogUtil.isStream(catalog, table.getMaterializer()))) {
-                //Non partitioned export table are not allowed so it should not get here.
-                Column bpc = table.getMaterializer().getPartitioncolumn();
-                if (bpc != null) {
-                    String bPartName = bpc.getName();
-                    Column pc = table.getColumns().get(bPartName);
-                    if (pc != null) {
-                        tables.add(table);
-                    }
-                }
-            }
-        }
-        return tables;
+        catalog.execute(getSerializedCatalogStringFromJar(jarFile));
+        return getDatabase(catalog);
     }
 
     /**
@@ -2987,30 +2835,6 @@ public abstract class CatalogUtil {
             sb.append(t.getSignatureChar());
         }
         return sb.toString();
-    }
-
-    /**
-     * Deterministically serializes all DR table signatures into a string and calculates the CRC checksum.
-     * @param catalog    The catalog
-     * @return A pair of CRC checksum and the serialized signature string.
-     */
-    public static Pair<Long, String> calculateDrTableSignatureAndCrc(Database catalog) {
-        SortedSet<Table> tables = Sets.newTreeSet();
-        tables.addAll(getSnapshotableTables(catalog, true).getFirst());
-        tables.addAll(getSnapshotableTables(catalog, false).getFirst());
-
-        final PureJavaCrc32 crc = new PureJavaCrc32();
-        final StringBuilder sb = new StringBuilder();
-        String delimiter = "";
-        for (Table t : tables) {
-            if (t.getIsdred()) {
-                crc.update(t.getSignature().getBytes(Charsets.UTF_8));
-                sb.append(delimiter).append(t.getSignature());
-                delimiter = SIGNATURE_DELIMITER;
-            }
-        }
-
-        return Pair.of(crc.getValue(), sb.toString());
     }
 
     /**

--- a/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
+++ b/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
@@ -43,7 +43,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.voltdb.benchmark.tpcc.TPCCProjectBuilder;
 import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Table;
 import org.voltdb.sysprocs.saverestore.SnapshotRequestConfig;
 
 import com.google_voltpatches.common.collect.Sets;
@@ -172,11 +171,11 @@ public class TestSnapshotInitiationInfo {
             return;
         }
         assertNull(invalid);
-        assertEquals(expectedTableCount, config.tables.length);
+        assertEquals(expectedTableCount, config.tables.size());
 
         final Set<String> allTables = new HashSet<>();
-        for (Table t : config.tables) {
-            allTables.add(t.getTypeName().toLowerCase());
+        for (SnapshotTableInfo t : config.tables) {
+            allTables.add(t.getName().toLowerCase());
         }
 
         if (include != null) {

--- a/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
+++ b/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.voltdb.benchmark.tpcc.TPCCProjectBuilder;
 import org.voltdb.catalog.Database;
 import org.voltdb.sysprocs.saverestore.SnapshotRequestConfig;
+import org.voltdb.sysprocs.saverestore.SystemTable;
 
 import com.google_voltpatches.common.collect.Sets;
 
@@ -137,7 +138,7 @@ public class TestSnapshotInitiationInfo {
     // include/exclude to contain an invalid table name
     private static void tableFilterAndCheck(String[] include, String[] exclude, String[] invalid) throws JSONException
     {
-        int expectedTableCount = 10; // TPC-C has 10 tables in total
+        int expectedTableCount = 10 + SystemTable.values().length; // TPC-C has 10 tables in total
 
         JSONStringer js = new JSONStringer();
         js.object();

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
@@ -23,9 +23,9 @@
 
 package org.voltdb.regressionsuites;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyListOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyListOf;
 import static org.mockito.Mockito.doAnswer;
 
 import java.io.ByteArrayOutputStream;
@@ -58,6 +58,7 @@ import org.voltdb.client.ProcCallException;
 import org.voltdb.client.SyncCallback;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
+import org.voltdb.sysprocs.saverestore.SystemTable;
 import org.voltdb.types.GeographyPointValue;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.utils.SnapshotVerifier;
@@ -67,7 +68,7 @@ import org.voltdb.utils.SnapshotVerifier;
  */
 public class TestSaveRestoreSerializationFailures extends SaveRestoreBase {
     private final static int SITE_COUNT = 2;
-    private final static int TABLE_COUNT = 11;  // Must match schema used.
+    private final static int TABLE_COUNT = 11 + SystemTable.values().length; // Must match schema used.
 
     public TestSaveRestoreSerializationFailures(String name) {
         super(name);
@@ -359,7 +360,9 @@ public class TestSaveRestoreSerializationFailures extends SaveRestoreBase {
     public void testSaveAndRestorePartitionedTable()
     throws Exception
     {
-        if (isValgrind()) return; // snapshot doesn't run in valgrind ENG-4034
+        if (isValgrind()) {
+            return; // snapshot doesn't run in valgrind ENG-4034
+        }
 
         System.out.println("Starting testSaveAndRestorePartitionedTable");
         int num_partitioned_items_per_chunk = 120; // divisible by 3

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -71,10 +71,6 @@ import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltTableRow;
 import org.voltdb.VoltType;
-import org.voltdb.catalog.CatalogMap;
-import org.voltdb.catalog.Cluster;
-import org.voltdb.catalog.Database;
-import org.voltdb.catalog.Table;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientFactory;
 import org.voltdb.client.ClientResponse;
@@ -86,6 +82,7 @@ import org.voltdb.iv2.TxnEgo;
 import org.voltdb.sysprocs.SnapshotRestoreResultSet;
 import org.voltdb.sysprocs.SnapshotRestoreResultSet.RestoreResultValue;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
+import org.voltdb.sysprocs.saverestore.SystemTable;
 import org.voltdb.types.GeographyPointValue;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.utils.MiscUtils;
@@ -104,7 +101,7 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
 
     private final static VoltLogger LOG = new VoltLogger("CONSOLE");
     private final static int SITE_COUNT = 2;
-    private final static int TABLE_COUNT = 11;  // Must match schema used.
+    private final static int TABLE_COUNT = 11 + SystemTable.values().length; // Must match schema used
 
     protected int getTableCount() {
         return TABLE_COUNT;
@@ -539,7 +536,7 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
                 tableSet.add(results[0].getString("TABLE"));
             }
         }
-        return tableSet.equals(new HashSet<>(Arrays.asList(tables)));
+        return tableSet.containsAll(Arrays.asList(tables));
     }
 
     private void generateAndValidateTextFile(Set<String> expectedText, boolean csv) throws Exception {
@@ -1822,27 +1819,8 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
         // Instead of something exhaustive, let's just make sure that we get
         // the number of result rows corresponding to the number of ExecutionSites
         // that did save work
-        Cluster cluster = VoltDB.instance().getCatalogContext().cluster;
-        Database database = cluster.getDatabases().get("database");
-        CatalogMap<Table> tables = database.getTables();
-        int num_hosts = 1;
-        int replicated = 0;
-        int total_tables = 0;
         int expected_entries = 3;
 
-        for (Table table : tables)
-        {
-            if (table.getMaterializer() != null
-                    && ! table.getIsreplicated()
-                    && table.getPartitioncolumn() == null) {
-                continue;
-            }
-            total_tables++;
-            if (table.getIsreplicated())
-            {
-                replicated++;
-            }
-        }
         //Make this failing test debuggable, why do we get the wrong number sometimes?
         if (results[0].getRowCount() != expected_entries) {
             System.out.println(results[0]);
@@ -1857,10 +1835,8 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
         // Now, try the save again and verify that we fail (since all the save
         // files will still exist. This will return one entry per table
         // per host
-        expected_entries =
-            ((total_tables - replicated) * num_hosts) + replicated;
         results = client.callProcedure("@SnapshotSave", TMPDIR, TESTNONCE, (byte) 1).getResults();
-        assertEquals(expected_entries, results[0].getRowCount());
+        assertEquals(getTableCount(), results[0].getRowCount());
         while (results[0].advanceRow())
         {
             if (!tmp_files[0].getName().contains(results[0].getString("TABLE"))) {

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
@@ -91,7 +91,7 @@ public class TestSnapshotStatus extends SaveRestoreBase {
         }
         System.out.println(results[0]);
         // better be five rows, one for the replicated table, and one for each partition of the partitioned table
-        assertEquals(5 + countSnapshotingSystemTables(), results[0].getRowCount());
+        assertEquals(5, results[0].getRowCount());
         // better not be any zeros in the completion time
         while (results[0].advanceRow()) {
             long completed = results[0].getLong("END_TIME");

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
@@ -31,6 +31,7 @@ import org.voltdb.client.Client;
 import org.voltdb.client.NoConnectionsException;
 import org.voltdb.client.ProcCallException;
 import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.sysprocs.saverestore.SystemTable;
 
 import junit.framework.Test;
 
@@ -55,8 +56,8 @@ public class TestSnapshotStatus extends SaveRestoreBase {
         assertEquals(4, results[0].getRowCount());
         results = client.callProcedure("@SnapshotStatus").getResults();
         System.out.println(results[0]);
-        // better be four rows, one for each table at each node, in the status results:
-        assertEquals(6, results[0].getRowCount());
+        // better be six rows, one for each table at each node, in the status results:
+        assertEquals(6 + countSnapshotingSystemTables(), results[0].getRowCount());
         // better not be any zeros in the completion time
         while (results[0].advanceRow()) {
             long completed = results[0].getLong("END_TIME");
@@ -90,12 +91,16 @@ public class TestSnapshotStatus extends SaveRestoreBase {
         }
         System.out.println(results[0]);
         // better be five rows, one for the replicated table, and one for each partition of the partitioned table
-        assertEquals(5, results[0].getRowCount());
+        assertEquals(5 + countSnapshotingSystemTables(), results[0].getRowCount());
         // better not be any zeros in the completion time
         while (results[0].advanceRow()) {
             long completed = results[0].getLong("END_TIME");
             assertTrue("END_TIME was not filled", completed != 0);
         }
+    }
+
+    private static int countSnapshotingSystemTables() {
+        return SystemTable.values().length * 2;
     }
 
     //

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
@@ -37,6 +37,7 @@ import org.voltcore.utils.CoreUtils;
 import org.voltdb.FlakyTestRule;
 import org.voltdb.FlakyTestRule.Flaky;
 import org.voltdb.MockVoltDB;
+import org.voltdb.SnapshotTableInfo;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltSystemProcedure.SynthesizedPlanFragment;
 import org.voltdb.VoltTable;
@@ -158,10 +159,7 @@ public class TestReplicatedTableSaveFileState
             }
         }
 
-        Table test_table = catalog_creator.getTable(TABLE_NAME);
-
-        SynthesizedPlanFragment[] test_plan =
-            m_state.generateRestorePlan(test_table, VoltDB.instance().getSiteTrackerForSnapshot());
+        SynthesizedPlanFragment[] test_plan = generateRestorePlan(catalog_creator);
         assertEquals(test_plan.length, number_of_sites + 1);
         for (int i = 0; i < number_of_sites - 1; ++i)
         {
@@ -218,10 +216,7 @@ public class TestReplicatedTableSaveFileState
             }
         }
 
-        Table test_table = catalog_creator.getTable(TABLE_NAME);
-
-        SynthesizedPlanFragment[] test_plan =
-            m_state.generateRestorePlan(test_table, VoltDB.instance().getSiteTrackerForSnapshot());
+        SynthesizedPlanFragment[] test_plan = generateRestorePlan(catalog_creator);
         assertEquals(test_plan.length, number_of_sites + 1);
         for (int i = 0; i < number_of_sites - 1; ++i)
         {
@@ -257,6 +252,13 @@ public class TestReplicatedTableSaveFileState
     {
         m_siteInput.addRow(hostId, "host", hostId, "ohost", "cluster", DATABASE_NAME,
                            TABLE_NAME, 0, "FALSE", 0, 2);
+    }
+
+    private SynthesizedPlanFragment[] generateRestorePlan(MockVoltDB mvdb) {
+        Table testTable = mvdb.getTable(TABLE_NAME);
+
+        return m_state.generateRestorePlan(new SnapshotTableInfo(testTable),
+                VoltDB.instance().getSiteTrackerForSnapshot());
     }
 
     private ReplicatedTableSaveFileState m_state;

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestSnapshotUtil.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestSnapshotUtil.java
@@ -1,0 +1,78 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.sysprocs.saverestore;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.voltdb.compiler.VoltProjectBuilder;
+import org.voltdb.utils.BuildDirectoryUtils;
+import org.voltdb.utils.CatalogUtil;
+import org.voltdb.utils.InMemoryJarfile;
+import org.voltdb.utils.MiscUtils;
+import org.voltdb.utils.VoltFile;
+
+public class TestSnapshotUtil {
+    @Test
+    public void getRequiredSnapshotableTableNames() throws Exception {
+        String schema = "CREATE TABLE NORMAL_A (C1 INTEGER NOT NULL, C2 TIMESTAMP NOT NULL);\n"
+                + "CREATE TABLE NORMAL_B (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL);\n" +
+                // NORMAL_C is partitioned on C1.
+                "CREATE TABLE NORMAL_C (C1 TINYINT NOT NULL, C2 VARCHAR(3) NOT NULL);\n"
+                + "CREATE VIEW VIEW_A (TOTAL_ROWS) AS SELECT COUNT(*) FROM NORMAL_A;\n" +
+                // VIEW_C1 is an explicitly partitioned persistent table view (included in the snapshot).
+                "CREATE VIEW VIEW_C1 AS SELECT C1, COUNT(*) FROM NORMAL_C GROUP BY C1;\n" +
+                // VIEW_C2 is an implicitly partitioned persistent table view (not included in the snapshot).
+                "CREATE VIEW VIEW_C2 AS SELECT C2, COUNT(*) FROM NORMAL_C GROUP BY C2;\n" +
+                // EXPORT_A is partitioned on C1.
+                "CREATE STREAM EXPORT_A (C1 BIGINT NOT NULL, C2 SMALLINT NOT NULL);\n" +
+                // VIEW_E1 contains the partition column of its source streamed table (included in the snapshot).
+                "CREATE VIEW VIEW_E1 AS SELECT C1, COUNT(*) FROM EXPORT_A GROUP BY C1;\n";
+        String testDir = BuildDirectoryUtils.getBuildDirectoryPath();
+        final File file = VoltFile.createTempFile("testGetNormalTableNamesFromInMemoryJar", ".jar", new File(testDir));
+
+        VoltProjectBuilder builder = new VoltProjectBuilder();
+        builder.addLiteralSchema(schema);
+        builder.addPartitionInfo("NORMAL_C", "C1");
+        builder.addPartitionInfo("EXPORT_A", "C1");
+
+        builder.compile(file.getPath());
+        byte[] bytes = MiscUtils.fileToBytes(file);
+        InMemoryJarfile jarfile = CatalogUtil.loadInMemoryJarFile(bytes);
+        file.delete();
+
+        Set<String> definedRequiredTableNames = new HashSet<>();
+        definedRequiredTableNames.add("NORMAL_A");
+        definedRequiredTableNames.add("NORMAL_B");
+        definedRequiredTableNames.add("NORMAL_C");
+        definedRequiredTableNames.add("VIEW_E1");
+
+        Set<String> requiredTableNames = SnapshotUtil.getRequiredSnapshotableTableNames(jarfile);
+        assertEquals(definedRequiredTableNames, requiredTableNames);
+    }
+}

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestTableSaveFile.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestTableSaveFile.java
@@ -106,7 +106,7 @@ public class TestTableSaveFile extends TestCase {
                 new ColumnInfo("RT_NAME", VoltType.STRING),
                 new ColumnInfo("RT_INTVAL", VoltType.INTEGER),
                 new ColumnInfo("RT_FLOATVAL", VoltType.FLOAT) };
-        VoltTable table = new VoltTable(columnInfo, columnInfo.length);
+        VoltTable table = new VoltTable(columnInfo);
         final File f = File.createTempFile("foo", "bar");
         f.deleteOnExit();
         ArrayList<Integer> partIds = new ArrayList<Integer>();
@@ -117,7 +117,7 @@ public class TestTableSaveFile extends TestCase {
         partIds.add(4);
         DefaultSnapshotDataTarget dsdt = new DefaultSnapshotDataTarget(f,
                 HOST_ID, CLUSTER_NAME, DATABASE_NAME, TABLE_NAME,
-                TOTAL_PARTITIONS, false, partIds, table,
+                TOTAL_PARTITIONS, false, partIds, PrivateVoltTableFactory.getSchemaBytes(table),
                 TXN_ID, TIMESTAMP, VERSION2);
 
         VoltTable currentChunkTable = new VoltTable(columnInfo,
@@ -142,9 +142,8 @@ public class TestTableSaveFile extends TestCase {
         System.out.println("Running testHeaderAccessors");
         final File f = File.createTempFile("foo", "bar");
         f.deleteOnExit();
-        VoltTable.ColumnInfo columns[] = new VoltTable.ColumnInfo[] { new VoltTable.ColumnInfo(
-                "Foo", VoltType.STRING) };
-        VoltTable vt = new VoltTable(columns, 1);
+        VoltTable.ColumnInfo columns[] = { new VoltTable.ColumnInfo("Foo", VoltType.STRING) };
+        byte[] schema = PrivateVoltTableFactory.getSchemaBytes(new VoltTable(columns));
         ArrayList<Integer> partIds = new ArrayList<Integer>();
         partIds.add(0);
         partIds.add(1);
@@ -153,7 +152,7 @@ public class TestTableSaveFile extends TestCase {
         partIds.add(4);
         DefaultSnapshotDataTarget dsdt = new DefaultSnapshotDataTarget(f,
                 HOST_ID, CLUSTER_NAME, DATABASE_NAME, TABLE_NAME,
-                TOTAL_PARTITIONS, false, partIds, vt,
+                TOTAL_PARTITIONS, false, partIds, schema,
                 TXN_ID, TIMESTAMP, VERSION1);
         dsdt.close();
 


### PR DESCRIPTION
1. Use a class other than Table as the reference for tables to snapshot
2. Retrieve schema of table from EE
3. Consolidate snapshot utility methods in SnapshotUtils
4. Include system tables in snapshots
5. Include system tables in Snaphsot restore