### PR TITLE
ENG-19044: refactor handling partition leadership changes in export

### DIFF
--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -113,6 +113,7 @@ import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.collect.ImmutableSet;
 import com.google_voltpatches.common.collect.Sets;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
+
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.SslContext;
 
@@ -154,7 +155,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long SNAPSHOT_UTIL_CID          = Long.MIN_VALUE + 2;
     public static final long ELASTIC_COORDINATOR_CID    = Long.MIN_VALUE + 3;
     // public static final long UNUSED_CID (was DR)     = Long.MIN_VALUE + 4;
-    // public static final long UNUSED_CID              = Long.MIN_VALUE + 5;
+    public static final long EXPORT_MANAGER_CID         = Long.MIN_VALUE + 5;
     public static final long EXECUTE_TASK_CID           = Long.MIN_VALUE + 6;
     public static final long DR_DISPATCHER_CID          = Long.MIN_VALUE + 7;
     public static final long RESTORE_SCHEMAS_CID        = Long.MIN_VALUE + 8;

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -161,7 +161,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long RESTORE_SCHEMAS_CID        = Long.MIN_VALUE + 8;
     public static final long SHUTDONW_SAVE_CID          = Long.MIN_VALUE + 9;
     public static final long NT_REMOTE_PROC_CID         = Long.MIN_VALUE + 10;
- // public static final long UNUSED_CID (was migrate)   = Long.MIN_VALUE + 11;
+    // public static final long UNUSED_CID (was migrate)= Long.MIN_VALUE + 11;
     public static final long TASK_MANAGER_CID           = Long.MIN_VALUE + 12;
 
     // Leave CL_REPLAY_BASE_CID at the end, it uses this as a base and generates more cids

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -161,7 +161,7 @@ public class ClientInterface implements SnapshotDaemon.DaemonInitiator {
     public static final long RESTORE_SCHEMAS_CID        = Long.MIN_VALUE + 8;
     public static final long SHUTDONW_SAVE_CID          = Long.MIN_VALUE + 9;
     public static final long NT_REMOTE_PROC_CID         = Long.MIN_VALUE + 10;
-    public static final long MIGRATE_ROWS_DELETE_CID    = Long.MIN_VALUE + 11;
+ // public static final long UNUSED_CID (was migrate)   = Long.MIN_VALUE + 11;
     public static final long TASK_MANAGER_CID           = Long.MIN_VALUE + 12;
 
     // Leave CL_REPLAY_BASE_CID at the end, it uses this as a base and generates more cids

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -125,7 +125,6 @@ public class ExportManager implements ExportManagerInterface
     private int m_connCount = 0;
     private boolean m_startPolling = false;
     private SimpleClientResponseAdapter m_migratePartitionAdapter;
-    private SimpleClientResponseAdapter m_migrateRowAdapter;
     private ClientInterface m_ci;
 
     // Track the data sources being closed, and a lock allowing {@code canUpdateCatalog()}
@@ -178,12 +177,7 @@ public class ExportManager implements ExportManagerInterface
     public void startListeners(ClientInterface cif) {
         m_ci = cif;
 
-        // Initialize adapter for migrating rows
-        m_migrateRowAdapter = new SimpleClientResponseAdapter(
-                ClientInterface.MIGRATE_ROWS_DELETE_CID, "MigrateRowsAdapter");
-        m_ci.bindAdapter(m_migrateRowAdapter, null);
-
-        // Initialize adapter fpr partition leadership and start a listener
+        // Initialize adapter for partition leadership and start a listener
         m_migratePartitionAdapter = new SimpleClientResponseAdapter(
                 ClientInterface.EXPORT_MANAGER_CID, getClass().getSimpleName());
 

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.voltcore.messaging.HostMessenger;
@@ -164,7 +163,7 @@ public interface ExportManagerInterface {
     public void initialize(CatalogContext catalogContext, List<Pair<Integer, Integer>> localPartitionsToSites,
             boolean isRejoin);
 
-    public void becomeLeader(int partitionId);
+    public void startListeners(ClientInterface cif);
 
     public void shutdown();
 
@@ -194,7 +193,6 @@ public interface ExportManagerInterface {
 
     public void sync();
 
-    public void clientInterfaceStarted(ClientInterface clientInterface);
     public void invokeMigrateRowsDelete(int partition, String tableName, long deletableTxnId,  ProcedureCallback cb);
 
     public ExportMode getExportMode();

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+
 import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.logging.VoltLogger;
@@ -43,7 +44,6 @@ import org.voltdb.StatsAgent;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltZK;
 import org.voltdb.dtxn.TransactionState;
-import org.voltdb.export.ExportManagerInterface;
 import org.voltdb.iv2.LeaderCache.LeaderCallBackInfo;
 import org.voltdb.iv2.RepairAlgo.RepairResult;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
@@ -313,15 +313,6 @@ public class SpInitiator extends BaseInitiator<SpScheduler> implements Promotabl
                             + (System.currentTimeMillis() - startTime) + " ms. of "
                             + "trying. Retrying.");
                 }
-            }
-            // Tag along and become the export master too
-            // leave the export on the former leader, now a replica
-            if (!migratePartitionLeader && lastLeaderHSId != m_initiatorMailbox.getHSId()) {
-                if (exportLog.isDebugEnabled()) {
-                    exportLog.debug("Export Manager has been notified that local partition " +
-                            m_partitionId + " to accept export stream mastership.");
-                }
-                ExportManagerInterface.instance().becomeLeader(m_partitionId);
             }
         } catch (Exception e) {
             VoltDB.crashLocalVoltDB("Terminally failed leader promotion.", true, e);


### PR DESCRIPTION
Using a listener for partition leadership changes. The amount of code that is identical between E2 and E3 Export Manager implementations calls for a base class. But that is beyond the scope of this bug fix and a follow-up ticket will be opened.