### PR TITLE
Eng 18856:  Resolve deployment file from zk in rejoing/join case

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -281,6 +281,11 @@ public class CatalogContext {
         assert(newCatalog != null);
         assert(catalogInfo != null);
 
+        if (!isForReplay) {
+            catalogInfo = m_preparedCatalogInfo;
+            newCatalog = catalogInfo.m_catalog;
+        }
+
         CatalogContext retval =
             new CatalogContext(
                     newCatalog,


### PR DESCRIPTION
Previously, rejoining node pick up remote (latest) deployment based on the fact that zk nodes for catalogBytes already exist. (i.e. hitting NodeExistsException when it tries to sync local deployment)

Since now that zk can keep up more than one version of catalogbytes. If previous version no longer exist, the rejoining node can accidentally always pick up local (and stale) deployment.