### PR TITLE
SSM: Only initialize members if not set

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -719,6 +719,7 @@ public class SynchronizedStatesManager {
             m_stateChangeInitiator = false;
             m_ourDistributedLockName = null;
             m_lockWaitingOn = null;
+            m_knownMembers = null;
             m_holdingDistributedLock = false;
             m_pendingProposal = null;
             m_currentRequestType = REQUEST_TYPE.INITIALIZING;


### PR DESCRIPTION
With ssm initialization being async the members passed into the
initialize method could become stale by the time m_knownMembers is set.
This can happen when a member update comes in after the initialization
is started and the updated is scheduled between two of the async steps
of the state machine initialization.