### PR TITLE
ENG-18653: Use E3 as default export implementation for enterprise

### DIFF
--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -54,9 +54,9 @@ import org.voltdb.compiler.deploymentfile.DrType;
 import org.voltdb.compiler.deploymentfile.ExportConfigurationType;
 import org.voltdb.compiler.deploymentfile.ExportType;
 import org.voltdb.compiler.deploymentfile.FeatureNameType;
-import org.voltdb.compiler.deploymentfile.FlushIntervalType;
 import org.voltdb.compiler.deploymentfile.FeatureType;
 import org.voltdb.compiler.deploymentfile.FeaturesType;
+import org.voltdb.compiler.deploymentfile.FlushIntervalType;
 import org.voltdb.compiler.deploymentfile.HeartbeatType;
 import org.voltdb.compiler.deploymentfile.HttpdType;
 import org.voltdb.compiler.deploymentfile.HttpdType.Jsonapi;
@@ -1374,7 +1374,7 @@ public class VoltProjectBuilder {
             conn.setSsl(m_drConsumerSslPropertyFile);
         }
 
-        setFeatureOptions(deployment);
+        deployment.setFeatures(m_featureOptions);
 
         // Have some yummy boilerplate!
         File file = File.createTempFile("myAppDeployment", ".tmp");
@@ -1386,24 +1386,6 @@ public class VoltProjectBuilder {
         final String deploymentPath = file.getPath();
         return deploymentPath;
     }
-
-    private void setFeatureOptions(DeploymentType deployment) {
-        // set export mode to ADVANCED in pro builds, unless it is already explicitly set.
-        // This is so that we can run E3 export in pro junits by default.
-           if (m_featureOptions == null &&
-               VoltDB.instance().getConfig() != null && VoltDB.instance().getConfig().m_isEnterprise) {
-            m_featureOptions = new FeaturesType();
-            FeatureType exportFeature = new FeatureType();
-            exportFeature.setName(ExportManagerInterface.EXPORT_FEATURE);
-            exportFeature.setOption(ExportMode.ADVANCED.name());
-            m_featureOptions.getFeature().add(exportFeature);
-        }
-
-        if (m_featureOptions != null) {
-            deployment.setFeatures(m_featureOptions);
-        }
-    }
-
 
     private SystemSettingsType createSystemSettingsType(org.voltdb.compiler.deploymentfile.ObjectFactory factory)
     {

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -60,25 +60,34 @@ public interface ExportManagerInterface {
     }
 
     static ExportMode getExportFeatureMode(FeaturesType features) throws SetupException {
+        boolean isEnterprise = VoltDB.instance().getConfig().m_isEnterprise;
+        String modeName = getExportFeatureConfigured(features);
+
+        if (modeName == null) {
+            return isEnterprise ? ExportMode.ADVANCED : ExportMode.BASIC;
+        }
+
+        for (ExportMode modeEnum : ExportMode.values()) {
+            if (modeName.equalsIgnoreCase(modeEnum.name())) {
+                if (!isEnterprise && modeEnum == ExportMode.ADVANCED) {
+                    throw new SetupException("Cannot use ADVANCED export mode in community edition");
+                }
+                return modeEnum;
+            }
+        }
+        throw new SetupException("Unknown export feature mode: " + modeName);
+    }
+
+    static String getExportFeatureConfigured(FeaturesType features) {
         if (features == null) {
-            return ExportMode.BASIC;
+            return null;
         }
         for (FeatureType feature : features.getFeature()) {
             if (feature.getName().equalsIgnoreCase(EXPORT_FEATURE)) {
-                String mode = feature.getOption();
-                for (ExportMode modeEnum : ExportMode.values()) {
-                    if (mode.equalsIgnoreCase(modeEnum.name())) {
-                        if (!VoltDB.instance().getConfig().m_isEnterprise && modeEnum == ExportMode.ADVANCED) {
-                            throw new SetupException("Cannot use ADVANCED export mode in community edition");
-                        }
-                        return modeEnum;
-                    }
-                }
-                throw new SetupException("Unknown export feature mode: " + mode);
+                return feature.getOption();
             }
         }
-
-        return ExportMode.BASIC;
+        return null;
     }
 
     static AtomicReference<ExportManagerInterface> m_self = new AtomicReference<>();


### PR DESCRIPTION
If the system is enterprise use E3 as the default export implementation.
If the export implemenation is in the deployment file honor it.