### PR TITLE
strip trailing spaces

### DIFF
--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -383,7 +383,7 @@ public class SQLCommand {
                     execListConfigurations();
                     break;
                 */
-                
+
             case "tasks":
                     executeListTasks();
                     break;


### PR DESCRIPTION
SQLCommand.java was failing in licensecheck because of a line containing trailing spaces.

(Looks like result of previous manual edit?)

