### PR TITLE
Snapshot iterator aware hook

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -215,16 +215,10 @@ inline void ChunkList<Chunk, E>::emplace_back(Args&&... args) {
 }
 
 template<typename Chunk, typename E>
-inline void ChunkList<Chunk, E>::splice(const_iterator pos, ChunkList& other, iterator it) noexcept {
+inline void ChunkList<Chunk, E>::splice(iterator pos, ChunkList& other, iterator it) noexcept {
     m_map.emplace(it->begin(), it);
     other.m_map.erase(it->begin());
-    super::splice(
-#ifdef CENTOS7
-            next(begin(), distance(cbegin(), pos)),
-#else
-            pos,
-#endif
-            other, it);
+    super::splice(pos, other, it);
 }
 
 template<typename Chunk, typename E>
@@ -651,7 +645,7 @@ private:
         } else {
             m_cursor = reinterpret_cast<char*>(m_iter->next()) -
                 reinterpret_cast<CompactingChunks const&>(m_cont).tupleSize();
-            assert(m_cursor >= m_iter->begin());
+            vassert(m_cursor >= m_iter->begin());
         }
     }
 };

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1400,17 +1400,15 @@ HookedCompactingChunks<Hook, E>::thaw() {
     CompactingChunks::thaw();
 }
 
-template<typename Hook, typename E> inline void const*
-HookedCompactingChunks<Hook, E>::insert(void const* src) {
-    void const* r = memcpy(CompactingChunks::allocate(), src, CompactingChunks::tupleSize());
+template<typename Hook, typename E> inline void* HookedCompactingChunks<Hook, E>::allocate() {
+    void* r = CompactingChunks::allocate();
     Hook::add(*this, Hook::ChangeType::Insertion, r);
     return r;
 }
 
 template<typename Hook, typename E> inline void
-HookedCompactingChunks<Hook, E>::update(void* dst, void const* src) {
+HookedCompactingChunks<Hook, E>::update(void* dst) {
     Hook::add(*this, Hook::ChangeType::Update, dst);
-    memcpy(dst, src, CompactingChunks::tupleSize());
 }
 
 template<typename Hook, typename E> inline void const*

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -200,7 +200,7 @@ inline void ChunkList<Chunk, E>::add(iterator const&& h) {
 template<typename Chunk, typename E>
 inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(void const* k) const {
     if (! m_map.empty()) {
-        auto const& iter = prev(m_map.upper_bound(k));                    // find last entry whose begin() <= k
+        auto const& iter = prev(m_map.upper_bound(k));                    // find first entry whose begin() > k
         return iter != m_map.cend() && iter->second->contains(k) ? &iter->second : nullptr;
     } else {
         return nullptr;

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -205,13 +205,6 @@ inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(v
 
 template<typename Chunk, typename E>
 template<typename... Args>
-inline void ChunkList<Chunk, E>::emplace_front(Args&&... args) {
-    super::emplace_front(forward<Args>(args)...);
-    add(super::begin());
-}
-
-template<typename Chunk, typename E>
-template<typename... Args>
 inline void ChunkList<Chunk, E>::emplace_back(Args&&... args) {
     super::emplace_back(forward<Args>(args)...);
     add(prev(super::end()));
@@ -345,8 +338,8 @@ inline void* NonCompactingChunks<C, E>::allocate() {
             [](C const& c) { return ! c.full(); });
     void* r;
     if (iter == list_type::cend()) {        // all chunks are full
-        list_type::emplace_front(m_tupleSize);
-        r = list_type::front().allocate();
+        list_type::emplace_back(m_tupleSize);
+        r = list_type::back().allocate();
     } else {
         r = iter->allocate();
     }

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -174,7 +174,6 @@ namespace voltdb {
             using reference = typename super::reference;
             using const_reference = typename super::const_reference;
             // "override" writing behavior
-            template<typename... Args> void emplace_front(Args&&...);     // NOTE: C++17 changed return type
             template<typename... Args> void emplace_back(Args&&...);
             iterator erase(iterator);
             iterator erase(iterator, iterator);

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -183,7 +183,7 @@ namespace voltdb {
             iterator const* find(void const*) const;
             // careful forwarding to maintain invariant
             void clear() noexcept;
-            void splice(const_iterator, ChunkList&, iterator) noexcept;
+            void splice(iterator, ChunkList&, iterator) noexcept;
             using super::begin; using super::end; using super::cbegin; using super::cend;
             using super::rbegin; using super::rend;
             using super::empty; using super::size;

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -453,7 +453,7 @@ namespace voltdb {
             bool m_recording = false;       // in snapshot process?
             bool m_hasDeletes = false;      // observer for iterator::advance()
             Alloc m_storage;
-            void* m_last = nullptr;   // last allocation by copy(void const*);
+            void* m_last = nullptr;         // last allocation by copy(void const*);
             /**
              * Creates a deep copy of the tuple stored in local
              * storage, and keep track of it.
@@ -499,16 +499,16 @@ namespace voltdb {
         /**
          * Client API that manipulates in high level.
          */
-        template<typename Chunks, typename Hook,       // product type
-            typename = typename enable_if<is_chunks<Chunks>::value && Hook::is_hook::value>::type>
-        class HookedCompactingChunks : public Chunks, public Hook {
-            using Chunks::allocate; using Chunks::free;            // hide details
+        template<typename Hook, typename = typename enable_if<Hook::is_hook::value>::type>
+        class HookedCompactingChunks : public CompactingChunks, public Hook {
+            using CompactingChunks::allocate; using CompactingChunks::free;// hide details
             using Hook::add; using Hook::copy;
+            // the end of allocations when snapshot started: (block id, end ptr)
         public:
             using hook_type = Hook;                    // for hooked_iterator_type
             using Hook::release;                       // reminds to client: this must be called for GC to happen (instead of delaying it to thaw())
             HookedCompactingChunks(size_t) noexcept;
-            void freeze(); void thaw();       // switch of snapshot process
+            void freeze(); void thaw();         // switch of snapshot process
             void const* insert(void const*);
             void const* remove(void*);
             /**

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -557,8 +557,9 @@ namespace voltdb {
             template<typename Tag>
             shared_ptr<typename IterableTableTupleChunks<HookedCompactingChunks<Hook, E>, Tag, void>::hooked_iterator>
             freeze();
-            void thaw();                 // switch of snapshot process
-            void const* insert(void const*);
+            void thaw();                               // switch of snapshot process
+            void* allocate();                          // NOTE: now that client in control of when to fill in, be cautious not to overflow!!
+            void update(void*);                        // NOTE: this must be called prior to any memcpy operations happen
             void const* remove(void*);
             /**
              * Batch removal using a single call
@@ -576,7 +577,6 @@ namespace voltdb {
             size_t remove_add(void*);
             map<void*, void*>const& remove_moves();
             size_t remove_force();
-            void update(void* dst, void const* src);   // src as temp tuple gets written to persistent location dst
         };
 
         /**

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -347,11 +347,13 @@ namespace voltdb {
          * Communication channel between TxnPreHook and
          * HookedCompactingChunks
          */
+        class CompactingChunks;
         class AllocPosition {
             size_t const m_lastChunkId = 0;
             void const* m_lastAlloc = nullptr;
         public:
             AllocPosition() noexcept = default;        // empty initiator
+            AllocPosition(CompactingChunks const&, void const*);
             template<typename iterator> AllocPosition(void const*, iterator const&) noexcept;
             AllocPosition(ChunkHolder const&) noexcept;
             AllocPosition(AllocPosition const&) noexcept = default;
@@ -435,7 +437,7 @@ namespace voltdb {
             void freeze(); void thaw();
             void const* endOfFirstChunk() const noexcept;
             AllocPosition const& boundary() const noexcept;        // notify the snapshot iterator state of affairs
-            using list_type::empty; using list_type::end;
+            using list_type::empty; using list_type::end; using list_type::find;
         };
 
         struct BaseHistoryRetainTrait {
@@ -527,7 +529,7 @@ namespace voltdb {
             void freeze(); void thaw();
             // NOTE: the deletion event need to happen before
             // calling add(...), unlike insertion/update.
-            void add(ChangeType, void const*);
+            void add(CompactingChunks const&, ChangeType, void const*);
             void const* reverted(void const*) const;               // revert history at this place!
             void release(void const*);                             // local memory clean-up. Client need to call this upon having done what is needed to record current address in snapshot.
             // auxillary buffer that client must need for tuple deletion/update operation,

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -188,8 +188,6 @@ namespace voltdb {
             using super::rbegin; using super::rend;
             using super::empty; using super::size;
             using super::front; using super::back;
-            size_t distance(iterator);           // std::distance(begin(), arg)
-            size_t distance(const_iterator) const;
         };
 
         /**
@@ -350,16 +348,15 @@ namespace voltdb {
             CompactingChunks(CompactingChunks const&) = delete;
             CompactingChunks& operator=(CompactingChunks const&) = delete;
             CompactingChunks(CompactingChunks&&) = delete;
-            class BatchRemoveAccumulator : private map<list_type::iterator, tuple<size_t, vector<void*>>> {
+            class BatchRemoveAccumulator : private map<list_type::iterator, vector<void*>> {
                 CompactingChunks* m_self;
-                using map_type = map<size_t, vector<void*>>;
+                using map_type = map<list_type::iterator, vector<void*>>;
             protected:
                 CompactingChunks& chunks() noexcept;
                 list_type::iterator pop();             // force removing the chunk to be compacted from
                 vector<void*> collect() const;
-                using map<list_type::iterator, tuple<size_t, vector<void*>>>::clear;
+                using map_type::clear;
             public:
-                using super = map<list_type::iterator, tuple<size_t, vector<void*>>>;
                 explicit BatchRemoveAccumulator(CompactingChunks*);
                 void insert(list_type::iterator, void*);
                 vector<void*> sorted();                         // in compacting order

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -823,7 +823,7 @@ void testHookedCompactingChunks() {
     for(i = 0; i < NumTuples; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();
+    alloc.template freeze<truth>();
     using const_iterator = typename IterableTableTupleChunks<Alloc, truth>::const_iterator;
     using snapshot_iterator = typename IterableTableTupleChunks<Alloc, truth>::hooked_iterator;
     auto const verify_snapshot_const = [&alloc_cref]() {
@@ -971,7 +971,7 @@ void testHookedCompactingChunksBatchRemove_single1() {
     for(i = 0; i < AllocsPerChunk; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();
+    alloc.template freeze<truth>();
     auto const verify_snapshot_const = [&alloc_cref]() {
         using const_snapshot_iterator = typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator;
         size_t i = 0;
@@ -1005,7 +1005,7 @@ void testHookedCompactingChunksBatchRemove_single2() {
     for(i = 0; i < AllocsPerChunk; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();
+    alloc.template freeze<truth>();
     // verifies both const snapshot iterator, and destructuring iterator
     auto const verify_snapshot_const = [&alloc, &alloc_cref]() {
         using const_snapshot_iterator = typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator;
@@ -1049,7 +1049,7 @@ void testHookedCompactingChunksBatchRemove_single3() {         // correctness on
     for(i = 0; i < 10; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();
+    alloc.template freeze<truth>();
     alloc.remove(set<void*>{const_cast<void*>(addresses[4])},      // 9 => 4
             [](map<void*, void*> const&){});
     i = 0;
@@ -1094,7 +1094,7 @@ void testHookedCompactingChunksBatchRemove_multi1() {
                 });
         assert(i == AllocsPerChunk * 3);
     };
-    alloc.freeze();
+    alloc.template freeze<truth>();
 
     set<void*> batch;
     auto iter = addresses.begin();
@@ -1141,7 +1141,7 @@ void testHookedCompactingChunksBatchRemove_multi2() {
                 });
         assert(i == NumTuples);
     };
-    alloc.freeze();
+    alloc.template freeze<truth>();
 
     set<void*> batch;
     for(auto iter = addresses.cbegin();                             // remove every other
@@ -1220,7 +1220,7 @@ void testInterleavedCompactingChunks() {
     for(i = 0; i < NumTuples; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();
+    alloc.template freeze<truth>();
     using const_iterator = typename IterableTableTupleChunks<Alloc, truth>::const_iterator;
     using snapshot_iterator = typename IterableTableTupleChunks<Alloc, truth>::hooked_iterator;
     using explicit_iterator_type = pair<size_t, snapshot_iterator>;
@@ -1348,7 +1348,7 @@ void testSingleChunkSnapshot() {
     for(i = 0; i < Number; ++i) {
         addresses[i] = alloc.insert(gen.get());
     }
-    alloc.freeze();                                            // single chunk, not full before freeze,
+    alloc.template freeze<truth>();                                     // single chunk, not full before freeze,
     alloc.remove(const_cast<void*>(addresses[0]));             // then a few deletions
     alloc.remove(const_cast<void*>(addresses[5]));
     alloc.remove(const_cast<void*>(addresses[10]));

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -806,12 +806,7 @@ void testHookedCompactingChunks() {
     for (i = 909; i < 999; ++i) {
         ss.emplace(const_cast<void*>(addresses[i]));
     }
-    auto index_of = [&addresses](void const* p) {
-        auto iter = find(addresses.cbegin(), addresses.cend(), p);
-        assert(iter != addresses.cend());
-        return distance(addresses.cbegin(), iter);
-    };
-    alloc.remove(ss, [&index_of](map<void*, void*> const& m) {});
+    alloc.remove(ss, [](map<void*, void*> const& m) {});
     verify_snapshot_const();
 
     // Step 4: insertion

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -749,7 +749,7 @@ TEST_F(TableTupleAllocatorTest, TestTxnHook) {
 template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunks() {
     using Hook = TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>;
-    using Alloc = HookedCompactingChunks<CompactingChunks, Hook>;
+    using Alloc = HookedCompactingChunks<Hook>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, NumTuples>;
     Gen gen;
@@ -904,7 +904,7 @@ template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunksBatchRemove_single1() {
     using HookAlloc = NonCompactingChunks<Chunk>;
     using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
-    using Alloc = HookedCompactingChunks<CompactingChunks, Hook>;
+    using Alloc = HookedCompactingChunks<Hook>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, AllocsPerChunk>;
     Gen gen;
@@ -938,7 +938,7 @@ template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunksBatchRemove_single2() {
     using HookAlloc = NonCompactingChunks<Chunk>;
     using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
-    using Alloc = HookedCompactingChunks<CompactingChunks, Hook>;
+    using Alloc = HookedCompactingChunks<Hook>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, AllocsPerChunk>;
     Gen gen;
@@ -982,7 +982,7 @@ template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunksBatchRemove_multi1() {
     using HookAlloc = NonCompactingChunks<Chunk>;
     using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
-    using Alloc = HookedCompactingChunks<CompactingChunks, Hook>;
+    using Alloc = HookedCompactingChunks<Hook>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, AllocsPerChunk * 3>;
     Gen gen;
@@ -1029,7 +1029,7 @@ template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunksBatchRemove_multi2() {
     using HookAlloc = NonCompactingChunks<Chunk>;
     using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
-    using Alloc = HookedCompactingChunks<CompactingChunks, Hook>;
+    using Alloc = HookedCompactingChunks<Hook>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, NumTuples>;
     Gen gen;
@@ -1123,7 +1123,7 @@ TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
  */
 template<typename Chunk, gc_policy pol>
 void testInterleavedCompactingChunks() {
-    using Alloc = HookedCompactingChunks<CompactingChunks, TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
     using Gen = StringGen<TupleSize>;
     using addresses_type = array<void const*, NumTuples>;
     Gen gen;
@@ -1250,8 +1250,7 @@ TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
 
 template<typename Chunk, gc_policy pol>
 void testSingleChunkSnapshot() {
-    using Alloc = HookedCompactingChunks<CompactingChunks,
-          TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
     using Gen = StringGen<TupleSize>;
     static constexpr auto Number = AllocsPerChunk - 3;
     using addresses_type = array<void const*, Number>;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -634,7 +634,7 @@ void testTxnHook() {
     // started
     for (i = NumTuples; i < NumTuples + InsertTuples; ++i) {
         auto* p = alloc.allocate();
-        hook.add(Hook::ChangeType::Insertion, p);
+        hook.add(alloc, Hook::ChangeType::Insertion, p);
         addresses[i] = gen.fill(p);
         InsertionTag::set(p);                                  // mark as "insertion pending"
     }
@@ -680,7 +680,7 @@ void testTxnHook() {
         hook.copy(src);                 // NOTE: client need to remember to call this, before making any deletes
         auto* dst = alloc.free(src);
         assert(dst);
-        hook.add(Hook::ChangeType::Deletion, src);
+        hook.add(alloc, Hook::ChangeType::Deletion, src);
         DeletionUpdateTag::reset(dst);   // NOTE: sequencing this before the hook would cause std::stack<void*> default ctor to crash in GLIBC++7 (~L94 of TableTupleAllocator.h), in /usr/include/c++/7/ext/new_allocator.h
     }
     i = 0;
@@ -706,7 +706,7 @@ void testTxnHook() {
         // for update changes, hook does not need to copy
         // tuple getting updated (i.e. dst), since the hook is
         // called pre-update.
-        hook.add(Hook::ChangeType::Update, addresses[i]);    // 1280 == first eval
+        hook.add(alloc, Hook::ChangeType::Update, addresses[i]);    // 1280 == first eval
         memcpy(addresses[i], addresses[i + 1], TupleSize);
         DeletionUpdateTag::reset(addresses[i]);
     }

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -117,6 +117,21 @@ public:
     }
 };
 
+TEST_F(TableTupleAllocatorTest, RollingNumberComparison) {
+#define RollingNumberComparisons(type)                                            \
+    ASSERT_TRUE(less_rolling(numeric_limits<type>::max(),                         \
+                static_cast<type>(numeric_limits<type>::max() + 1)));             \
+    ASSERT_FALSE(less_rolling(static_cast<type>(numeric_limits<type>::max() + 1), \
+                numeric_limits<type>::max()))
+    RollingNumberComparisons(unsigned char);
+    RollingNumberComparisons(unsigned short);
+    RollingNumberComparisons(unsigned);
+    RollingNumberComparisons(unsigned long);
+    RollingNumberComparisons(unsigned long long);
+    RollingNumberComparisons(size_t);
+#undef RollingNumberComparisons
+}
+
 TEST_F(TableTupleAllocatorTest, HelloWorld) {
     // Test on StringGen test util
     /*
@@ -802,7 +817,7 @@ void testHookedCompactingChunks() {
         using const_snapshot_iterator = typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator;
         size_t i = 0;
         fold<const_snapshot_iterator>(alloc_cref, [&i](void const* p) {
-            assert(p == nullptr || Gen::same(p, i++));
+            assert(Gen::same(p, i++));
         });
         assert(i == NumTuples);
     };
@@ -920,10 +935,8 @@ void testHookedCompactingChunks() {
     // simulates actual snapshot process: memory clean up as we go
     i = 0;
     for_each<snapshot_iterator>(alloc, [&alloc, &i](void const* p) {
-                if (p != nullptr) {
-                    assert(Gen::same(p, i++));
-                    alloc.release(p);                          // snapshot of the tuple finished
-                }
+                assert(Gen::same(p, i++));
+                alloc.release(p);                          // snapshot of the tuple finished
             });
     assert(i == NumTuples);
     alloc.thaw();

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -193,6 +193,19 @@ void testNonCompactingChunks(size_t outOfOrder) {
     assert(alloc.empty());                 // everything gone
 }
 
+TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
+    CompactingChunks alloc(TupleSize);
+    array<void*, 3 * AllocsPerChunk> addresses;
+    for(auto i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.allocate();
+    }
+    for(auto i = 0; i < addresses.size(); ++i) {
+        auto const* iter = alloc.find(addresses[i]);
+        ASSERT_NE(iter, nullptr);
+        ASSERT_TRUE((*iter)->contains(addresses[i]));
+    }
+}
+
 template<typename Chunks>
 void testIteratorOfNonCompactingChunks() {
     using const_iterator = typename IterableTableTupleChunks<Chunks, truth>::const_iterator;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -619,7 +619,7 @@ void testTxnHook() {
     // started
     for (i = NumTuples; i < NumTuples + InsertTuples; ++i) {
         auto* p = alloc.allocate();
-        hook.add(Hook::ChangeType::Insertion, nullptr, p);
+        hook.add(Hook::ChangeType::Insertion, p);
         addresses[i] = gen.fill(p);
         InsertionTag::set(p);                                  // mark as "insertion pending"
     }
@@ -665,7 +665,7 @@ void testTxnHook() {
         hook.copy(src);                 // NOTE: client need to remember to call this, before making any deletes
         auto* dst = alloc.free(src);
         assert(dst);
-        hook.add(Hook::ChangeType::Deletion, src, dst);
+        hook.add(Hook::ChangeType::Deletion, src);
         DeletionUpdateTag::reset(dst);   // NOTE: sequencing this before the hook would cause std::stack<void*> default ctor to crash in GLIBC++7 (~L94 of TableTupleAllocator.h), in /usr/include/c++/7/ext/new_allocator.h
     }
     i = 0;
@@ -691,7 +691,7 @@ void testTxnHook() {
         // for update changes, hook does not need to copy
         // tuple getting updated (i.e. dst), since the hook is
         // called pre-update.
-        hook.add(Hook::ChangeType::Update, addresses[i + 1], addresses[i]);    // 1280 == first eval
+        hook.add(Hook::ChangeType::Update, addresses[i]);    // 1280 == first eval
         memcpy(addresses[i], addresses[i + 1], TupleSize);
         DeletionUpdateTag::reset(addresses[i]);
     }

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -607,7 +607,7 @@ void testTxnHook() {
     using Hook = TxnPreHook<HookAlloc, RetainTrait>;
     DataAlloc alloc(TupleSize);
     auto const& alloc_cref = alloc;
-    Hook hook(TupleSize);
+    Hook hook(TupleSize, alloc.boundary());
     /**
      * We reserve 2 bits in the leading char to signify that this
      * tuple is newly inserted, thus invisible in snapshot view (bit#7),


### PR DESCRIPTION
Made `HookedIteratorType` nested template class aware of allocator state when `freeze()` is called. This guarantees that the iterator (types) will never return `NULL` value, and skip any newly allocated values after `freeze()`.
Other types of snapshot iterator (templates) remain unaware of the status: `iterator_type`, `iterator_cb_type` and `time_traveling_iterator_type`. But that is fine, since `iterator_type` should only serve for txn view, and the other two are simply building blocks for the `hooked_iterator_type`.

And some other simplifications.

Now changed `freeze()` method to be template method that creates a shared pointer of snapshot rw iterator.