### PR TITLE
ENG-18785  Prevent NT callAllNodeNTProcedure from being blocked by rejoining host

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1295,6 +1295,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 .clientInterfaceHandleManagerMap(m_cihm)
                 .siteId(m_siteId)
                 .build();
+        VoltZK.addClientInterfaceMailbox(m_zk, m_siteId);
     }
 
     private InternalClientResponseAdapter createInternalAdapter(int pid) {

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1295,7 +1295,8 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
                 .clientInterfaceHandleManagerMap(m_cihm)
                 .siteId(m_siteId)
                 .build();
-        VoltZK.addClientInterfaceMailbox(m_zk, m_siteId);
+        // add client interface mailbox id to ZK for NT proc
+        VoltZK.registerMailBoxForNT(m_zk, m_siteId);
     }
 
     private InternalClientResponseAdapter createInternalAdapter(int pid) {

--- a/src/frontend/org/voltdb/ProcedureRunnerNT.java
+++ b/src/frontend/org/voltdb/ProcedureRunnerNT.java
@@ -267,7 +267,7 @@ public class ProcedureRunnerNT {
         Set<Long> hsids;
         synchronized(m_allHostCallbackLock) {
             // collect the set of live client interface mailbox ids
-            hsids = VoltZK.getClientInterfaceMailboxes(VoltDB.instance().getHostMessenger().getZK());
+            hsids = VoltZK.getMailBoxesForNT(VoltDB.instance().getHostMessenger().getZK());
             m_outstandingAllHostProcedureHostIds =
                     hsids.stream().map(hsid->CoreUtils.getHostIdFromHSId(hsid)).collect(Collectors.toSet());
         }

--- a/src/frontend/org/voltdb/ProcedureRunnerNT.java
+++ b/src/frontend/org/voltdb/ProcedureRunnerNT.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.voltcore.logging.VoltLogger;
-import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltcore.network.Connection;
@@ -264,14 +264,12 @@ public class ProcedureRunnerNT {
 
         // hold this lock while getting the count of live nodes
         // also held when
-        long[] hsids;
+        Set<Long> hsids;
         synchronized(m_allHostCallbackLock) {
             // collect the set of live client interface mailbox ids
-            m_outstandingAllHostProcedureHostIds = VoltDB.instance().getHostMessenger().getLiveHostIds();
-            // convert host ids to hsids
-            hsids = m_outstandingAllHostProcedureHostIds.stream()
-                    .mapToLong(hostId -> CoreUtils.getHSIdFromHostAndSite(hostId, HostMessenger.CLIENT_INTERFACE_SITE_ID))
-                    .toArray();
+            hsids = VoltZK.getClientInterfaceMailboxes(VoltDB.instance().getHostMessenger().getZK());
+            m_outstandingAllHostProcedureHostIds =
+                    hsids.stream().map(hsid->CoreUtils.getHostIdFromHSId(hsid)).collect(Collectors.toSet());
         }
 
         // send the invocation to all live nodes

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -46,6 +46,7 @@ import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
 import org.voltdb.iv2.MigratePartitionLeaderInfo;
 
 import com.google_voltpatches.common.base.Charsets;
+import com.google_voltpatches.common.collect.Sets;
 
 /**
  * VoltZK provides constants for all voltdb-registered
@@ -96,9 +97,8 @@ public class VoltZK {
         ClientInterface, ExecutionSite, Initiator, StatsAgent,
         OTHER
     }
-    public static final String mailboxes = "/db/mailboxes";
 
-    public static final String clientInterfaceMailboxes = "/db/cl_mailboxes";
+    public static final String nt_mailboxes = "/db/cl_mailboxes";
 
     // snapshot and command log
     public static final String completed_snapshots = "/db/completed_snapshots";
@@ -266,7 +266,7 @@ public class VoltZK {
             actionLock,
             hashMismatchedReplicas,
             catalogbytes,
-            clientInterfaceMailboxes
+            nt_mailboxes
     };
 
     /**
@@ -731,8 +731,8 @@ public class VoltZK {
         return false;
     }
 
-    public static void addClientInterfaceMailbox(ZooKeeper zk, long hsid) {
-        String path = ZKUtil.joinZKPath(clientInterfaceMailboxes, Long.toString(hsid));
+    public static void registerMailBoxForNT(ZooKeeper zk, long hsid) {
+        String path = ZKUtil.joinZKPath(nt_mailboxes, Long.toString(hsid));
         try {
             zk.create(path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
         } catch (KeeperException.NoNodeException e) {
@@ -741,14 +741,14 @@ public class VoltZK {
         }
     }
 
-    public static Set<Long> getClientInterfaceMailboxes(ZooKeeper zk) {
+    public static Set<Long> getMailBoxesForNT(ZooKeeper zk) {
+        Set<Long> mailboxes = Sets.newHashSet();
         try {
-            List<String> clMailboxes = zk.getChildren(clientInterfaceMailboxes, false);
-            Set<Long> mailboxes = clMailboxes.stream().map(Long::valueOf).collect(Collectors.toSet());
-            return mailboxes;
+            List<String> clMailboxes = zk.getChildren(nt_mailboxes, false);
+            mailboxes = clMailboxes.stream().map(Long::valueOf).collect(Collectors.toSet());
         } catch (KeeperException | InterruptedException e) {
-            VoltDB.crashLocalVoltDB("Unable to read client interface mailbxoes.", true, e);
+            VoltDB.crashLocalVoltDB("Unable to read client interface mailboxes.", true, e);
         }
-        return null;
+        return mailboxes;
     }
 }


### PR DESCRIPTION
NT procedure runner gets a list of live hosts and send requests to their client interfaces for callAllNodeNTProcedure.  If a request is sent to the rejoining host, the caller won't get any response from the rejoining host. The scenario occurred in rejoining and UAC since  they are mutually exclusive.  UAC sends @VerifyCatalogAndWriteJar to all the live hosts which includes the rejoining host.  UAC will eventually timed out. Rejoining may also fail because it is unable to get action blocker.