### PR TITLE
Allocator add chunk size

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -69,31 +69,24 @@ inline size_t ChunkHolder::chunkSize(size_t tupleSize) noexcept {
         0x100000/*1MB*/, 2 * 0x100000, 4 * 0x100000,  8 * 0x100000,
         0x10 * 0x100000
     }};
-    static LRU<512, size_t, size_t> lru{};
-    auto const* maybe_value = lru.get(tupleSize);
-    if (maybe_value != nullptr) {
-        return *maybe_value;
-    } else {
-        // we always pick smallest preferred chunk size to calculate
-        // how many tuples a chunk fits. The picked chunk should fit
-        // for > 4 allocations
-        auto const value = *find_if(preferred.cbegin(), preferred.cend(),
-                [tupleSize](size_t s) { return tupleSize * 4 <= s; })
-            / tupleSize * tupleSize;
-        lru.add(tupleSize, value);
-        return value;
-    }
+    // we always pick smallest preferred chunk size to calculate
+    // how many tuples a chunk fits. The picked chunk should fit
+    // for >= 32 allocations
+    return *find_if(preferred.cbegin(), preferred.cend(),
+            [tupleSize](size_t s) { return tupleSize * 32 <= s; }) / tupleSize * tupleSize;
+}
+
+inline size_t ChunkHolder::chunkSize() const noexcept {
+    return m_chunkSize;
 }
 
 // We remove member initialization from init list to save from
 // storing chunk size into object
-inline ChunkHolder::ChunkHolder(size_t id, size_t tupleSize): m_id(id), m_tupleSize(tupleSize) {
-    vassert(tupleSize <= 4 * 0x100000);    // individual tuple cannot exceeding 4MB
-    auto const size = chunkSize(m_tupleSize);
-    m_resource.reset(new char[size]);
-    m_next = m_resource.get();
+inline ChunkHolder::ChunkHolder(size_t id, size_t tupleSize, size_t storageSize) :
+    m_id(id), m_tupleSize(tupleSize), m_chunkSize(storageSize),
+    m_resource(new char[m_chunkSize]), m_end(m_resource.get() + m_chunkSize), m_next(m_resource.get()) {
+    vassert(tupleSize <= 4 * 0x100000);
     vassert(m_next != nullptr);
-    const_cast<void*&>(m_end) = reinterpret_cast<char*>(m_next) + size;
 }
 
 inline size_t ChunkHolder::id() const noexcept {
@@ -141,7 +134,7 @@ inline size_t ChunkHolder::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-inline EagerNonCompactingChunk::EagerNonCompactingChunk(size_t id, size_t s): ChunkHolder(id, s) {}
+inline EagerNonCompactingChunk::EagerNonCompactingChunk(size_t s1, size_t s2, size_t s3) : ChunkHolder(s1, s2, s3) {}
 
 inline void* EagerNonCompactingChunk::allocate() noexcept {
     if (m_freed.empty()) {
@@ -175,7 +168,7 @@ inline bool EagerNonCompactingChunk::full() const noexcept {
     return ChunkHolder::full() && m_freed.empty();
 }
 
-inline LazyNonCompactingChunk::LazyNonCompactingChunk(size_t id, size_t tupleSize) : ChunkHolder(id, tupleSize) {}
+inline LazyNonCompactingChunk::LazyNonCompactingChunk(size_t s1, size_t s2, size_t s3) : ChunkHolder(s1, s2, s3) {}
 
 inline void LazyNonCompactingChunk::free(void* src) {
     vassert(src >= begin() && src < next());
@@ -348,7 +341,8 @@ inline void* NonCompactingChunks<C, E>::allocate() {
     if (iter == list_type::cend()) {        // all chunks are full
         list_type::emplace_back(
                 list_type::empty() ? 0 : list_type::back().id() + 1,
-                m_tupleSize);
+                m_tupleSize,
+                list_type::empty() ? ChunkHolder::chunkSize(m_tupleSize) : list_type::front().chunkSize());
         r = list_type::back().allocate();
     } else {
         r = iter->allocate();
@@ -383,7 +377,7 @@ template<typename C, typename E> inline bool NonCompactingChunks<C, E>::tryFree(
     return p != nullptr;
 }
 
-inline CompactingChunk::CompactingChunk(size_t id, size_t s) : ChunkHolder(id, s) {}
+inline CompactingChunk::CompactingChunk(size_t id, size_t s, size_t s2) : ChunkHolder(id, s, s2) {}
 
 inline void CompactingChunk::free(void* dst, void const* src) {     // cross-chunk free(): update only on dst chunk
     vassert(contains(dst));
@@ -502,9 +496,15 @@ size_t CompactingChunks::chunks() const noexcept {
     return list_type::size();
 }
 
+size_t CompactingChunks::chunkSize() const noexcept {
+    return empty() ? ChunkHolder::chunkSize(m_tupleSize) :
+        list_type::front().chunkSize();
+}
+
 inline void* CompactingChunks::allocate() {
     if (empty() || back().full()) {                  // always allocates from tail
-        emplace_back(empty() ? 0 : back().id() + 1, m_tupleSize);
+        emplace_back(empty() ? 0 : back().id() + 1, m_tupleSize,
+                empty() ? ChunkHolder::chunkSize(m_tupleSize) : front().chunkSize());
     }
     ++m_allocs;
     return back().allocate();
@@ -723,8 +723,7 @@ typename CompactingChunks::DelayedRemover& CompactingChunks::DelayedRemover::pre
 size_t CompactingChunks::DelayedRemover::force() {
     auto hd = super::chunks().begin();
     auto const tupleSize = super::chunks().tupleSize(),
-        allocsPerTuple = (reinterpret_cast<char const*>(hd->end()) -
-                reinterpret_cast<char const*>(hd->begin())) / tupleSize;
+        allocsPerChunk = hd->chunkSize() / tupleSize;
     auto const total = m_move.size() + m_remove.size();
     if (total > 0) {
         // storage remapping and clean up
@@ -736,16 +735,16 @@ size_t CompactingChunks::DelayedRemover::force() {
         auto const offset =
             reinterpret_cast<char const*>(hd->next()) - reinterpret_cast<char const*>(hd->begin());
         // dangerous: direct manipulation on each offended chunks
-        for (auto wholeChunks = total / allocsPerTuple; wholeChunks > 0; --wholeChunks) {
+        for (auto wholeChunks = total / allocsPerChunk; wholeChunks > 0; --wholeChunks) {
             hd = super::pop();
         }
-        if (total >= allocsPerTuple) {       // any chunk released at all?
+        if (total >= allocsPerChunk) {       // any chunk released at all?
             reinterpret_cast<char*&>(hd->m_next) +=
                 reinterpret_cast<char const*>(hd->begin()) - reinterpret_cast<char const*>(hd->end()) + offset;
             // cannot possibly remove more entries than table already contains
             vassert(hd->next() >= hd->begin());
         }
-        auto const remBytes = (total % allocsPerTuple) * tupleSize;
+        auto const remBytes = (total % allocsPerChunk) * tupleSize;
         if (remBytes > 0) {          // need manual cursor adjustment on the remaining chunks
             auto const rem = reinterpret_cast<char*>(hd->next()) - reinterpret_cast<char*>(hd->begin());
             if (remBytes >= rem) {

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -90,19 +90,21 @@ namespace voltdb {
          * Holder for a chunk, whether it is self-compacting or not.
          */
         class ChunkHolder {
-            static size_t chunkSize(size_t) noexcept;
             size_t const m_id;                         // chunk id
             size_t const m_tupleSize;                  // size of a table tuple per allocation
-            unique_ptr<char[]> m_resource{};
-            void*const m_end = nullptr;                // indication of chunk capacity
+            size_t const m_chunkSize;                  // free space for allocation
+            unique_ptr<char[]> m_resource;
+            void*const m_end;                          // indication of chunk capacity
         protected:
-            void* m_next = nullptr;                    // tail of allocation
+            void* m_next;                              // tail of allocation
             ChunkHolder(ChunkHolder const&) = delete;  // non-copyable, non-assignable, non-moveable
             ChunkHolder& operator=(ChunkHolder const&) = delete;
             ChunkHolder(ChunkHolder&&) = delete;
             friend class CompactingChunks;      // for batch free
         public:
-            ChunkHolder(size_t id, size_t tupleSize);
+            static size_t chunkSize(size_t) noexcept;
+            size_t chunkSize() const noexcept;
+            ChunkHolder(size_t id, size_t tupleSize, size_t chunkSize);
             ~ChunkHolder() = default;
             void* allocate() noexcept;                 // returns NULL if this chunk is full.
             bool contains(void const*) const;          // query if a table tuple is stored in current chunk
@@ -128,7 +130,7 @@ namespace voltdb {
             EagerNonCompactingChunk& operator=(EagerNonCompactingChunk const&) = delete;
             EagerNonCompactingChunk(EagerNonCompactingChunk&&) = delete;
         public:
-            EagerNonCompactingChunk(size_t, size_t);
+            EagerNonCompactingChunk(size_t, size_t, size_t);
             ~EagerNonCompactingChunk() = default;
             void* allocate() noexcept;
             void free(void*);
@@ -151,7 +153,7 @@ namespace voltdb {
             LazyNonCompactingChunk& operator=(LazyNonCompactingChunk const&) = delete;
             LazyNonCompactingChunk(LazyNonCompactingChunk&&) = delete;
         public:
-            LazyNonCompactingChunk(size_t, size_t);
+            LazyNonCompactingChunk(size_t, size_t, size_t);
             ~LazyNonCompactingChunk() = default;
             // void* allocate() noexcept; same as ChunkHolder
             // when contains(void const*) returns true, the addr may
@@ -243,7 +245,7 @@ namespace voltdb {
          * self-compacting chunk (with help from CompactingChunks to compact across a list)
          */
         struct CompactingChunk final : public ChunkHolder {
-            CompactingChunk(size_t id, size_t tupleSize);
+            CompactingChunk(size_t id, size_t tupleSize, size_t chunkSize);
             CompactingChunk(CompactingChunk&&) = delete;
             CompactingChunk(CompactingChunk const&) = delete;
             CompactingChunk& operator=(CompactingChunk const&) = delete;
@@ -425,6 +427,8 @@ namespace voltdb {
             using Compact = integral_constant<bool, true>;
             CompactingChunks(size_t tupleSize) noexcept;
             size_t tupleSize() const noexcept;
+            size_t chunkSize() const noexcept;         // number of bytes per chunk
+            size_t chunks() const noexcept;            // number of chunks
             void* allocate();
             // frees a single tuple, and returns the tuple that gets copied
             // over the given address, which is at the tail of
@@ -434,7 +438,6 @@ namespace voltdb {
             // details.
             void* free(void*);
             size_t size() const noexcept;              // number of allocation requested
-            size_t chunks() const noexcept;            // number of chunks
             size_t id() const noexcept;
             void freeze(); void thaw();
             void const* endOfFirstChunk() const noexcept;
@@ -846,47 +849,6 @@ namespace voltdb {
             }
         }
     }
-
-    // utility
-    template<size_t N, typename key_type, typename value_type,
-        typename = typename std::enable_if<N >= 2>::type>
-    class LRU {
-        using map_type = std::map<key_type, value_type>;
-        using array_type = std::array<typename map_type::iterator, N>;
-
-        bool m_full = false;
-        map_type m_map{};
-        array_type m_iters{};
-        size_t m_insertPos = 0;
-        inline static void inc(size_t& s) noexcept {
-            s = (s + 1) % N;
-        }
-    public:
-#ifdef CENTOS7
-        inline LRU() : m_map(), m_iters() {}
-#else
-        inline LRU() = default;
-#endif
-        inline void add(key_type const& key, value_type const& value) {
-            if (m_full) {
-                m_iters[m_insertPos] = m_map.emplace_hint(
-                        m_map.erase(m_iters[m_insertPos]), key, value);
-                m_insertPos = (1 + m_insertPos) % N;
-            } else {          // not full
-                assert(m_insertPos < N);
-                m_iters[m_insertPos] = m_map.emplace_hint(
-                        m_map.end(), key, value);
-                if (++m_insertPos >= N) {
-                    m_full = true;
-                    m_insertPos = 0;
-                }
-            }
-        }
-        inline value_type const* get(key_type const& key) const {
-            auto const iter = m_map.find(key);
-            return iter == m_map.cend() ? nullptr : &iter->second;
-        }
-    };
 
     template<typename F1, typename F2>
     struct Compose {                                   // functor composer

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -92,7 +92,6 @@ namespace voltdb {
         class ChunkHolder {
             size_t const m_id;                         // chunk id
             size_t const m_tupleSize;                  // size of a table tuple per allocation
-            size_t const m_chunkSize;                  // free space for allocation
             unique_ptr<char[]> m_resource;
             void*const m_end;                          // indication of chunk capacity
         protected:
@@ -103,7 +102,6 @@ namespace voltdb {
             friend class CompactingChunks;      // for batch free
         public:
             static size_t chunkSize(size_t) noexcept;
-            size_t chunkSize() const noexcept;
             ChunkHolder(size_t id, size_t tupleSize, size_t chunkSize);
             ~ChunkHolder() = default;
             void* allocate() noexcept;                 // returns NULL if this chunk is full.
@@ -223,6 +221,7 @@ namespace voltdb {
         class NonCompactingChunks final : private ChunkList<Chunk> {
             template<typename Chunks, typename Tag, typename E> friend class IterableTableTupleChunks;
             size_t const m_tupleSize;
+            size_t const m_chunkSize;
             size_t m_allocs = 0;
             NonCompactingChunks(EagerNonCompactingChunk const&) = delete;
             NonCompactingChunks(NonCompactingChunks&&) = delete;
@@ -382,6 +381,7 @@ namespace voltdb {
 
             size_t const m_id;                    // ensure injection relation to rw iterator
             size_t const m_tupleSize;
+            size_t const m_chunkSize;
             // used to keep track of end of 1st chunk when frozen:
             // needed for special case when there is a single
             // non-full chunk when snapshot started.

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -132,33 +132,6 @@ TEST_F(TableTupleAllocatorTest, RollingNumberComparison) {
 #undef RollingNumberComparisons
 }
 
-TEST_F(TableTupleAllocatorTest, HelloWorld) {
-    // Test on StringGen test util
-    /*
-    StringGen<16> gen;
-    for(auto c = 0; c < 500; ++c) {
-        cout<<c<<": "<<StringGen<16>::hex(gen.get());
-    }
-    */
-    // Test on LRU src util
-    voltdb::LRU<10, int, int> lru;
-    for(int i = 0; i < 10; ++i) {
-        ASSERT_FALSE(lru.get(i));
-        lru.add(i, i);
-        ASSERT_EQ(*lru.get(i), i);
-    }
-    for(int i = 10; i < 20; ++i) {
-        ASSERT_FALSE(lru.get(i));
-        ASSERT_TRUE(lru.get(i - 10));
-        lru.add(i, i);
-        ASSERT_EQ(*lru.get(i), i);
-        ASSERT_FALSE(lru.get(i - 10));
-    }
-    for(int i = 10; i < 20; ++i) {
-        ASSERT_EQ(*lru.get(i), i);
-    }
-}
-
 constexpr size_t TupleSize = 16;       // bytes per allocation
 constexpr size_t AllocsPerChunk = 512 / TupleSize;     // 512 comes from ChunkHolder::chunkSize()
 constexpr size_t NumTuples = 256 * AllocsPerChunk;     // # allocations: fits in 256 chunks


### PR DESCRIPTION
Added `chunkSize()` method to CompactingChunks, that returns how many bytes of memory each chunk contains available for allocation.
Removed caching mechanism.