### PR TITLE
Eng 18513 add eecheck test simulating mp execution

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -560,6 +560,7 @@ namespace voltdb { namespace storage {          // older GCC would warn in absen
 }}
 
 template<typename Chunks, typename Tag, typename E> Tag IterableTableTupleChunks<Chunks, Tag, E>::s_tagger{};
+template<typename Chunks, typename Tag, typename E> bool const IterableTableTupleChunks<Chunks, Tag, E>::FALSE_VALUE = false;
 
 template<typename Chunks, typename Tag, typename E>
 template<iterator_permission_type perm, iterator_view_type view>

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -520,7 +520,7 @@ namespace voltdb {
             typename = typename enable_if<is_class<Tag>::value && is_chunks<Chunks>::value>::type>
         struct IterableTableTupleChunks final {
             using iterator_value_type = void*;         // constness-independent type being iterated over
-            static constexpr bool const FALSE_VALUE = false;           // default binding to iterator_type::m_deletedSnapshot when  is ignored.
+            static bool const FALSE_VALUE;             // default binding to iterator_type::m_deletedSnapshot when  is ignored.
             static Tag s_tagger;
             IterableTableTupleChunks() = delete;       // only iterator types can be created/used
             template<iterator_permission_type perm, iterator_view_type vtype>

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -719,7 +719,7 @@ namespace voltdb {
          * converted to boolean, and loop exists when it evaluates to true.
          */
         template<typename iterator_type, typename Fun, typename Chunks,
-            typename = typename enable_if<is_chunks<Chunks>::value && ! iterator_type::constness::value && ! is_const<Chunks>::value>::type>
+            typename = typename enable_if<is_chunks<Chunks>::value && iterator_type::constness::value == is_const<Chunks>::value>::type>
         inline void until(Chunks& c, Fun&& f) {
             for (auto iter = iterator_type::begin(c); ! iter.drained();) {
                 auto* addr = *iter;
@@ -751,8 +751,8 @@ namespace voltdb {
 
         template<typename iterator_type, typename Fun, typename Chunks, typename... Args>
         inline void until(Chunks& c, Fun&& f, Args&&... args) {
-            static_assert(! iterator_type::constness::value && ! is_const<Chunks>::value,
-                    "until only applies to non-const iterators and non-const chunks");
+            static_assert(iterator_type::constness::value == is_const<Chunks>::value,
+                    "until(): constness of Chunks and iterator should be the same");
             for (auto iter = iterator_type::begin(c, forward<Args&&>(args)...); ! iter.drained();) {
                 auto* addr = *iter;
                 ++iter;

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -542,7 +542,7 @@ namespace voltdb {
             protected:
                 using value_type = typename super::value_type;
                 value_type m_cursor;
-                bool* m_firstChunkToEnd = nullptr;        // if compacting from head with >1 chunks and snapshot has witnessed any deletes
+                bool* m_deletedSnapshot = nullptr;        // has any tuple deletion occurred during snapshot process?
                 // ctor arg type
                 using container_type = typename
                     add_lvalue_reference<typename conditional<perm == iterator_permission_type::ro,


### PR DESCRIPTION
New ee test added that simulates interleaved txn execution with snapshot process.
Found a bug from this test of an edge condition, fixed. Also contains some minor simplifications of the module.