### PR TITLE
Table tuple allocator batch removal api

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -475,6 +475,30 @@ inline CompactingChunks<dir>::CompactingChunks(size_t tupleSize) noexcept : m_tu
     trait::associate(this);
 }
 
+// returns non-null value only if in snapshot,
+// and the marked position is still in the first chunk.
+template<shrink_direction dir> inline void const* CompactingChunks<dir>::endOfFirstChunk() const noexcept {
+    if (m_endOfFirstChunk == nullptr || list_type::empty()) {
+        return nullptr;
+    } else {
+        auto const& first = list_type::front();
+        return first.begin() < m_endOfFirstChunk && first.end() >= m_endOfFirstChunk ?
+            m_endOfFirstChunk : nullptr;
+    }
+}
+
+template<shrink_direction dir> inline void CompactingChunks<dir>::freeze() noexcept {
+    if (! list_type::empty()) {
+        m_endOfFirstChunk = list_type::begin()->next();
+    }
+    trait::freeze();
+}
+
+template<shrink_direction dir> inline void CompactingChunks<dir>::thaw() noexcept {
+    m_endOfFirstChunk = nullptr;
+    trait::thaw();
+}
+
 template<shrink_direction dir> inline size_t CompactingChunks<dir>::size() const noexcept {
     return m_allocs;
 }
@@ -579,9 +603,8 @@ template<typename Chunks, typename Tag, typename E>
 template<iterator_permission_type perm, iterator_view_type view>
 inline IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>::iterator_type(
         typename IterableTableTupleChunks<Chunks, Tag, E>::template iterator_type<perm, view>::container_type src,
-        bool const& f):
-    m_offset(src.tupleSize()), m_storage(src),
-    m_iter(m_storage.begin()),
+        bool const& f) :
+    m_offset(src.tupleSize()), m_storage(src), m_iter(m_storage.begin()),
     m_cursor(const_cast<value_type>(m_iter == m_storage.end() ? nullptr : m_iter->begin())),
     m_deletedSnapshot(f) {
     // paranoid check
@@ -625,17 +648,30 @@ inline bool IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>:
  * head-compacting, when there are tuple deletions occurring
  * during snapshot.
  */
-template<typename Chunks, typename Iter, iterator_view_type view, typename Comp>
+template<typename ChunkList, typename Iter, iterator_view_type view, typename Comp>
 struct ChunkBoundary {
-    inline void const* operator()(Chunks&, Iter const& iter, bool) const noexcept {
+    inline void const* operator()(ChunkList const&, Iter const& iter, bool) const noexcept {
         return iter->next();
     }
 };
 
-template<typename Chunks, typename Iter>
-struct ChunkBoundary<Chunks, Iter, iterator_view_type::snapshot, integral_constant<Compactibility, Compactibility::head>> {
-    inline void const* operator()(Chunks& l, Iter const& iter, bool flag) const noexcept {
-        return flag && iter == l.begin() ? iter->end() : iter->next();
+template<typename ChunkList, typename Iter>
+struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot,
+    integral_constant<Compactibility, Compactibility::head>> {
+    inline void const* operator()(ChunkList const& l, Iter const& iter, bool flag) const noexcept {
+        if (flag && iter == l.begin()) {
+            void const* end = reinterpret_cast<CompactingChunks<shrink_direction::head> const&>(l).endOfFirstChunk();
+            if (end != nullptr) {              // The first chunk in txn is the first chunk when snapshot started
+                return end;
+            } else if (l.size() > 1) {         // The first chunk when snapshot started had been "reclaimed" in txn view,
+                return iter->end();            // and the first chunk in current txn view is not the last chunk: frozen view needs
+                // (and is safe) to cover the whole first chunk
+            } else {                           // There is now a single chunk in txn view, which is not the first chunk
+                return iter->next();           // when we froze.
+            }
+        } else {
+            return iter->next();
+        }
     }
 };
 

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -224,7 +224,7 @@ namespace voltdb {
         class NonCompactingChunks final : private ChunkList<Chunk> {
             template<typename Chunks, typename Tag, typename E> friend class IterableTableTupleChunks;
             size_t const m_tupleSize;
-
+            size_t m_allocs = 0;
             NonCompactingChunks(EagerNonCompactingChunk const&) = delete;
             NonCompactingChunks(NonCompactingChunks&&) = delete;
             NonCompactingChunks& operator=(NonCompactingChunks const&) = delete;
@@ -233,6 +233,7 @@ namespace voltdb {
             NonCompactingChunks(size_t) noexcept;
             ~NonCompactingChunks() = default;
             size_t tupleSize() const noexcept;
+            size_t size() const noexcept;
             void* allocate();
             void free(void*);
             bool tryFree(void*);                       // not an error if addr not found
@@ -346,6 +347,7 @@ namespace voltdb {
             using list_type = ChunkList<CompactingChunk>;
             using trait = CompactingStorageTrait<dir>;
             size_t const m_tupleSize;
+            size_t m_allocs = 0;
 
             CompactingChunks(CompactingChunks const&) = delete;
             CompactingChunks& operator=(CompactingChunks const&) = delete;
@@ -372,6 +374,7 @@ namespace voltdb {
             // CompactingChunksIgnorableFree struct in .cpp for
             // details.
             void* free(void*);
+            size_t size() const noexcept;              // used for table count executor
             using trait::freeze; using trait::thaw;
             using list_type::empty;
         };

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -190,6 +190,7 @@ void testIteratorOfNonCompactingChunks() {
     for(i = 0; i < NumTuples; ++i) {
         addresses[i] = gen.fill(alloc.allocate());
     }
+    assert(alloc.size() == NumTuples);
     class Checker {
         size_t m_index = 0;                // Note that NonCompactingChunks uses singly-linked list
         map<void const*, size_t> m_remains;
@@ -242,6 +243,7 @@ void testIteratorOfNonCompactingChunks() {
         gen.fill(alloc.allocate());
     }
     assert(! alloc.empty());
+    assert(alloc.size() == NumTuples);
     i = 0;
     for_each<iterator>(alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });
     assert(i == NumTuples);
@@ -249,7 +251,6 @@ void testIteratorOfNonCompactingChunks() {
     // Iterating on empty chunks is a no-op
     for_each<iterator>(alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });
     assert(i == NumTuples);
-
     // expected compiler error: cannot mix const_iterator with non-const
     // lambda function. Uncomment next 2 lines to see
     /*for_each<typename IterableTableTupleChunks<Chunks, truth>::const_iterator>(
@@ -287,6 +288,7 @@ void testCompactingChunks() {
     fold<const_iterator>(alloc_cref,
             [&i, &addresses](void const* p) { assert(p == addresses[i++]); });
     assert(i == NumTuples);
+    assert(alloc_cref.size() == NumTuples);
     // testing compacting behavior
     // 1. free() call sequence that does not trigger compaction
     bool const shrinkFromHead = Chunks::Compact::value == Compactibility::head;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1094,7 +1094,7 @@ void testSingleChunkSnapshot() {
     using Alloc = HookedCompactingChunks<CompactingChunks<dir>,
           TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
     using Gen = StringGen<TupleSize>;
-    static constexpr auto Number = NumTuples - 3;
+    static constexpr auto Number = AllocsPerChunk - 3;
     using addresses_type = array<void const*, Number>;
     Gen gen;
     Alloc alloc(TupleSize);


### PR DESCRIPTION
 - Picked up latest dev-branch improvements/bug fixes related to the module
 - (Finally) Fixed the special edge case of single non-full chunk when snapshot started, AND when tuple deletes occur in the snapshot process, to ensure that snapshot view is intact. (Involves quite some logic/arbitrage, and some meta-programming crap to get the wheels running!)
 - No work on the new API for batch removal operation done. Will continue on this branch; but plan to merge current changes to master.