### PR TITLE
ENG-18612: catalog prechecks wait on closing sources up to fixed timeout

### DIFF
--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -626,7 +626,7 @@ public class ExportManager implements ExportManagerInterface
     public synchronized void waitOnClosingSources() {
         boolean locked = false;
         try {
-            locked = m_allowCatalogUpdate.tryAcquire(1, UPDATE_CORE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            locked = m_allowCatalogUpdate.tryAcquire(UPDATE_CORE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!locked && !m_dataSourcesClosing.isEmpty()) {
                 exportLog.warn("After " + UPDATE_CORE_TIMEOUT_SECONDS
                         + " seconds, these export streams are still closing: "

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -622,8 +622,9 @@ public class ExportManager implements ExportManagerInterface
                 "@MigrateRowsDeleterNT", new Object[] {partition, tableName, deletableTxnId});
     }
 
+    // Note: not synchronized as only needs to touch the semaphore and must not block {@code onClosedSource}
     @Override
-    public synchronized void waitOnClosingSources() {
+    public void waitOnClosingSources() {
         boolean locked = false;
         try {
             locked = m_allowCatalogUpdate.tryAcquire(UPDATE_CORE_TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.voltcore.messaging.HostMessenger;
 import org.voltcore.utils.Pair;
+import org.voltcore.zk.SynchronizedStatesManager;
 import org.voltdb.CatalogContext;
 import org.voltdb.ClientInterface;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
@@ -189,11 +190,17 @@ public interface ExportManagerInterface {
     public ExportMode getExportMode();
 
     /**
-     * If data sources are still closing, wait until a fixed timeout.
+     * If data sources are still closing, wait until a fixed timeout, and proceed.
+     * <p>
+     * When a data source is dropped, the shutdown of the export coordinators proceed in the
+     * background, as it involves shutting down multi-node synchronized state machines (SSM).
+     * It is necessary to wait for this process to be completed before running the next catalog
+     * update, in case the latter update re-creates data sources that were dropped, and attempts
+     * to initialize SSMs using the same Zookeeper nodes as the previous SSM instances.
      *
-     * @return null if catalog update is possible, or an error message if not.
+     * @see {@link ExportCoordinator}, {@link E3ExportCoordinator}, and {@link SynchronizedStatesManager}.
      */
-    public String canUpdateCatalog();
+    public void waitOnClosingSources();
 
     /**
      * Notification that a data source was drained

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -189,6 +189,8 @@ public interface ExportManagerInterface {
     public ExportMode getExportMode();
 
     /**
+     * If data sources are still closing, wait until a fixed timeout.
+     *
      * @return null if catalog update is possible, or an error message if not.
      */
     public String canUpdateCatalog();

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -240,10 +240,9 @@ public class UpdateCore extends VoltSystemProcedure {
                 throw ex;
             }
 
-            String canUpdate = ExportManagerInterface.instance().canUpdateCatalog();
-            if (canUpdate != null) {
-                throw new SpecifiedException(ClientResponse.GRACEFUL_FAILURE, canUpdate);
-            }
+            // Note: this call can block up to a fixed timeout waiting for data source
+            // to complete closing.
+            ExportManagerInterface.instance().waitOnClosingSources();
 
             // Send out fragments to do the initial round-trip to synchronize
             // all the cluster sites on the start of catalog update, we'll do


### PR DESCRIPTION
The fragment PF_updateCatalogPrecheckAndSync now waits for all closing sources until a fixed timeout of 30s. 