### PR TITLE
Moved memcpy before batch-remove callback execution

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -715,16 +715,18 @@ typename CompactingChunks::DelayedRemover& CompactingChunks::DelayedRemover::pre
     return *this;
 }
 
-size_t CompactingChunks::DelayedRemover::force() {
+size_t CompactingChunks::DelayedRemover::force(bool moved) {
     auto hd = super::chunks().begin();
     auto const tupleSize = super::chunks().tupleSize(),
         allocsPerChunk = super::chunks().chunkSize() / tupleSize;
     auto const total = m_move.size() + m_remove.size();
     if (total > 0) {
-        // storage remapping and clean up
-        for_each(m_move.cbegin(), m_move.cend(), [tupleSize](typename map<void*, void*>::value_type const& entry) {
+        if (! moved) {
+            // storage remapping and clean up
+            for_each(m_move.cbegin(), m_move.cend(), [tupleSize](typename map<void*, void*>::value_type const& entry) {
                     memcpy(entry.first, entry.second, tupleSize);
-                });
+                    });
+        }
         m_move.clear();
         m_remove.clear();
         auto const offset =
@@ -1430,7 +1432,6 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 batch.add(p);
                 return batch;
             }).prepare(false);
-    cb(batch.movements());
     // hook registration
     for_each(batch.removed().cbegin(), batch.removed().cend(),
             [this](void* s) {
@@ -1442,7 +1443,14 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 Hook::copy(entry.first);
                 Hook::add(*this, Hook::ChangeType::Deletion, entry.first);
             });
-    auto const removed = batch.force();
+    // moves (i.e. memcpy) before call back
+    auto const tuple_size = tupleSize();
+    for_each(batch.movements().cbegin(), batch.movements().cend(),
+            [tuple_size](typename map<void*, void*>::value_type const& entry) {
+                memcpy(entry.first, entry.second, tuple_size);
+            });
+    cb(batch.movements());
+    auto const removed = batch.force(false);
     CompactingChunks::m_allocs -= removed;                     // adjust tuple count
     return removed;
 }
@@ -1467,7 +1475,7 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 Hook::copy(entry.first);
                 Hook::add(*this, Hook::ChangeType::Deletion, entry.first);
             });
-    auto const removed = CompactingChunks::m_batched.prepare(true).force();
+    auto const removed = CompactingChunks::m_batched.prepare(true).force(true);    // memcpy after remove_moves()
     CompactingChunks::m_allocs -= removed;
     return removed;
 }

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -421,7 +421,7 @@ namespace voltdb {
                 map<void*, void*> const& movements() const;
                 set<void*> const& removed() const;
                 // Actuate batch remove
-                size_t force();
+                size_t force(bool);
             } m_batched;
         public:
             using Compact = integral_constant<bool, true>;


### PR DESCRIPTION
So that the call back function sees the world as having all compaction done
(but head is not adjusted)