### PR TITLE
ENG-19025: Update the readOffset as well when we mark all as read.

### DIFF
--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -913,11 +913,11 @@ class PBDRegularSegment<M> extends PBDSegment<M> {
         }
 
         @Override
-        public void markAllReadAndDiscarded() {
-            // This doesn't set the readOffset and bytesRead nor does it move the file pointer,
-            // but just updates the read and discarded count
+        public void markAllReadAndDiscarded() throws IOException {
+            //TODO: This doesn't set bytesRead. But, looks like we don't really use bytesRead?
             m_objectReadIndex = m_numOfEntries;
             m_discardCount = m_numOfEntries;
+            m_readOffset = m_fc.size();
         }
 
         @Override

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -109,5 +109,5 @@ interface PBDSegmentReader<M> {
      */
     public boolean isClosed();
 
-    public void markAllReadAndDiscarded();
+    public void markAllReadAndDiscarded() throws IOException;
 }


### PR DESCRIPTION
We were not updating read offset we marked a segment as fully read and discarded. This was OK when the segment is not the last one. When the segment is the last one, we may write and read additional buffers, which means the readOffset has to be set correctly as well.