### PR TITLE
ENG-18533: Added sqlcov tests of sub-query with (& without) LIMIT

### DIFF
--- a/tests/sqlcoverage/SQLCoverageReport.py
+++ b/tests/sqlcoverage/SQLCoverageReport.py
@@ -96,7 +96,7 @@ AllExceptionTypes.extend(NonfatalExceptionTypes)
 def highlight(s, flag):
     if not isinstance(s, basestring):
         s = str(s)
-    return flag and "<span style=\"color: red\">%s</span>" % (s) or s
+    return flag and '<span style="color: red">%s*</span>' % (s) or s
 
 def as_html_unicode_string(s):
     if isinstance(s, list):

--- a/tests/sqlcoverage/template/include/advanced-select.sql
+++ b/tests/sqlcoverage/template/include/advanced-select.sql
@@ -153,3 +153,11 @@ SELECT @star FROM @fromtables Q38 WHERE CASE      Q38._variable[#arg @columntype
 SELECT @star FROM @fromtables Q39 WHERE CASE      Q39._variable[#arg @columntype] WHEN @comparableconstant THEN Q39._variable[#numone @columntype] @aftermath                              END @cmp (@comparableconstant@plus10)
 SELECT __[#numone]            Q40,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath ELSE   A.__[#arg] @aftermath END FROM @fromtables A WHERE @columnpredicate
 SELECT __[#arg]               Q41,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath                              END FROM @fromtables A WHERE @columnpredicate
+
+-- Test simple sub-queries, with and without LIMIT (see ENG-18533)
+{_maybelimit |= ""}
+{_maybelimit |= "LIMIT 10"}
+SELECT SUB.COL1 FROM \
+    (SELECT _variable[@columntype] COL1, @idcol PARTCOL FROM @fromtables ORDER BY COL1, PARTCOL _maybelimit) SUB, \
+    @fromtables Q42 \
+    WHERE Q42.@idcol = SUB.PARTCOL ORDER BY PARTCOL


### PR DESCRIPTION
Also, a tiny tweak to make it easier to find mismatched results (in failed tests), with an asterisk ('*').

(cherry picked from commit 2ddd66eb5237e2f7d5928ed8df1d222125ed5c3c)