### PR TITLE
ENG-18944: Check if state machine is shutdown

### DIFF
--- a/src/frontend/org/voltdb/export/ExportCoordinator.java
+++ b/src/frontend/org/voltdb/export/ExportCoordinator.java
@@ -929,7 +929,7 @@ public class ExportCoordinator {
                         exportLog.debug("Export coordinator shutting down...");
                     }
                     m_stateMachine.shutdownCoordinationTask();
-                    m_ssm.ShutdownSynchronizedStatesManager();
+                    m_ssm.shutdownSynchronizedStatesManager();
 
                 } catch (Exception e) {
                     exportLog.error("Failed to initiate a coordinator shutdown: " + e);

--- a/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
+++ b/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
@@ -624,7 +624,7 @@ public class StateMachineSnipits extends ZKTestBase {
             assertTrue(monitorForManager1.m_members.size() == 3);
 
             // Remove MembershipMonitor1 from ZooKeeper0 while keeping MembershipMonitor3 alive
-            ssm1.ShutdownSynchronizedStatesManager();
+            ssm1.shutdownSynchronizedStatesManager();
 
             while (monitorForManager3.m_members.size() != 2 &&
                     !monitorForManager2.hasIdenticalMembership(monitorForManager3)) {


### PR DESCRIPTION
While the zoo keeper watchers do check if the state machine is shutdown
before scheduling any work to be done the work does not check if the
state machine has been shutdown since then. This is problematic if there
is a lot of work executing on the SSM thread since that means there
could be significant lag between when a watcher is triggered and when
the actual work is performed. Make sure each runnable or callable checks
the state of the state machine before performing any work.

Also change the state from a boolena to an enum so that reset can detect
when the state machine has been shutdown and not perform a reset.