### PR TITLE
ENG-18663. Move the maven prep step.

### DIFF
--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -354,6 +354,8 @@ if __name__ == "__main__":
                 buildCommunity()
                 buildRabbitMQExport(versionCentos, "community")
                 copyCommunityFilesToReleaseDir(releaseDir, versionCentos, "LINUX")
+                makeMavenJars()
+                copyMavenJarsToReleaseDir(releaseDir, versionCentos)
             buildEnterprise(versionCentos)
             buildRabbitMQExport(versionCentos, "ent")
             makeSHA256SUM(versionCentos,"ent")
@@ -363,8 +365,6 @@ if __name__ == "__main__":
             copyFilesToReleaseDir(releaseDir, versionCentos, "pro")
             licensefile = makeTrialLicense(licensee="VoltDB Internal Use Only " + versionCentos)
             copyTrialLicenseToReleaseDir(builddir + "/pro/" + licensefile, releaseDir)
-            makeMavenJars()
-            copyMavenJarsToReleaseDir(releaseDir, versionCentos)
 
     except Exception as e:
         print traceback.format_exc()


### PR DESCRIPTION
(cherry picked from commit c369b0ed2cfac18e217e63f1dc75b95e9896a9c7). This has been tested on V9.2.2 and no supplies the corrected .jar file to maven.