### PR TITLE
Fixed bad batch-removal on multiple sites

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1348,7 +1348,9 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 Hook::copy(entry.first);
                 Hook::add(Hook::ChangeType::Deletion, entry.first, nullptr);
             });
-    return batch.force();
+    auto const removed = batch.force();
+    CompactingChunks::m_allocs -= removed;                     // adjust tuple count
+    return removed;
 }
 
 template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E>::remove_add(void* p) {
@@ -1371,7 +1373,9 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 Hook::copy(entry.first);
                 Hook::add(Hook::ChangeType::Deletion, entry.first, nullptr);
             });
-    return CompactingChunks::m_batched.prepare(true).force();
+    auto const removed = CompactingChunks::m_batched.prepare(true).force();
+    CompactingChunks::m_allocs -= removed;
+    return removed;
 }
 
 // # # # # # # # # # # # # # # # # # Codegen: begin # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -540,7 +540,7 @@ namespace voltdb {
              * occurs. Map for removed addr => addr that fills in
              * the removed address
              */
-            void remove(set<void*> const&, function<void(map<void*, void*>const&)> const&);
+            size_t remove(set<void*> const&, function<void(map<void*, void*>const&)> const&);
             /**
              * Batch removal using separate calls
              */

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -358,7 +358,6 @@ namespace voltdb {
 
             size_t const m_id;                    // ensure injection relation to rw iterator
             size_t const m_tupleSize;
-            size_t m_allocs = 0;
             // used to keep track of end of 1st chunk when frozen:
             // needed for special case when there is a single
             // non-full chunk when snapshot started.
@@ -380,6 +379,7 @@ namespace voltdb {
                 vector<void*> sorted();                         // in compacting order
             };
         protected:
+            size_t m_allocs = 0;
             class DelayedRemover : protected BatchRemoveAccumulator {
                 using super = BatchRemoveAccumulator;
                 size_t m_size = 0;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1133,6 +1133,28 @@ void testHookedCompactingChunksBatchRemove_multi2() {
     alloc.thaw();
 }
 
+TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
+    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    using Gen = StringGen<TupleSize>;
+    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
+    Gen gen;
+    Alloc alloc(TupleSize);
+    addresses_type addresses;
+    assert(alloc.empty());
+    size_t i;
+    for(i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.insert(gen.get());
+    }
+    set<void*> batch;
+    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
+        batch.emplace(const_cast<void*>(addresses[i]));
+    }
+    alloc.remove(batch, [](map<void*, void*> const&){});
+    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
+}
+
 template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
     inline void operator()() const {
         testHookedCompactingChunks<Chunk, pol>();


### PR DESCRIPTION
Bug on pointer arithmetic when there are whole chunk removed in batch removal, and the following chunk (after whole-chunk-removal) happens to be not full.