### PR TITLE
ENG-18527-ap-large-jar3:

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/build.xml
+++ b/tests/test_apps/txnid-selfcheck2/build.xml
@@ -34,7 +34,7 @@
 
     <target name="client-compile">
         <mkdir dir="${clientclasses.dir}"/>
-        <javac debug="on" srcdir="${clientsrc.dir}" destdir="${clientclasses.dir}" >
+        <javac debug="on" srcdir="${clientsrc.dir}" destdir="${clientclasses.dir}" includeantruntime="false">
             <classpath refid="build-classpath"/>
         </javac>
     </target>
@@ -47,14 +47,14 @@
 
     <target name="procedures-compile">
         <mkdir dir="${proceduresclasses.dir}"/>
-        <javac debug="on" srcdir="${procedures.dir}" destdir="${proceduresclasses.dir}" >
+        <javac debug="on" srcdir="${procedures.dir}" destdir="${proceduresclasses.dir}" includeantruntime="false">
             <classpath refid="build-classpath"/>
         </javac>
     </target>
 
     <target name="dummy-compile">
         <mkdir dir="${dummyclasses.dir}"/>
-        <javac debug="on" srcdir="${dummysrc.dir}" destdir="${dummyclasses.dir}" >
+        <javac debug="on" srcdir="${dummysrc.dir}" destdir="${dummyclasses.dir}" includeantruntime="false">
             <classpath refid="build-classpath"/>
         </javac>
     </target>

--- a/tests/test_apps/txnid-selfcheck2/run.sh
+++ b/tests/test_apps/txnid-selfcheck2/run.sh
@@ -87,7 +87,7 @@ function alt-jars() {
 }
 
 # create alternate jars that are functionally equivalent but
-# each includes some very large files (> 30Mb, but < 50Mb)
+# each includes some very large files (> 40Mb, but < 50Mb)
 function big-jars() {
     # find the voltdb-X.X.jar file
     JAR_NAME=`ls $VOLTDB_VOLTDB | grep .jar | grep -v client`
@@ -97,23 +97,25 @@ function big-jars() {
     if [[ ! -d "obj" ]]; then
         mkdir obj
     fi
+    # stop if compilation fails, but with some debug info
+    set +e
     javac -cp $VOLTDB_JAR -d obj src/largejar/CreateLargeFiles.java
-    # stop if compilation fails
     if [ $? != 0 ]; then
         echo -e "Compilation failed, with:\nVOLTDB_VOLTDB: $VOLTDB_VOLTDB"
         echo -e "JAR_NAME     : $JAR_NAME\nVOLTDB_JAR   : $VOLTDB_JAR"
-        exit 9
+        exit 10
     fi
 
     # create large (random) text files
-    java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text1.txt
-    if [ $? != 0 ]; then exit 1; fi
-    java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text2.txt
-    if [ $? != 0 ]; then exit 2; fi
-    java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text3.txt
-    if [ $? != 0 ]; then exit 3; fi
-    java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text4.txt
-    if [ $? != 0 ]; then exit 4; fi
+    java -cp obj:$VOLTDB_JAR largejar.CreateLargeFiles -o obj/large-random-text1.txt
+    if [ $? != 0 ]; then echo "Failed to create large-random-text1.txt"; exit 11; fi
+    java -cp obj:$VOLTDB_JAR largejar.CreateLargeFiles -o obj/large-random-text2.txt
+    if [ $? != 0 ]; then echo "Failed to create large-random-text2.txt"; exit 12; fi
+    java -cp obj:$VOLTDB_JAR largejar.CreateLargeFiles -o obj/large-random-text3.txt
+    if [ $? != 0 ]; then echo "Failed to create large-random-text3.txt"; exit 13; fi
+    java -cp obj:$VOLTDB_JAR largejar.CreateLargeFiles -o obj/large-random-text4.txt
+    if [ $? != 0 ]; then echo "Failed to create large-random-text4.txt"; exit 14; fi
+    set -e
 
     # make copies of the standard txnid.jar, and add a different large text
     # file to each one
@@ -121,14 +123,16 @@ function big-jars() {
     cp txnid.jar txnid-big-text2.jar
     cp txnid.jar txnid-big-text3.jar
     cp txnid.jar txnid-big-text4.jar
+    set +e
     jar uvf txnid-big-text1.jar obj/large-random-text1.txt
-    if [ $? != 0 ]; then exit 5; fi
+    if [ $? != 0 ]; then echo "Failed to update txnid-big-text1.jar"; exit 21; fi
     jar uvf txnid-big-text2.jar obj/large-random-text2.txt
-    if [ $? != 0 ]; then exit 6; fi
+    if [ $? != 0 ]; then echo "Failed to update txnid-big-text2.jar"; exit 22; fi
     jar uvf txnid-big-text3.jar obj/large-random-text3.txt
-    if [ $? != 0 ]; then exit 7; fi
+    if [ $? != 0 ]; then echo "Failed to update txnid-big-text3.jar"; exit 23; fi
     jar uvf txnid-big-text4.jar obj/large-random-text4.txt
-    if [ $? != 0 ]; then exit 8; fi
+    if [ $? != 0 ]; then echo "Failed to update txnid-big-text4.jar"; exit 24; fi
+    set -e
 }
 
 # run the voltdb server locally

--- a/tests/test_apps/txnid-selfcheck2/run.sh
+++ b/tests/test_apps/txnid-selfcheck2/run.sh
@@ -98,12 +98,22 @@ function big-jars() {
         mkdir obj
     fi
     javac -cp $VOLTDB_JAR -d obj src/largejar/CreateLargeFiles.java
+    # stop if compilation fails
+    if [ $? != 0 ]; then
+        echo -e "Compilation failed, with:\nVOLTDB_VOLTDB: $VOLTDB_VOLTDB"
+        echo -e "JAR_NAME     : $JAR_NAME\nVOLTDB_JAR   : $VOLTDB_JAR"
+        exit 9
+    fi
 
     # create large (random) text files
     java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text1.txt
+    if [ $? != 0 ]; then exit 1; fi
     java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text2.txt
+    if [ $? != 0 ]; then exit 2; fi
     java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text3.txt
+    if [ $? != 0 ]; then exit 3; fi
     java -cp obj:$VOLT_JAR largejar.CreateLargeFiles -o obj/large-random-text4.txt
+    if [ $? != 0 ]; then exit 4; fi
 
     # make copies of the standard txnid.jar, and add a different large text
     # file to each one
@@ -112,9 +122,13 @@ function big-jars() {
     cp txnid.jar txnid-big-text3.jar
     cp txnid.jar txnid-big-text4.jar
     jar uvf txnid-big-text1.jar obj/large-random-text1.txt
+    if [ $? != 0 ]; then exit 5; fi
     jar uvf txnid-big-text2.jar obj/large-random-text2.txt
+    if [ $? != 0 ]; then exit 6; fi
     jar uvf txnid-big-text3.jar obj/large-random-text3.txt
+    if [ $? != 0 ]; then exit 7; fi
     jar uvf txnid-big-text4.jar obj/large-random-text4.txt
+    if [ $? != 0 ]; then exit 8; fi
 }
 
 # run the voltdb server locally

--- a/tests/test_apps/txnid-selfcheck2/src/largejar/CreateLargeFiles.java
+++ b/tests/test_apps/txnid-selfcheck2/src/largejar/CreateLargeFiles.java
@@ -1,0 +1,163 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2020 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package largejar;
+
+import org.voltdb.CLIConfig;
+import org.voltdb.CLIConfig.Option;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Creates either a large file containing random text, or a bunch of Java source
+ * files, either or both of which may be used to create very large .jar files,
+ * which are used to test loading such files, via @UpdateClasses.
+ **/
+public class CreateLargeFiles {
+
+    /** The characters from which random text is chosen; includes multiple
+     *  spaces, to make them more frequent **/
+    private static final String POSSIBLE_CHARACTERS =
+            "ABCD EFG HIJ KLM NOP QRS TUV WXYZ abcd efg hij klm nop qrs tuv wxyz ";
+
+    /** The current configuration, containing various option values **/
+    private final Config config;
+
+
+    /** CreateLargeFiles Constuctor **/
+    private CreateLargeFiles(Config config) {
+        this.config = config;
+    }
+
+
+    /**
+     * Inherits from the {@link CLIConfig} class, to declaratively state command
+     * line options with defaults and validation.
+     */
+    private static class Config extends CLIConfig {
+        @Option(shortOpt = "f", opt = "filetype", desc = "The type of file(s) "
+                + "to be generated: either 'text' or 'java'; default 'text'")
+        String generateFileType = "text";
+
+        @Option(shortOpt = "o", opt = "outputfile", desc = "The name of the (large, random) "
+                + "text output file; ignored for 'java'; default 'large-random-text.jar'")
+        String outputTextFileName = "large-random-text.jar";
+
+        @Option(shortOpt = "l", opt = "numtextlines", desc = "The number of lines "
+                + "in the (text) output file; ignored for 'java'; default 800000")
+        int numTextLines = 850000;  // results in a .jar file a little under 50Mb
+
+        @Option(shortOpt = "c", opt = "numchars", desc = "The number of characters per "
+                + "line, in the (text) output file; ignored for 'java'; default 80")
+        int numCharsPerLine = 80;
+
+        @Option(shortOpt = "d", opt = "templatedir", desc = "The directory in "
+                + "which to find the Java template file to be copied and modified; "
+                + "ignored for 'text'; default './procedures'")
+        String javaTemplateDirectory = "./procedures";
+
+        @Option(shortOpt = "t", opt = "templatefile", desc = "The name of the "
+                + "Java template file to be copied and modified; ignored for "
+                + "'text'; default 'SelectLEtbd.java'")
+        String javaTemplateFilename = "SelectLEtbd.java";
+
+        @Option(shortOpt = "r", opt = "replace", desc = "The substring in the "
+                + "Java template file, which is to be replaced in each copy, "
+                + "including in the filename; ignored for 'text'; default 'tbd'")
+        String javaReplacedValue = "tbd";
+
+        @Option(shortOpt = "n", opt = "minfilenum", desc = "The minimum (int) "
+                + "value to be used in copies of the Java template file; "
+                + "ignored for 'text'; default 1")
+        int javaFileMinValue = 1;
+
+        @Option(shortOpt = "m", opt = "maxfilenum", desc = "The maximum (int) "
+                + "value to be used in copies of the Java template file; "
+                + "ignored for 'text'; default 10 (TODO)")
+        int javaFileMaxValue = 10;  // TODO: make this bigger! (how big?)
+
+        @Override
+        public void validate() {
+            if (!Arrays.asList("text", "java").contains(generateFileType.toLowerCase())) {
+                exitWithMessageAndUsage("filetype ("+generateFileType
+                        + ") must be 'text' or 'java'");
+            }
+            if (numTextLines <= 0) exitWithMessageAndUsage("numtextlines ("
+                        + numTextLines+") must be > 0");
+            if (numCharsPerLine <= 0) exitWithMessageAndUsage("numchars ("
+                        + numCharsPerLine+") must be > 0");
+            if (!javaTemplateFilename.contains(javaReplacedValue)) {
+                exitWithMessageAndUsage("templatefile ("+javaTemplateFilename
+                        + ") must contain replace ("+javaReplacedValue+")");
+            }
+            if (javaFileMaxValue < javaFileMinValue) {
+                exitWithMessageAndUsage("maxfilenum ("+javaFileMaxValue
+                        + ") must be >= minfilenum ("+javaFileMinValue+")");
+            }
+        }
+    }
+
+    public void createLargeTextFile() throws IOException {
+        Path outputFile = Paths.get(config.outputTextFileName);
+        Files.write(outputFile, Arrays.asList("Randomly generated text:"),
+                StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+
+        Random random = new Random();
+        List<String> lines = new ArrayList<String>();
+        for (long i=0; i < config.numTextLines; i++) {
+            StringBuffer line = new StringBuffer(config.numCharsPerLine);
+            for (int j=0; j < config.numCharsPerLine; j++) {
+                int index = random.nextInt(POSSIBLE_CHARACTERS.length());
+                line.append(POSSIBLE_CHARACTERS.charAt(index));
+            }
+            lines.add(line.toString());
+        }
+        Files.write(outputFile, lines, StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+    }
+
+    public void createJavaClassFiles() {
+        throw new UnsupportedOperationException("Method createJavaClassFiles not yet implemented.");
+    }
+
+    public static void main(String[] args) throws IOException {
+        Config config = new Config();
+        config.parse(CreateLargeFiles.class.getName(), args);
+
+        CreateLargeFiles clf = new CreateLargeFiles(config);
+        if ("java".equalsIgnoreCase(config.generateFileType)) {
+            clf.createJavaClassFiles();
+        } else {
+            clf.createLargeTextFile();
+        }
+    }
+
+}


### PR DESCRIPTION
Community (VoltDB): in txnid-selfcheck2, added CreateLargeFiles.java,
which creates large files, currently 'large-random-textX.txt' (where X
is 1, 2, 3, or 4); and added, to the run.sh, file, a 'function
big-jars', which calls CreateLargeFiles.java, and uses its large text
files to generate 4 different jar files ('txnid-big-textX.jar'), each a
little less than 50Mb (compressed from the text files, which are a
little bigger than 50Mb); plus a few cosmetic changes.