### PR TITLE
ENG-18639: resume polling on leadership change

### DIFF
--- a/src/frontend/org/voltdb/export/ExportCoordinator.java
+++ b/src/frontend/org/voltdb/export/ExportCoordinator.java
@@ -361,8 +361,9 @@ public class ExportCoordinator {
                                 // through another runnable and the invocation path.
                                 requestTrackers();
                             } else {
-                                // Reset the safe point to force a Mastership re-evaluation
+                                // Reset the safe point and resune polling to force a Mastership re-evaluation
                                 resetSafePoint();
+                                m_eds.resumePolling();
                             }
                         } catch (Exception e) {
                             exportLog.error("Failed to change to new leader: " + e);

--- a/src/frontend/org/voltdb/export/ExportCoordinator.java
+++ b/src/frontend/org/voltdb/export/ExportCoordinator.java
@@ -361,7 +361,7 @@ public class ExportCoordinator {
                                 // through another runnable and the invocation path.
                                 requestTrackers();
                             } else {
-                                // Reset the safe point and resune polling to force a Mastership re-evaluation
+                                // Reset the safe point and resume polling to force a Mastership re-evaluation
                                 resetSafePoint();
                                 m_eds.resumePolling();
                             }


### PR DESCRIPTION
Intermittent bug hard to reproduce: a node becomes leader but because there are no new buffers pushed after this point, it does not resume polling.