### PR TITLE
ENG-18833: Use try with resource to guarantee unlock

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -34,8 +34,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.zookeeper_voltpatches.AsyncCallback;
 import org.apache.zookeeper_voltpatches.CreateMode;
@@ -49,6 +47,7 @@ import org.apache.zookeeper_voltpatches.data.Stat;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.VoltDB;
+import org.voltdb.utils.Mutex;
 
 import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableSet;
@@ -294,62 +293,19 @@ public class SynchronizedStatesManager {
         private boolean m_initializationCompleted = false;
 
         private boolean isInitializationCompleted() {
-            lockLocalState();
-            unlockLocalState();
-            return m_initializationCompleted;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                return m_initializationCompleted;
+            }
         }
 
         public int getResetCounter() {
             return m_resetCounter;
         }
 
-        private final Lock m_mutex = new ReentrantLock();
-        private int m_mutexLockedCnt = 0;
-        private final ThreadLocal<Boolean> m_mutexLocked = new ThreadLocal<Boolean>() {
-            @Override
-            protected Boolean initialValue()
-            {
-                return new Boolean(false);
-            }
-        };
+        private final Mutex m_mutex = new Mutex();
 
-        private boolean debugVerifyLockAcquire() {
-            m_mutexLocked.set(new Boolean(true));
-            return m_mutexLockedCnt++ == 0;
-        }
-
-        private boolean debugVerifyLockRelease() {
-            m_mutexLocked.set(new Boolean(false));
-            return (m_mutexLockedCnt-- == 1);
-        }
-
-        protected boolean debugIsLocalStateLocked() {
-            return m_mutexLocked.get();
-        }
-
-        private void lockLocalState() {
-            m_mutex.lock();
-            assert(debugVerifyLockAcquire());
-        }
-
-        // This wrapper resolves getStackTrace correctly when debugging locking
-        private void lockLocalStateForLockRunner() {
-            lockLocalState();
-        }
-
-        // This wrapper resolves getStackTrace correctly when debugging locking
-        private void lockLocalStateForResultsRunner() {
-            lockLocalState();
-        }
-
-        // This wrapper resolves getStackTrace correctly when debugging locking
-        private void lockLocalStateForParticipantRunner() {
-            lockLocalState();
-        }
-
-        private void unlockLocalState() {
-            assert(debugVerifyLockRelease());
-            m_mutex.unlock();
+        boolean debugIsLocalStateLocked() {
+            return m_mutex.isHeldByCurrentThread();
         }
 
         private class LockWatcher implements Watcher {
@@ -598,119 +554,131 @@ public class SynchronizedStatesManager {
 
         private void initializeStateMachine(Set<String> knownMembers)
                 throws KeeperException, InterruptedException {
-            lockLocalState();
-            // Make sure the child count is correct so that an init does not race with a released lock where the
-            // results have not been processed yet. If it is non-zero, it means results still need to be collected
-            // by some nodes even if the distributed lock list is empty.
-            m_currentParticipants = m_zk.getChildren(m_barrierParticipantsPath, null).size();
-            boolean ownDistributedLock = requestDistributedLock();
-            ByteBuffer startStates = buildProposal(REQUEST_TYPE.INITIALIZING,
-                    m_requestedInitialState.asReadOnlyBuffer(), m_requestedInitialState.asReadOnlyBuffer());
-            addIfMissing(m_barrierResultsPath, CreateMode.PERSISTENT, startStates.array());
-            boolean stateMachineNodeCreated = false;
-            if (ownDistributedLock) {
-                // Only the very first initializer of the state machine will both get the lock and successfully
-                // allocate "STATE_INITIALIZED". This guarantees that only one node will assign the initial state.
-                stateMachineNodeCreated = addIfMissing(ZKUtil.joinZKPath(m_statePath, "STATE_INITIALIZED"),
-                        CreateMode.PERSISTENT, null);
-            }
-
-            if (m_membershipChangePending) {
-                getLatestMembership();
-            } else if (m_knownMembers == null) {
-                // Members could be set by the callback which was handled between the async initialization calls
-                m_knownMembers = knownMembers;
-            }
-            // We need to always monitor participants so that if we are initialized we can add ourselves and insert
-            // our results and if we are not initialized, we can always auto-insert a null result.
-            if (stateMachineNodeCreated) {
-                assert(ownDistributedLock);
-                m_synchronizedState = m_requestedInitialState;
-                m_requestedInitialState = null;
-                m_lastProposalVersion = getProposalVersion();
-                ByteBuffer readOnlyResult = m_synchronizedState.asReadOnlyBuffer();
-                // Add an acceptable result so the next initializing member recognizes an immediate quorum.
-                byte result[] = new byte[1];
-                result[0] = (byte)(1);
-                addResultEntry(result);
-                m_lockWaitingOn = "bogus"; // Avoids call to notifyDistributedLockWaiter
-                if (m_log.isDebugEnabled()) {
-                    m_log.debug(m_stateMachineId + ": Initialized (first member) with State " +
-                            stateToString(m_synchronizedState.asReadOnlyBuffer()));
-                }
-                m_initializationCompleted = true;
-                cancelDistributedLock();
-                checkForBarrierParticipantsChange();
-                // Notify the derived object that we have a stable state
-                try {
-                    setInitialState(readOnlyResult);
-                } catch (Exception e) {
-                    if (m_log.isDebugEnabled()) {
-                        m_log.debug("Error in StateMachineInstance callbacks.", e);
-                    }
-                    m_initializationCompleted = false;
-                    submitCallable(new CallbackExceptionHandler(this));
-                }
-            }
-            else {
-                // To get a stable result set, we need to get the lock for this state machine. If someone else has the
-                // lock they can clear the stale results out from under us.
+            SmiCallable outOfLockWork = null;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                // Make sure the child count is correct so that an init does not race with a released lock where the
+                // results have not been processed yet. If it is non-zero, it means results still need to be collected
+                // by some nodes even if the distributed lock list is empty.
+                m_currentParticipants = m_zk.getChildren(m_barrierParticipantsPath, null).size();
+                boolean ownDistributedLock = requestDistributedLock();
+                ByteBuffer startStates = buildProposal(REQUEST_TYPE.INITIALIZING,
+                        m_requestedInitialState.asReadOnlyBuffer(), m_requestedInitialState.asReadOnlyBuffer());
+                addIfMissing(m_barrierResultsPath, CreateMode.PERSISTENT, startStates.array());
+                boolean stateMachineNodeCreated = false;
                 if (ownDistributedLock) {
-                    initializeFromActiveCommunity();
+                    // Only the very first initializer of the state machine will both get the lock and successfully
+                    // allocate "STATE_INITIALIZED". This guarantees that only one node will assign the initial state.
+                    stateMachineNodeCreated = addIfMissing(ZKUtil.joinZKPath(m_statePath, "STATE_INITIALIZED"),
+                            CreateMode.PERSISTENT, null);
+                }
+
+                if (m_membershipChangePending) {
+                    getLatestMembership();
+                } else if (m_knownMembers == null) {
+                    // Members could be set by the callback which was handled between the async initialization calls
+                    m_knownMembers = knownMembers;
+                }
+                // We need to always monitor participants so that if we are initialized we can add ourselves and insert
+                // our results and if we are not initialized, we can always auto-insert a null result.
+                if (stateMachineNodeCreated) {
+                    assert (ownDistributedLock);
+                    m_synchronizedState = m_requestedInitialState;
+                    m_requestedInitialState = null;
+                    m_lastProposalVersion = getProposalVersion();
+                    ByteBuffer readOnlyResult = m_synchronizedState.asReadOnlyBuffer();
+                    // Add an acceptable result so the next initializing member recognizes an immediate quorum.
+                    byte result[] = new byte[1];
+                    result[0] = (byte) (1);
+                    addResultEntry(result);
+                    m_lockWaitingOn = "bogus"; // Avoids call to notifyDistributedLockWaiter
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug(m_stateMachineId + ": Initialized (first member) with State "
+                                + stateToString(m_synchronizedState.asReadOnlyBuffer()));
+                    }
+                    m_initializationCompleted = true;
+                    cancelDistributedLock();
+                    outOfLockWork = new ChainedCallable(checkForBarrierParticipantsChange()) {
+                        @Override
+                        protected void callImpl() {
+                            // Notify the derived object that we have a stable state
+                            try {
+                                setInitialState(readOnlyResult);
+                            } catch (Exception e) {
+                                if (m_log.isDebugEnabled()) {
+                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                }
+                                m_initializationCompleted = false;
+                                submitCallable(new CallbackExceptionHandler(StateMachineInstance.this));
+                            }
+                        }
+                    };
+
                 }
                 else {
-                    // This means we will ignore the current update if there is one in progress.
-                    // Note that if we are not the next waiter for the lock, we will blindly
-                    // accept the next proposal and use the outcome to set our initial state.
-                    addResultEntry(null);
-                    Stat nodeStat = new Stat();
-                    boolean resultNodeFound = false;
-                    do {
-                        try {
-                            m_zk.getData(m_barrierResultsPath, false, nodeStat);
-                            resultNodeFound = true;
-                        }
-                        catch (NoNodeException noNode) {
-                            // This is a race between another node who got the Distributed lock but
-                            // Has not set up the result path yet. Keep Retrying.
-                        }
-                    } while (!resultNodeFound);
-                    m_lastProposalVersion = nodeStat.getVersion();
-                    checkForBarrierParticipantsChange();
+                    // To get a stable result set, we need to get the lock for this state machine. If someone else has
+                    // the
+                    // lock they can clear the stale results out from under us.
+                    if (ownDistributedLock) {
+                        outOfLockWork = initializeFromActiveCommunity();
+                    } else {
+                        // This means we will ignore the current update if there is one in progress.
+                        // Note that if we are not the next waiter for the lock, we will blindly
+                        // accept the next proposal and use the outcome to set our initial state.
+                        addResultEntry(null);
+                        Stat nodeStat = new Stat();
+                        boolean resultNodeFound = false;
+                        do {
+                            try {
+                                m_zk.getData(m_barrierResultsPath, false, nodeStat);
+                                resultNodeFound = true;
+                            } catch (NoNodeException noNode) {
+                                // This is a race between another node who got the Distributed lock but
+                                // Has not set up the result path yet. Keep Retrying.
+                            }
+                        } while (!resultNodeFound);
+                        m_lastProposalVersion = nodeStat.getVersion();
+                        outOfLockWork = checkForBarrierParticipantsChange();
+                    }
                 }
             }
-            assert(!debugIsLocalStateLocked());
+
+            if (outOfLockWork != null) {
+                outOfLockWork.call();
+            }
         }
 
         /*
          * This state machine and all other state machines under this manager are being removed
          */
         private void disableMembership() {
-            lockLocalState();
-            // put in two separate try-catch blocks so that both actions are attempted
-            try {
-                m_zk.delete(m_myParticipantPath, -1);
-            }
-            catch (KeeperException | InterruptedException e) {
-                if (m_log.isDebugEnabled()) {
-                    m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName() + " in disableMembership");
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                // put in two separate try-catch blocks so that both actions are attempted
+                try {
+                    m_zk.delete(m_myParticipantPath, -1);
                 }
-            }
-            try {
-                if (m_ourDistributedLockName != null) {
+                catch (KeeperException | InterruptedException e) {
                     if (m_log.isDebugEnabled()) {
-                        m_log.debug(m_stateMachineId + ": cancelLockRequest (Shutdown) for " + m_ourDistributedLockName);
+                        m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName()
+                                + " in disableMembership");
                     }
-                    m_zk.delete(m_ourDistributedLockName, -1);
                 }
-            }
-            catch (KeeperException | InterruptedException e) {
-                if (m_log.isDebugEnabled()) {
-                    m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName() + " in disableMembership");
+                try {
+                    if (m_ourDistributedLockName != null) {
+                        if (m_log.isDebugEnabled()) {
+                            m_log.debug(m_stateMachineId + ": cancelLockRequest (Shutdown) for "
+                                    + m_ourDistributedLockName);
+                        }
+                        m_zk.delete(m_ourDistributedLockName, -1);
+                    }
                 }
+                catch (KeeperException | InterruptedException e) {
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName()
+                                + " in disableMembership");
+                    }
+                }
+                m_initializationCompleted = false;
             }
-            m_initializationCompleted = false;
-            unlockLocalState();
         }
 
         private void reset(boolean isDirectVictim) {
@@ -738,7 +706,6 @@ public class SynchronizedStatesManager {
             m_currentRequestType = REQUEST_TYPE.INITIALIZING;
             m_memberResults = null;
             m_lastProposalVersion = 0;
-            m_mutexLockedCnt = 0;
 
             m_myResultPath = ZKUtil.joinZKPath(m_barrierResultsPath, m_memberId);
             m_myParticipantPath = ZKUtil.joinZKPath(m_barrierParticipantsPath, m_memberId);
@@ -793,7 +760,7 @@ public class SynchronizedStatesManager {
             return new StateChangeRequest(requestType, states.slice(), proposedState);
         }
 
-        private void checkForBarrierParticipantsChange() throws KeeperException {
+        private SmiCallable checkForBarrierParticipantsChange() throws KeeperException {
             assert(debugIsLocalStateLocked());
             try {
                 m_participantsChangePending = false;
@@ -815,7 +782,6 @@ public class SynchronizedStatesManager {
                         if (m_requestedInitialState != null) {
                             // Since we have not initialized yet, we acknowledge this proposal with an empty result.
                             addResultEntry(null);
-                            unlockLocalState();
                         }
                         else {
                             // Don't add ourselves as a participant because we don't care about the results
@@ -831,7 +797,6 @@ public class SynchronizedStatesManager {
                                     result[0] = (byte)0;
                                 }
                                 addResultEntry(result);
-                                unlockLocalState();
                             }
                             else {
                                 // We track the number of people waiting on the results so we know when the result is stale and
@@ -856,29 +821,30 @@ public class SynchronizedStatesManager {
                                                 taskToString(proposedState.asReadOnlyBuffer()));
                                     }
                                 }
-                                unlockLocalState();
-                                if (type == REQUEST_TYPE.STATE_CHANGE_REQUEST) {
-                                    try {
-                                        stateChangeProposed(proposedState);
-                                    } catch (Exception e) {
-                                        if (m_log.isDebugEnabled()) {
-                                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                return () -> {
+                                    if (type == REQUEST_TYPE.STATE_CHANGE_REQUEST) {
+                                        try {
+                                            stateChangeProposed(proposedState);
+                                        } catch (Exception e) {
+                                            if (m_log.isDebugEnabled()) {
+                                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                            }
+                                            m_initializationCompleted = false;
+                                            submitCallable(new CallbackExceptionHandler(this));
                                         }
-                                        m_initializationCompleted = false;
-                                        submitCallable(new CallbackExceptionHandler(this));
                                     }
-                                }
-                                else {
-                                    try {
-                                        taskRequested(proposedState);
-                                    } catch (Exception e) {
-                                        if (m_log.isDebugEnabled()) {
-                                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                    else {
+                                        try {
+                                            taskRequested(proposedState);
+                                        } catch (Exception e) {
+                                            if (m_log.isDebugEnabled()) {
+                                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                            }
+                                            m_initializationCompleted = false;
+                                            submitCallable(new CallbackExceptionHandler(this));
                                         }
-                                        m_initializationCompleted = false;
-                                        submitCallable(new CallbackExceptionHandler(this));
                                     }
-                                }
+                                };
                             }
                         }
                     }
@@ -890,19 +856,17 @@ public class SynchronizedStatesManager {
                             // This is a Task request made by us so notify the derived state machine to perform the task
                             // provide a result.
                             ByteBuffer taskRequest = m_pendingProposal.asReadOnlyBuffer();
-                            unlockLocalState();
-                            try {
-                                taskRequested(taskRequest);
-                            } catch (Exception e) {
-                                if (m_log.isDebugEnabled()) {
-                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                            return () -> {
+                                try {
+                                    taskRequested(taskRequest);
+                                } catch (Exception e) {
+                                    if (m_log.isDebugEnabled()) {
+                                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                    }
+                                    m_initializationCompleted = false;
+                                    submitCallable(new CallbackExceptionHandler(this));
                                 }
-                                m_initializationCompleted = false;
-                                submitCallable(new CallbackExceptionHandler(this));
-                            }
-                        }
-                        else {
-                            unlockLocalState();
+                            };
                         }
                     }
                 }
@@ -910,10 +874,7 @@ public class SynchronizedStatesManager {
                     m_currentParticipants = newParticipantCnt;
                     if (canObtainDistributedLock()) {
                         // We can finally notify the lock waiter because everyone is finished evaluating the previous state proposal
-                        notifyDistributedLockWaiter();
-                    }
-                    else {
-                        unlockLocalState();
+                        return notifyDistributedLockWaiter();
                     }
                 }
             } catch (KeeperException.SessionExpiredException | KeeperException.ConnectionLossException
@@ -923,9 +884,8 @@ public class SynchronizedStatesManager {
                     m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName()
                             + " in checkForBarrierParticipantsChange");
                 }
-                unlockLocalState();
             }
-            assert(!debugIsLocalStateLocked());
+            return null;
         }
 
         /**
@@ -942,8 +902,13 @@ public class SynchronizedStatesManager {
             // always start checking for participation changes after the result notifications
             // or initialization notifications to ensure these notifications happen before lock
             // ownership notifications.
-            lockLocalState();
-            checkForBarrierParticipantsChange();
+            SmiCallable outOfLockWork;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                outOfLockWork = checkForBarrierParticipantsChange();
+            }
+            if (outOfLockWork != null) {
+                outOfLockWork.call();
+            }
         }
 
         private RESULT_CONCENSUS resultsAgreeOnSuccess(Set<String> memberList)
@@ -1051,7 +1016,7 @@ public class SynchronizedStatesManager {
         }
 
         // The number of results is a superset of the membership so analyze the results
-        private void processResultQuorum(Set<String> memberList) throws KeeperException {
+        private SmiCallable processResultQuorum(Set<String> memberList) throws KeeperException {
             assert(m_currentRequestType != REQUEST_TYPE.INITIALIZING);
             m_memberResults = null;
             if (m_requestedInitialState != null) {
@@ -1132,25 +1097,23 @@ public class SynchronizedStatesManager {
                                 stateToString(m_synchronizedState.asReadOnlyBuffer()));
                     }
                     m_initializationCompleted = true;
-                    unlockLocalState();
-                    try {
-                        setInitialState(readOnlyResult);
-                    } catch (Exception e) {
-                        if (m_log.isDebugEnabled()) {
-                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    return () -> {
+                        try {
+                            setInitialState(readOnlyResult);
+                        } catch (Exception e) {
+                            if (m_log.isDebugEnabled()) {
+                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                            }
+                            m_initializationCompleted = false;
+                            submitCallable(new CallbackExceptionHandler(this));
                         }
-                        m_initializationCompleted = false;
-                        submitCallable(new CallbackExceptionHandler(this));
-                    }
 
-                    if (m_initializationCompleted) {
-                        // If we are ready to provide an initial state to the derived state machine, add us to
-                        // participants watcher so we can see the next request
-                        monitorParticipantChanges();
-                    }
-                }
-                else {
-                    unlockLocalState();
+                        if (m_initializationCompleted) {
+                            // If we are ready to provide an initial state to the derived state machine, add us to
+                            // participants watcher so we can see the next request
+                            monitorParticipantChanges();
+                        }
+                    };
                 }
             }
             else {
@@ -1191,21 +1154,23 @@ public class SynchronizedStatesManager {
                         m_log.debug(m_stateMachineId + ": Proposed state " + (success?"succeeded ":"failed ") +
                                 stateToString(attemptedChange.asReadOnlyBuffer()));
                     }
-                    unlockLocalState();
-                    // Notify the derived state machine engine of the current state
-                    try {
-                        proposedStateResolved(initiator, attemptedChange, success);
-                    } catch (Exception e) {
-                        if (m_log.isDebugEnabled()) {
-                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                    final boolean finalSuccess = success;
+                    return () -> {
+                        // Notify the derived state machine engine of the current state
+                        try {
+                            proposedStateResolved(initiator, attemptedChange, finalSuccess);
+                        } catch (Exception e) {
+                            if (m_log.isDebugEnabled()) {
+                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                            }
+                            m_initializationCompleted = false;
+                            submitCallable(new CallbackExceptionHandler(this));
                         }
-                        m_initializationCompleted = false;
-                        submitCallable(new CallbackExceptionHandler(this));
-                    }
 
-                    if (m_initializationCompleted) {
-                        monitorParticipantChanges();
-                    }
+                        if (m_initializationCompleted) {
+                            monitorParticipantChanges();
+                        }
+                    };
                 }
                 else {
                     // Process the results of a TASK request
@@ -1223,16 +1188,21 @@ public class SynchronizedStatesManager {
                             m_stateChangeInitiator = false;
                             cancelDistributedLock();
                         }
-                        unlockLocalState();
-                        try {
-                            correlatedTaskCompleted(initiator, taskRequest, results);
-                        } catch (Exception e) {
-                            if (m_log.isDebugEnabled()) {
-                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                        return () -> {
+                            try {
+                                correlatedTaskCompleted(initiator, taskRequest, results);
+                            } catch (Exception e) {
+                                if (m_log.isDebugEnabled()) {
+                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                }
+                                m_initializationCompleted = false;
+                                submitCallable(new CallbackExceptionHandler(this));
                             }
-                            m_initializationCompleted = false;
-                            submitCallable(new CallbackExceptionHandler(this));
-                        }
+
+                            if (m_initializationCompleted) {
+                                monitorParticipantChanges();
+                            }
+                        };
                     }
                     else {
                         ArrayList<ByteBuffer> results = getUncorrelatedResults(taskRequest, memberList);
@@ -1242,31 +1212,32 @@ public class SynchronizedStatesManager {
                             m_stateChangeInitiator = false;
                             cancelDistributedLock();
                         }
-                        unlockLocalState();
-                        try {
-                            uncorrelatedTaskCompleted(initiator, taskRequest, results);
-                        } catch (Exception e) {
-                            if (m_log.isDebugEnabled()) {
-                                m_log.debug("Error in StateMachineInstance callbacks.", e);
+                        return () -> {
+                            try {
+                                uncorrelatedTaskCompleted(initiator, taskRequest, results);
+                            } catch (Exception e) {
+                                if (m_log.isDebugEnabled()) {
+                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                }
+                                m_initializationCompleted = false;
+                                submitCallable(new CallbackExceptionHandler(this));
                             }
-                            m_initializationCompleted = false;
-                            submitCallable(new CallbackExceptionHandler(this));
-                        }
-                    }
 
-                    if (m_initializationCompleted) {
-                        monitorParticipantChanges();
+                            if (m_initializationCompleted) {
+                                monitorParticipantChanges();
+                            }
+                        };
                     }
                 }
             }
+            return null;
         }
 
-        private void checkForBarrierResultsChanges() throws KeeperException {
+        private SmiCallable checkForBarrierResultsChanges() throws KeeperException {
             assert(debugIsLocalStateLocked());
             if (m_pendingProposal == null) {
                 // Don't check for barrier results until we notice the participant list change.
-                unlockLocalState();
-                return;
+                return null;
             }
             Set<String> membersWithResults;
             try {
@@ -1281,22 +1252,17 @@ public class SynchronizedStatesManager {
                 }
             }
             if (Sets.difference(m_knownMembers, membersWithResults).isEmpty()) {
-                processResultQuorum(membersWithResults);
-                assert(!debugIsLocalStateLocked());
+                return processResultQuorum(membersWithResults);
             }
-            else {
-                m_memberResults = membersWithResults;
-                unlockLocalState();
-            }
+            m_memberResults = membersWithResults;
+            return null;
         }
 
         /*
          * Assumes this state machine owns the distributed lock and can either interrogate the existing state
          * or request the current state from the community (if the existing state is ambiguous)
          */
-        private void initializeFromActiveCommunity() throws KeeperException {
-            ByteBuffer readOnlyResult = null;
-            ByteBuffer staleTask = null;
+        private SmiCallable initializeFromActiveCommunity() throws KeeperException {
             byte oldAndProposedState[];
             try {
                 Stat lastProposal = new Stat();
@@ -1337,7 +1303,7 @@ public class SynchronizedStatesManager {
                             existingAndProposedStates.m_previousState, existingAndProposedStates.m_proposal);
                     m_lastProposalVersion = wakeCommunityWithProposal(stateChange.array());
                     addResultEntry(null);
-                    checkForBarrierResultsChanges();
+                    return checkForBarrierResultsChanges();
                 }
                 else {
                     assert(existingAndProposedStates.m_requestType == REQUEST_TYPE.INITIALIZING ||
@@ -1345,21 +1311,49 @@ public class SynchronizedStatesManager {
                             existingAndProposedStates.m_requestType == REQUEST_TYPE.UNCORRELATED_COORDINATED_TASK);
                     m_synchronizedState = existingAndProposedStates.m_previousState;
                     m_requestedInitialState = null;
-                    readOnlyResult = m_synchronizedState.asReadOnlyBuffer();
+                    ByteBuffer readOnlyResult = m_synchronizedState.asReadOnlyBuffer();
                     m_lastProposalVersion = lastProposal.getVersion();
                     m_pendingProposal = null;
                     if (m_log.isDebugEnabled()) {
                         m_log.debug(m_stateMachineId + ": Initialized (existing) with State " +
                                 stateToString(m_synchronizedState.asReadOnlyBuffer()));
                     }
+                    ByteBuffer staleTask;
                     if (existingAndProposedStates.m_requestType != REQUEST_TYPE.INITIALIZING) {
                         staleTask = existingAndProposedStates.m_proposal.asReadOnlyBuffer();
+                    } else {
+                        staleTask = null;
                     }
                     m_initializationCompleted = true;
                     cancelDistributedLock();
                     // Add an acceptable result so the next initializing member recognizes an immediate quorum.
                     m_lockWaitingOn = "bogus"; // Avoids call to notifyDistributedLockWaiter below
-                    checkForBarrierParticipantsChange();
+                    return new ChainedCallable(checkForBarrierParticipantsChange()) {
+                        @Override
+                        public void callImpl() {
+                            // Notify the derived object that we have a stable state
+                            try {
+                                setInitialState(readOnlyResult);
+                            } catch (Exception e) {
+                                if (m_log.isDebugEnabled()) {
+                                    m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                }
+                                m_initializationCompleted = false;
+                                submitCallable(new CallbackExceptionHandler(StateMachineInstance.this));
+                            }
+                            if (staleTask != null) {
+                                try {
+                                    staleTaskRequestNotification(staleTask);
+                                } catch (Exception e) {
+                                    if (m_log.isDebugEnabled()) {
+                                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                                    }
+                                    m_initializationCompleted = false;
+                                    submitCallable(new CallbackExceptionHandler(StateMachineInstance.this));
+                                }
+                            }
+                        }
+                    };
                 }
             } catch (KeeperException.SessionExpiredException | KeeperException.ConnectionLossException
                     | InterruptedException e) {
@@ -1368,29 +1362,7 @@ public class SynchronizedStatesManager {
                             + " in initializeFromActiveCommunity");
                 }
             }
-            if (readOnlyResult != null) {
-                // Notify the derived object that we have a stable state
-                try {
-                    setInitialState(readOnlyResult);
-                } catch (Exception e) {
-                    if (m_log.isDebugEnabled()) {
-                        m_log.debug("Error in StateMachineInstance callbacks.", e);
-                    }
-                    m_initializationCompleted = false;
-                    submitCallable(new CallbackExceptionHandler(this));
-                }
-            }
-            if (staleTask != null) {
-                try {
-                    staleTaskRequestNotification(staleTask);
-                } catch (Exception e) {
-                    if (m_log.isDebugEnabled()) {
-                        m_log.debug("Error in StateMachineInstance callbacks.", e);
-                    }
-                    m_initializationCompleted = false;
-                    submitCallable(new CallbackExceptionHandler(this));
-                }
-            }
+            return null;
         }
 
         private int wakeCommunityWithProposal(byte[] proposal) throws KeeperException {
@@ -1428,9 +1400,13 @@ public class SynchronizedStatesManager {
         private final Callable<Void> HandlerForBarrierParticipantsEvent = new Callable<Void>() {
             @Override
             public Void call() throws KeeperException {
-                lockLocalStateForParticipantRunner();
-                checkForBarrierParticipantsChange();
-                assert(!debugIsLocalStateLocked());
+                SmiCallable outOfLockWork;
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    outOfLockWork = checkForBarrierParticipantsChange();
+                }
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
+                }
                 return null;
             }
         };
@@ -1438,9 +1414,14 @@ public class SynchronizedStatesManager {
         private final Callable<Void> HandlerForBarrierResultsEvent = new Callable<Void>() {
             @Override
             public Void call() throws KeeperException {
-                lockLocalStateForResultsRunner();
-                checkForBarrierResultsChanges();
-                assert(!debugIsLocalStateLocked());
+                SmiCallable outOfLockWork;
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    outOfLockWork = checkForBarrierResultsChanges();
+                }
+
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
+                }
                 return null;
             }
         };
@@ -1482,30 +1463,30 @@ public class SynchronizedStatesManager {
         private final Callable<Void> HandlerForDistributedLockEvent = new Callable<Void>() {
             @Override
             public Void call() throws KeeperException {
-                lockLocalStateForLockRunner();
-                if (m_ourDistributedLockName != null) {
-                    try {
-                        m_lockWaitingOn = getNextLockNodeFromList();
-                    } catch (KeeperException.SessionExpiredException | KeeperException.ConnectionLossException
-                            | InterruptedException e) {
-                        if (m_log.isDebugEnabled()) {
-                            m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName()+ " in HandlerForDistributedLockEvent");
+                SmiCallable outOfLockWork = null;
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    if (m_ourDistributedLockName != null) {
+                        try {
+                            m_lockWaitingOn = getNextLockNodeFromList();
+                        } catch (KeeperException.SessionExpiredException | KeeperException.ConnectionLossException
+                                | InterruptedException e) {
+                            if (m_log.isDebugEnabled()) {
+                                m_log.debug(m_stateMachineId + ": Received " + e.getClass().getSimpleName()
+                                        + " in HandlerForDistributedLockEvent");
+                            }
+                            m_lockWaitingOn = "We died so we can't ever get the distributed lock";
                         }
-                        m_lockWaitingOn = "We died so we can't ever get the distributed lock";
-                    }
-                    if (canObtainDistributedLock()) {
-                        // There are no more members still processing the last result
-                        notifyDistributedLockWaiter();
-                    }
-                    else {
-                        unlockLocalState();
+                        if (canObtainDistributedLock()) {
+                            // There are no more members still processing the last result
+                            outOfLockWork = notifyDistributedLockWaiter();
+                        }
                     }
                 }
-                else {
-                    // lock was cancelled
-                    unlockLocalState();
+
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
                 }
-                assert(!debugIsLocalStateLocked());
+
                 return null;
             }
         };
@@ -1541,18 +1522,21 @@ public class SynchronizedStatesManager {
          */
         private void membershipChanged(Set<String> knownHosts, Set<String> addedMembers, Set<String> removedMembers)
                 throws KeeperException {
-            lockLocalState();
-            // Even though we got a direct update, membership could have changed again between the
-            m_knownMembers = knownHosts;
-            m_membershipChangePending = false;
-            boolean notInitializing = m_requestedInitialState == null;
-            if (m_pendingProposal != null && m_memberResults != null &&
-                    Sets.difference(m_knownMembers, m_memberResults).isEmpty()) {
-                // We can stop watching for results since we have a quorum.
-                processResultQuorum(m_memberResults);
+            boolean notInitializing;
+            SmiCallable outOfLockWork = null;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                // Even though we got a direct update, membership could have changed again between the
+                m_knownMembers = knownHosts;
+                m_membershipChangePending = false;
+                notInitializing = m_requestedInitialState == null;
+                if (m_pendingProposal != null && m_memberResults != null
+                        && Sets.difference(m_knownMembers, m_memberResults).isEmpty()) {
+                    // We can stop watching for results since we have a quorum.
+                    outOfLockWork = processResultQuorum(m_memberResults);
+                }
             }
-            else {
-                unlockLocalState();
+            if (outOfLockWork != null) {
+                outOfLockWork.call();
             }
             if (notInitializing) {
                 try {
@@ -1565,7 +1549,6 @@ public class SynchronizedStatesManager {
                     submitCallable(new CallbackExceptionHandler(this));
                 }
             }
-            assert(!debugIsLocalStateLocked());
         }
 
         /*
@@ -1587,7 +1570,7 @@ public class SynchronizedStatesManager {
             }
         }
 
-        private void notifyDistributedLockWaiter() throws KeeperException {
+        private SmiCallable notifyDistributedLockWaiter() throws KeeperException {
             assert(debugIsLocalStateLocked());
             assert(m_currentParticipants == 0);
             m_holdingDistributedLock = true;
@@ -1599,26 +1582,26 @@ public class SynchronizedStatesManager {
                 // look at the last set of results. We need to set proposedState so results will be checked.
                 assert(m_pendingProposal == null);
                 m_pendingProposal = m_requestedInitialState;
-                initializeFromActiveCommunity();
-                assert(!debugIsLocalStateLocked());
+                return initializeFromActiveCommunity();
             }
             else {
                 if (m_log.isDebugEnabled()) {
                     m_log.debug(m_stateMachineId + ": Granted lockRequest for " + m_ourDistributedLockName);
                 }
                 m_lockWaitingOn = null;
-                unlockLocalState();
                 // Notify the derived class that the lock is available
-                try {
-                    lockRequestCompleted();
-                } catch (Exception e) {
-                    cancelLockRequest();
-                    if (m_log.isDebugEnabled()) {
-                        m_log.debug("Error in StateMachineInstance callbacks.", e);
+                return () -> {
+                    try {
+                        lockRequestCompleted();
+                    } catch (Exception e) {
+                        cancelLockRequest();
+                        if (m_log.isDebugEnabled()) {
+                            m_log.debug("Error in StateMachineInstance callbacks.", e);
+                        }
+                        m_initializationCompleted = false;
+                        submitCallable(new CallbackExceptionHandler(this));
                     }
-                    m_initializationCompleted = false;
-                    submitCallable(new CallbackExceptionHandler(this));
-                }
+                };
             }
         }
 
@@ -1674,7 +1657,7 @@ public class SynchronizedStatesManager {
             }
         }
 
-        private void assignStateChangeAgreement(boolean acceptable) throws KeeperException {
+        private SmiCallable assignStateChangeAgreement(boolean acceptable) throws KeeperException {
             assert(debugIsLocalStateLocked());
             assert(m_pendingProposal != null);
             assert(m_currentRequestType == REQUEST_TYPE.STATE_CHANGE_REQUEST);
@@ -1683,7 +1666,7 @@ public class SynchronizedStatesManager {
             addResultEntry(result);
             if (acceptable) {
                 // Since we are only interested in the results when we agree with the proposal
-                checkForBarrierResultsChanges();
+                return checkForBarrierResultsChanges();
             }
             else {
                 m_pendingProposal = null;
@@ -1697,8 +1680,8 @@ public class SynchronizedStatesManager {
                                 + " in assignStateChangeAgreement");
                     }
                 }
-                unlockLocalState();
             }
+            return null;
         }
 
         /*
@@ -1706,11 +1689,9 @@ public class SynchronizedStatesManager {
          * current state of the community
          */
         protected boolean isInitialized() {
-            boolean initialized;
-            lockLocalState();
-            initialized = m_initializationCompleted && m_requestedInitialState == null;
-            unlockLocalState();
-            return initialized;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                return m_initializationCompleted && m_requestedInitialState == null;
+            }
         }
 
         /*
@@ -1723,15 +1704,12 @@ public class SynchronizedStatesManager {
          * Attempts to get the distributed lock. Returns true if the lock was acquired
          */
         protected boolean requestLock() {
-            lockLocalState();
-            try {
+            try (Mutex.Releaser r = m_mutex.acquire()) {
                 if (m_initializationCompleted) {
                     return requestDistributedLock();
                 }
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
-            } finally {
-                unlockLocalState();
             }
             return false;
         }
@@ -1742,16 +1720,13 @@ public class SynchronizedStatesManager {
          * is no longer necessary).
          */
         protected void cancelLockRequest() {
-            lockLocalState();
-            try {
+            try (Mutex.Releaser r = m_mutex.acquire()) {
                 if (m_initializationCompleted) {
                     assert (m_pendingProposal == null);
                     cancelDistributedLock();
                 }
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
-            } finally {
-                unlockLocalState();
             }
         }
 
@@ -1767,35 +1742,41 @@ public class SynchronizedStatesManager {
             assert m_holdingDistributedLock;
             assert(proposedState != null);
             assert(proposedState.remaining() < Short.MAX_VALUE);
-            lockLocalState();
-            if (!m_initializationCompleted) {
-                unlockLocalState();
-                return;
-            }
-            // Only the lock owner can initiate a barrier request
-            assert(m_requestedInitialState == null);
-            if (proposedState.position() == 0) {
-                m_pendingProposal = proposedState;
-            }
-            else {
-                // Move to a new 0 aligned buffer
-                m_pendingProposal = ByteBuffer.allocate(proposedState.remaining());
-                m_pendingProposal.put(proposedState.array(),
-                        proposedState.arrayOffset()+proposedState.position(), proposedState.remaining());
-                m_pendingProposal.flip();
-            }
-            if (m_log.isDebugEnabled()) {
-                m_log.debug(m_stateMachineId + ": Proposing new state " + stateToString(m_pendingProposal.asReadOnlyBuffer()));
-            }
-            m_stateChangeInitiator = true;
-            m_currentRequestType = REQUEST_TYPE.STATE_CHANGE_REQUEST;
-            ByteBuffer stateChange = buildProposal(REQUEST_TYPE.STATE_CHANGE_REQUEST,
-                    m_synchronizedState.asReadOnlyBuffer(), m_pendingProposal.asReadOnlyBuffer());
             try {
-                m_lastProposalVersion = wakeCommunityWithProposal(stateChange.array());
-                assignStateChangeAgreement(true);
+                SmiCallable outOfLockWork;
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    if (!m_initializationCompleted) {
+                        return;
+                    }
+                    // Only the lock owner can initiate a barrier request
+                    assert (m_requestedInitialState == null);
+                    if (proposedState.position() == 0) {
+                        m_pendingProposal = proposedState;
+                    } else {
+                        // Move to a new 0 aligned buffer
+                        m_pendingProposal = ByteBuffer.allocate(proposedState.remaining());
+                        m_pendingProposal.put(proposedState.array(),
+                                proposedState.arrayOffset() + proposedState.position(), proposedState.remaining());
+                        m_pendingProposal.flip();
+                    }
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug(m_stateMachineId + ": Proposing new state "
+                                + stateToString(m_pendingProposal.asReadOnlyBuffer()));
+                    }
+                    m_stateChangeInitiator = true;
+                    m_currentRequestType = REQUEST_TYPE.STATE_CHANGE_REQUEST;
+                    ByteBuffer stateChange = buildProposal(REQUEST_TYPE.STATE_CHANGE_REQUEST,
+                            m_synchronizedState.asReadOnlyBuffer(), m_pendingProposal.asReadOnlyBuffer());
+
+                    m_lastProposalVersion = wakeCommunityWithProposal(stateChange.array());
+                    outOfLockWork = assignStateChangeAgreement(true);
+                }
+
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
+                }
             } catch (Exception e) {
-                VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
+                throw VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
             }
         }
 
@@ -1809,18 +1790,23 @@ public class SynchronizedStatesManager {
          * Called to accept or reject a new proposed state change by another member.
          */
         protected void requestedStateChangeAcceptable(boolean acceptable) {
-            lockLocalState();
-            if (!m_initializationCompleted) {
-                unlockLocalState();
-                return;
-            }
-            assert(!m_stateChangeInitiator);
-            if (m_log.isDebugEnabled()) {
-                m_log.debug(m_stateMachineId + (acceptable ? ": Agrees with State proposal" :
-                        ": Disagrees with State proposal"));
-            }
             try {
-                assignStateChangeAgreement(acceptable);
+                SmiCallable outOfLockWork;
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    if (!m_initializationCompleted) {
+                        return;
+                    }
+                    assert (!m_stateChangeInitiator);
+                    if (m_log.isDebugEnabled()) {
+                        m_log.debug(m_stateMachineId
+                                + (acceptable ? ": Agrees with State proposal" : ": Disagrees with State proposal"));
+                    }
+
+                    outOfLockWork = assignStateChangeAgreement(acceptable);
+                }
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
+                }
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
             }
@@ -1836,10 +1822,9 @@ public class SynchronizedStatesManager {
          * Propose a new task. Only call after successful acquisition of the distributed lock.
          */
         protected void initiateCoordinatedTask(boolean correlated, ByteBuffer proposedTask) {
-            assert(proposedTask != null);
-            assert(proposedTask.remaining() < Short.MAX_VALUE);
-            lockLocalState();
-            try {
+            assert (proposedTask != null);
+            assert (proposedTask.remaining() < Short.MAX_VALUE);
+            try (Mutex.Releaser r = m_mutex.acquire()) {
                 if (m_initializationCompleted) {
                     // Only the lock owner can initiate a barrier request
                     assert (m_requestedInitialState == null);
@@ -1871,8 +1856,6 @@ public class SynchronizedStatesManager {
                 }
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
-            } finally {
-                unlockLocalState();
             }
         }
 
@@ -1893,24 +1876,28 @@ public class SynchronizedStatesManager {
          */
         protected void requestedTaskComplete(ByteBuffer result)
         {
-            lockLocalState();
-            if (!m_initializationCompleted) {
-                unlockLocalState();
-                return;
-            }
-            assert(m_pendingProposal != null);
-            if (m_log.isDebugEnabled()) {
-                if (result.hasRemaining()) {
-                    m_log.debug(m_stateMachineId + ": Local Task completed with result " +
-                            taskResultToString(m_pendingProposal.asReadOnlyBuffer(), result.asReadOnlyBuffer()));
-                }
-                else {
-                    m_log.debug(m_stateMachineId + ": Local Task completed with empty result");
-                }
-            }
+            SmiCallable outOfLockWork;
             try {
-                addResultEntry(result.array());
-                checkForBarrierResultsChanges();
+                try (Mutex.Releaser r = m_mutex.acquire()) {
+                    if (!m_initializationCompleted) {
+                        return;
+                    }
+                    assert (m_pendingProposal != null);
+                    if (m_log.isDebugEnabled()) {
+                        if (result.hasRemaining()) {
+                            m_log.debug(m_stateMachineId + ": Local Task completed with result " + taskResultToString(
+                                    m_pendingProposal.asReadOnlyBuffer(), result.asReadOnlyBuffer()));
+                        } else {
+                            m_log.debug(m_stateMachineId + ": Local Task completed with empty result");
+                        }
+                    }
+
+                    addResultEntry(result.array());
+                    outOfLockWork = checkForBarrierResultsChanges();
+                }
+                if (outOfLockWork != null) {
+                    outOfLockWork.call();
+                }
             } catch (Exception e) {
                 VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
             }
@@ -1934,31 +1921,21 @@ public class SynchronizedStatesManager {
          * warning: The ByteBuffer taskRequest is not guaranteed to start at position 0 (avoid rewind, flip, ...)
          */
         protected ByteBuffer getCurrentState() {
-            ByteBuffer currentState;
-            lockLocalState();
-            if (m_initializationCompleted) {
-                currentState = m_synchronizedState.asReadOnlyBuffer();
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                return m_initializationCompleted ? m_synchronizedState.asReadOnlyBuffer() : ByteBuffer.allocate(0);
             }
-            else {
-                currentState = ByteBuffer.allocate(0);
-            }
-            unlockLocalState();
-            return currentState;
         }
 
         protected void membershipChanged(Set<String> addedMembers, Set<String> removedMembers) {}
 
         protected Set<String> getCurrentMembers() {
-            lockLocalState();
-            try {
+            try (Mutex.Releaser r = m_mutex.acquire()) {
                 if (m_membershipChangePending) {
                     getLatestMembership();
                 }
                 return ImmutableSet.copyOf(m_knownMembers);
             } catch (Exception e) {
                 throw VoltDB.crashLocalVoltDB("SSM: Unexpected error encountered", true, e);
-            } finally {
-                unlockLocalState();
             }
         }
 
@@ -1976,9 +1953,9 @@ public class SynchronizedStatesManager {
         }
 
         protected boolean holdingDistributedLock() {
-            lockLocalState();
-            unlockLocalState();
-            return m_holdingDistributedLock;
+            try (Mutex.Releaser r = m_mutex.acquire()) {
+                return m_holdingDistributedLock;
+            }
         }
 
         protected abstract String stateToString(ByteBuffer state);
@@ -1986,6 +1963,26 @@ public class SynchronizedStatesManager {
         protected String taskToString(ByteBuffer task) { return ""; }
 
         protected String taskResultToString(ByteBuffer task, ByteBuffer taskResult) { return ""; }
+
+        /** Simple class which chains one callable to another */
+        private abstract class ChainedCallable implements SmiCallable {
+            private final SmiCallable m_previous;
+
+            ChainedCallable(SmiCallable callable) {
+                assert (debugIsLocalStateLocked());
+                m_previous = callable;
+            }
+
+            @Override
+            public final void call() throws KeeperException {
+                if (m_previous != null) {
+                    m_previous.call();
+                }
+                callImpl();
+            }
+
+            protected abstract void callImpl() throws KeeperException;
+        }
     }
 
     public SynchronizedStatesManager(ZooKeeper zk, String rootPath, String ssmNodeName, String memberId)
@@ -2296,4 +2293,8 @@ public class SynchronizedStatesManager {
         }
     }
 
+    /** Interface used by {@link StateMachineInstance} for work that needs to be performed outside of the member lock */
+    private interface SmiCallable {
+        void call() throws KeeperException;
+    }
 }

--- a/src/frontend/org/voltdb/utils/Mutex.java
+++ b/src/frontend/org/voltdb/utils/Mutex.java
@@ -1,0 +1,260 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.AbstractQueuedLongSynchronizer;
+
+/**
+ * A simple mutex which can only be locked and unlocked by the same thread once. If a thread attempts to lock the mutex
+ * a second time {@link IllegalMonitorStateException} will be thrown.
+ * <p>
+ * This class returns a {@link Mutex.Releaser} from all acquire methods when the lock is successfully acquired.
+ * {@link Mutex.Releaser} implements {@link AutoCloseable} so it can be used in a try with resources block. This
+ * guarantees that the mutex will be released at the end of the try block automatically by java.
+ *
+ * <pre>
+ * try (Mutex.Releaser r = mutex.acquire()) {
+ *     ...
+ * }
+ * </pre>
+ */
+public final class Mutex {
+    private final Sync m_sync = new Sync();
+    private final Releaser m_releaser = new Releaser();
+
+    /**
+     * Lock this mutex blocking until the mutex can be acquired.
+     *
+     * @return {@link Mutex.Releaser} to release this mutex
+     * @throws IllegalMonitorStateException if this mutex is already held by this thread
+     */
+    public Releaser acquire() {
+        m_sync.acquire();
+        return m_releaser;
+    }
+
+    /**
+     * Acquire this mutex blocking until the mutex is acquired or the thread is interrupted
+     *
+     * @return {@link Mutex.Releaser} to release this mutex
+     * @throws InterruptedException         If this thread was interrupted
+     * @throws IllegalMonitorStateException if this mutex is already held by this thread
+     */
+    public Releaser acquireInterruptibly() throws InterruptedException {
+        m_sync.acquireInterruptibly();
+        return m_releaser;
+    }
+
+    /**
+     * Test if the mutex can be acquired immediately and return whether or not it was successful
+     *
+     * @return {@link Mutex.Releaser} to release this mutex or {@code null} if the mutex was not acquired
+     * @throws IllegalMonitorStateException if this mutex is already held by this thread
+     */
+    public Releaser tryAcquire() {
+        return m_sync.tryAcquire() ? m_releaser : null;
+    }
+
+    /**
+     * Try to acquire this mutex blocking until timeout was reached or the mutex was acquired.
+     *
+     * @return {@link Mutex.Releaser} to release this mutex or {@code null} if the mutex was not acquired
+     * @throws InterruptedException         If this thread was interrupted
+     * @throws IllegalMonitorStateException if this mutex is already held by this thread
+     */
+    public Releaser tryAcquire(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return m_sync.tryAcquire(timeout, timeUnit) ? m_releaser : null;
+    }
+
+    /**
+     * Release the mutex if held by this thread
+     *
+     * @throws IllegalMonitorStateException If this thread did not hold the mutex
+     */
+    public void release() throws IllegalMonitorStateException {
+        m_sync.release();
+    }
+
+    /**
+     * @return {@code true} if this thread holds the mutex
+     */
+    public boolean isHeldByCurrentThread() {
+        return m_sync.isHeldByCurrentThread();
+    }
+
+    /**
+     * @return {@code true} if this mutex is currently held by a thread
+     */
+    public boolean isHeld() {
+        return m_sync.isHeld();
+    }
+
+    /**
+     * @return An estimate of the number of threads waiting to acquire this mutex
+     * @see AbstractQueuedLongSynchronizer#getQueueLength()
+     */
+    public int getQueueLength() {
+        return m_sync.getQueueLength();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(super.toString()).append(": ");
+        return m_sync.toString(sb).toString();
+    }
+
+    /**
+     * Simple class that implements {@link AutoCloseable} to be able to release the mutex in a try with resources block
+     */
+    public final class Releaser implements AutoCloseable {
+        /**
+         * Release the mutex if held by this thread
+         *
+         * @throws IllegalMonitorStateException If this thread did not hold the mutex
+         * @see Mutex#release()
+         */
+        @Override
+        public void close() {
+            release();
+        }
+    }
+
+    /**
+     * Synchronization implementation used by this mutex to guarantee non reentrent mutex holding
+     */
+    private static final class Sync extends AbstractQueuedLongSynchronizer {
+        private static final long serialVersionUID = 1L;
+        private static final long UNHELD = -1;
+
+        public Sync() {
+            setState(UNHELD);
+        }
+
+        /**
+         * Lock this mutex blocking until the mutex can be acquired.
+         *
+         * @throws IllegalMonitorStateException if this mutex is already held by this thread
+         */
+        public void acquire() {
+            Thread thread = Thread.currentThread();
+            acquire(thread.getId());
+            setExclusiveOwnerThread(thread);
+        }
+
+        /**
+         * Acquire this mutex blocking until the mutex is acquired or the thread is interrupted
+         *
+         * @throws InterruptedException         If this thread was interrupted
+         * @throws IllegalMonitorStateException if this mutex is already held by this thread
+         */
+        public void acquireInterruptibly() throws InterruptedException {
+            Thread thread = Thread.currentThread();
+            acquireInterruptibly(thread.getId());
+            setExclusiveOwnerThread(thread);
+        }
+
+        /**
+         * Test if the mutex can be acquired immediately and return whether or not it was successful
+         *
+         * @return {@code true} if the mutex is now held by this thread
+         * @throws IllegalMonitorStateException if this mutex is already held by this thread
+         */
+        public boolean tryAcquire() {
+            Thread thread = Thread.currentThread();
+            if (tryAcquire(thread.getId())) {
+                setExclusiveOwnerThread(thread);
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * Try to acquire this mutex blocking until timeout was reached or the mutex was acquired.
+         *
+         * @return {@code true} if the mutex is now held by this thread
+         * @throws InterruptedException         If this thread was interrupted
+         * @throws IllegalMonitorStateException if this mutex is already held by this thread
+         */
+        public boolean tryAcquire(long timeout, TimeUnit timeUnit) throws InterruptedException {
+            Thread thread = Thread.currentThread();
+            if (tryAcquireNanos(thread.getId(), timeUnit.toNanos(timeout))) {
+                setExclusiveOwnerThread(thread);
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * Release the mutex if held by this thread
+         *
+         * @throws IllegalMonitorStateException If this thread did not hold the mutex
+         */
+        public void release() throws IllegalMonitorStateException {
+            release(Thread.currentThread().getId());
+        }
+
+        /**
+         * @return {@code true} if this thread holds the mutex
+         */
+        public boolean isHeldByCurrentThread() {
+            return Thread.currentThread() == getExclusiveOwnerThread();
+        }
+
+        /**
+         * @return {@code true} if this mutex is currently held by a thread
+         */
+        public boolean isHeld() {
+            return getState() != UNHELD;
+        }
+
+        public StringBuilder toString(StringBuilder sb) {
+            long s = getState();
+            if (s == UNHELD) {
+                sb.append("unheld");
+            } else {
+                sb.append("held by thread ").append(s).append(" queue is ");
+                if (!hasQueuedThreads()) {
+                    sb.append("not ");
+                }
+                sb.append("empty");
+            }
+            return sb;
+        }
+
+        @Override
+        protected boolean tryAcquire(long threadId) {
+            if (!compareAndSetState(-1, threadId)) {
+                if (getState() == threadId) {
+                    throw new IllegalMonitorStateException("Thread already holds this lock");
+                }
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        protected boolean tryRelease(long threadId) {
+            if (!compareAndSetState(threadId, UNHELD)) {
+                throw new IllegalMonitorStateException("Lock not held by this thread");
+            }
+            setExclusiveOwnerThread(null);
+            return true;
+        }
+    }
+}

--- a/tests/frontend/org/voltdb/utils/TestMutex.java
+++ b/tests/frontend/org/voltdb/utils/TestMutex.java
@@ -1,0 +1,246 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+public class TestMutex {
+
+    @Test(timeout = 1_000)
+    public void acquireWithResourceApi() {
+        Mutex mutex = new Mutex();
+
+        try (Mutex.Releaser r = mutex.acquire()) {
+            assertTrue(mutex.isHeldByCurrentThread());
+        }
+        assertFalse(mutex.isHeldByCurrentThread());
+    }
+
+    @Test(timeout = 1_000)
+    public void acquireInterruptiblyWithResourceApi() throws Exception {
+        Mutex mutex = new Mutex();
+
+        try (Mutex.Releaser r = mutex.acquireInterruptibly()) {
+            assertTrue(mutex.isHeldByCurrentThread());
+        }
+        assertFalse(mutex.isHeldByCurrentThread());
+    }
+
+    @Test(timeout = 1_000)
+    public void tryAcquireWithResourceApi() {
+        Mutex mutex = new Mutex();
+
+        try (Mutex.Releaser r = mutex.tryAcquire()) {
+            assertTrue(mutex.isHeldByCurrentThread());
+        }
+        assertFalse(mutex.isHeldByCurrentThread());
+    }
+
+    @Test(timeout = 1_000)
+    public void tryAcquireTimeoutWithResourceApi() throws Exception {
+        Mutex mutex = new Mutex();
+
+        try (Mutex.Releaser r = mutex.tryAcquire(1, TimeUnit.MINUTES)) {
+            assertTrue(mutex.isHeldByCurrentThread());
+        }
+        assertFalse(mutex.isHeldByCurrentThread());
+    }
+
+    @Test(timeout = 1_000)
+    public void canNotLockTwice() throws Exception {
+        Mutex mutex = new Mutex();
+        assertNotNull("Should have been able to acquire mutex", mutex.tryAcquire());
+
+        try {
+            mutex.acquire();
+            fail("Should have thrown IllegalMonitorStateException");
+        } catch (IllegalMonitorStateException e) {
+        }
+
+        try {
+            mutex.acquireInterruptibly();
+            fail("Should have thrown IllegalMonitorStateException");
+        } catch (IllegalMonitorStateException e) {
+        }
+
+        try {
+            mutex.tryAcquire();
+            fail("Should have thrown IllegalMonitorStateException");
+        } catch (IllegalMonitorStateException e) {
+        }
+
+        try {
+            mutex.tryAcquire(10, TimeUnit.MILLISECONDS);
+            fail("Should have thrown IllegalMonitorStateException");
+        } catch (IllegalMonitorStateException e) {
+        }
+
+        mutex.release();
+        assertFalse(mutex.isHeldByCurrentThread());
+
+        assertNotNull("Should have been able to acquire mutex", mutex.tryAcquire());
+        assertTrue(mutex.isHeldByCurrentThread());
+        mutex.release();
+    }
+
+    @Test
+    public void releaseThrowsIfNotHeld() {
+        try {
+            new Mutex().release();
+            fail("Should have thrown IllegalMonitorStateException");
+        } catch (IllegalMonitorStateException e) {
+        }
+    }
+
+    @Test(timeout = 2_000)
+    public void onlyOneThreadHoldsMutex() throws Exception {
+        Mutex mutex = new Mutex();
+
+        AtomicBoolean failed = new AtomicBoolean();
+        AtomicBoolean lockHeld = new AtomicBoolean(true);
+        AtomicInteger lockAcquiredCount = new AtomicInteger();
+
+        mutex.acquire();
+        assertTrue(mutex.isHeldByCurrentThread());
+
+        Thread thread1 = new Thread() {
+            @Override
+            public void run() {
+                try (Mutex.Releaser r = mutex.acquire()) {
+                    lockAcquiredCount.getAndIncrement();
+                    if (mutex.isHeldByCurrentThread()) {
+                        failed.compareAndSet(false, lockHeld.get());
+                    } else {
+                        failed.set(true);
+                    }
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failed.set(true);
+                }
+            }
+        };
+        thread1.setDaemon(true);
+
+        Thread thread2 = new Thread() {
+            @Override
+            public void run() {
+                try (Mutex.Releaser r = mutex.acquireInterruptibly()) {
+                    lockAcquiredCount.getAndIncrement();
+                    if (mutex.isHeldByCurrentThread()) {
+                        failed.compareAndSet(false, lockHeld.get());
+                    } else {
+                        failed.set(true);
+                    }
+                } catch (InterruptedException e) {
+                    failed.set(true);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failed.set(true);
+                }
+            }
+        };
+        thread2.setDaemon(true);
+
+        Thread thread3 = new Thread() {
+            @Override
+            public void run() {
+                try (Mutex.Releaser r = mutex.tryAcquire(1, TimeUnit.SECONDS)) {
+                    if (r != null) {
+                        lockAcquiredCount.getAndIncrement();
+                        if (mutex.isHeldByCurrentThread()) {
+                            failed.compareAndSet(false, lockHeld.get());
+                        } else {
+                            failed.set(true);
+                        }
+                    } else {
+                        failed.set(true);
+                    }
+                } catch (InterruptedException e) {
+                    failed.set(true);
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    failed.set(true);
+                }
+            }
+        };
+        thread3.setDaemon(true);
+
+        thread1.start();
+        thread2.start();
+        thread3.start();
+
+        do {
+            Thread.yield();
+        } while (mutex.getQueueLength() != 3);
+
+        lockHeld.set(false);
+        mutex.release();
+        assertFalse(mutex.isHeldByCurrentThread());
+
+        thread1.join(250);
+        thread2.join(250);
+        thread3.join(250);
+
+        assertFalse(failed.get());
+        assertEquals("Lock not acquired the expected number of times", 3, lockAcquiredCount.get());
+    }
+
+    @Test(timeout = 2_000)
+    public void tryAcquireLockAlreadyHeld() throws Exception {
+        Mutex mutex = new Mutex();
+        boolean[] failed = { false };
+        try (Mutex.Releaser r = mutex.acquire()) {
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        if (mutex.tryAcquire() != null || mutex.tryAcquire(10, TimeUnit.MICROSECONDS) != null) {
+                            assertFalse(mutex.isHeldByCurrentThread());
+                            failed[0] = true;
+                        }
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                        failed[0] = true;
+                    }
+                }
+            };
+            t.setDaemon(true);
+            t.start();
+
+            t.join();
+        }
+
+        assertFalse(failed[0]);
+    }
+}


### PR DESCRIPTION
Simplify the locking in StateMachineInstance so that the method which
locks also unlocks. If a method being called needs to perform work
outside of the lock it returns a callback which will be invoked after
the lock is released. This implemenation guarantees that a method will
never return with the lock still locked. It does make the unlock work a
little harder to manage but it should be easier over all.