### PR TITLE
ENG-18989, ENG-18991 & ENG-18995: Add group and offset operations

### DIFF
--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -210,6 +210,7 @@ SET (VOLTDB_SRC
   indexes/IndexStats.cpp
   indexes/tableindex.cpp
   indexes/tableindexfactory.cpp
+  kipling/GroupStore.cpp
   kipling/messages/OffsetCommit.cpp
   kipling/messages/OffsetFetch.cpp
   kipling/orm/Group.cpp

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -427,6 +427,12 @@ public:
         m_position += length;
     }
 
+    void writeVarBinary(std::function<void(SerializeOutput&)> writer) {
+        int pos = reserveBytes(sizeof(int32_t));
+        writer(*this);
+        writeIntAt(pos, position() - pos - sizeof(int32_t));
+    }
+
     /** Reserves length bytes of space for writing. Returns the offset to the bytes. */
     size_t reserveBytes(size_t length) {
         assureExpand(length);

--- a/src/ee/kipling/GroupStore.cpp
+++ b/src/ee/kipling/GroupStore.cpp
@@ -1,0 +1,165 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GroupStore.h"
+
+#include "indexes/tableindex.h"
+#include "kipling/TableFactory.h"
+#include "kipling/messages/CheckedSerializeInput.h"
+#include "kipling/messages/OffsetCommit.h"
+#include "kipling/messages/OffsetFetch.h"
+#include "kipling/orm/Group.h"
+#include "kipling/orm/GroupMember.h"
+#include "kipling/orm/GroupOffset.h"
+
+namespace voltdb { namespace kipling {
+
+#define DECREMENT_REFCOUNT(t) if (t) t->decrementRefcount()
+
+GroupStore::~GroupStore() {
+    DECREMENT_REFCOUNT(m_group);
+    DECREMENT_REFCOUNT(m_groupMember);
+    DECREMENT_REFCOUNT(m_groupOffset);
+}
+
+void GroupStore::initialize(VoltDBEngine *engine) {
+    initialize(engine->getSystemTable(SystemTableId::KIPLING_GROUP),
+            engine->getSystemTable(SystemTableId::KIPLING_GROUP_MEMBER),
+            engine->getSystemTable(SystemTableId::KIPLING_GROUP_OFFSET));
+}
+
+#define ASSIGN_TABLE(v, t) vassert(t); t->incrementRefcount(); v = t
+
+void GroupStore::initialize(PersistentTable *group, PersistentTable *groupMember, PersistentTable *groupOffset) {
+    ASSIGN_TABLE(m_group, group);
+    ASSIGN_TABLE(m_groupMember, groupMember);
+    ASSIGN_TABLE(m_groupOffset, groupOffset);
+}
+
+void GroupStore::storeGroup(SerializeInputBE& groupMetadata) {
+    Group::upsert(*this, groupMetadata);
+}
+
+void GroupStore::deleteGroup(const NValue& groupId) {
+    Group group(*this, groupId);
+    group.markForDelete();
+    group.commit();
+
+    GroupOffset::visitAll(*this, groupId, [] (GroupOffset &offset) {
+        offset.markForDelete();
+        offset.commit(0);
+    });
+}
+
+bool GroupStore::fetchGroups(int maxResultSize, const NValue& startGroupId, SerializeOutput& out) {
+    TableTuple next(m_group->schema());
+
+    out.writeVarBinary([this, &startGroupId, maxResultSize, &next] (SerializeOutput& out) {
+        TableIndex* index = m_group->primaryKeyIndex();
+        TableTuple searchKey(index->getKeySchema());
+
+        char data[searchKey.tupleLength()];
+        searchKey.move(data);
+        searchKey.setNValue(static_cast<int32_t>(GroupOffsetTable::IndexColumn::GROUP_ID), startGroupId);
+
+        IndexCursor cursor(m_group->schema());
+        index->moveToGreaterThanKey(&searchKey, cursor);
+
+        int32_t groupCount = 0;
+        size_t pos = out.reserveBytes(sizeof(groupCount));
+
+        while (!(next = index->nextValue(cursor)).isNullTuple()) {
+            Group group(*this, next);
+            if (out.position() + group.serializedSize() > maxResultSize) {
+                break;
+            }
+
+            ++groupCount;
+            group.serialize(out);
+        }
+
+        out.writeIntAt(pos, groupCount);
+    });
+
+    return !next.isNullTuple();
+}
+
+void GroupStore::commitOffsets(int64_t spUniqueId, int16_t requestVersion, const NValue& groupId,
+        SerializeInputBE& offsets, SerializeOutput& out) {
+
+    OffsetCommitResponse response;
+    CheckedSerializeInput checkedIn(offsets);
+
+    int topicCount = checkedIn.readInt();
+    for (int i = 0; i < topicCount; ++i) {
+        NValue topic = checkedIn.readString();
+        OffsetCommitResponseTopic& responseTopic = response.addTopic(topic);
+
+        int partitionCount = checkedIn.readInt();
+        for (int j = 0; j < partitionCount; ++j) {
+            OffsetCommitRequestPartition partition(requestVersion, checkedIn);
+            GroupOffset offset(*this, groupId, topic, partition.partitionIndex());
+            offset.update(partition);
+            offset.commit(UniqueId::ts(spUniqueId));
+            responseTopic.addPartition(partition.partitionIndex());
+        }
+    }
+
+    out.writeVarBinary([&response, requestVersion](SerializeOutput &out) { response.write(requestVersion, out); });
+}
+
+void GroupStore::fetchOffsets(int16_t requestVersion, const NValue& groupId, SerializeInputBE& topicPartitions,
+        SerializeOutput& out) {
+    OffsetFetchResponse response;
+    CheckedSerializeInput checkedIn(topicPartitions);
+
+    int topicCount = checkedIn.readInt();
+    if (topicCount == 0) {
+        OffsetFetchResponseTopic* responseTopic = nullptr;
+
+        GroupOffset::visitAll(*this, groupId, [&response, &responseTopic] (GroupOffset& offset) {
+            if (responseTopic == nullptr || responseTopic->topic() != offset.getTopic()) {
+                responseTopic = &response.addTopic(offset.getTopic());
+            }
+
+            responseTopic->addPartition(offset.getPartition(), offset.getOffset(), offset.getLeaderEpoch(),
+                    offset.getMetadata());
+        });
+    } else {
+        for (int i = 0; i < topicCount; ++i) {
+            NValue topic = checkedIn.readString();
+            OffsetFetchResponseTopic& responseTopic = response.addTopic(topic);
+
+            int partitionCount = checkedIn.readInt();
+            for (int j = 0; j < partitionCount; ++j) {
+                int32_t partition = checkedIn.readInt();
+                GroupOffset offset(*this, groupId, topic, partition);
+
+                if (offset.isInTable()) {
+                    responseTopic.addPartition(partition, offset.getOffset(), offset.getLeaderEpoch(),
+                            offset.getMetadata());
+                } else {
+                    responseTopic.addPartition(partition, -1, -1, ValueFactory::getNullStringValue());
+                }
+            }
+        }
+    }
+
+    out.writeVarBinary([&response, requestVersion](SerializeOutput &out) { response.write(requestVersion, out); });
+}
+
+} }

--- a/src/ee/kipling/GroupStore.h
+++ b/src/ee/kipling/GroupStore.h
@@ -1,0 +1,102 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "storage/persistenttable.h"
+#include "kipling/GroupTables.h"
+
+namespace voltdb { namespace kipling {
+
+/**
+ * High level API for interacting with the kipling system tables. This API allows group and group offsets to be stored,
+ * retrieved and deleted
+ */
+class GroupStore : public GroupTables {
+public:
+    virtual ~GroupStore();
+
+    /**
+     * Initialize this instance from the provided engine
+     */
+    void initialize(VoltDBEngine* engine);
+
+    /**
+     * Initialize this instance from the explicitly specified values
+     */
+    void initialize(PersistentTable* group, PersistentTable* groupMember, PersistentTable* groupOffset);
+
+    /**
+     * Perform an upsert to update the metadata about a kipling group and its members
+     */
+    void storeGroup(SerializeInputBE& groupMetadata);
+
+    /**
+     * Delete the group, all members and offsets which have the given groupId
+     */
+    void deleteGroup(const NValue& groupId);
+
+    /**
+     * Fetch kipling groups in a serialized format from the kipling system tables. A fetch is initialized whenever
+     * maxSize is > 0. If maxSize <= 0 then this method will continue fetching groups until all groups have been
+     * fetched.
+     *
+     * @param maxResultSize maximum size of data to serialize in out
+     * @param startGroupId Non inclusive groupId at which to start fetching
+     * @param out buffer where the groups being returned are to be serialized
+     * @return true if there are more groups to return otherwise false
+     */
+    bool fetchGroups(int maxResultSize, const NValue& startGroupId, SerializeOutput& out);
+
+    /**
+     * Store offsets and associate them with the provided group. Offsets are serialized in the kipling wire format
+     *
+     * @param spUniqueId unique ID for this transaction
+     * @param requestVersion Version of the commit request message
+     * @param groupId where the offsets should be stored
+     * @param offsets serialized set offsets for topics and partitions
+     * @param out buffer where the response to the commit will be serialized
+     */
+    void commitOffsets(int64_t spUniqueId, int16_t requestVersion, const NValue& groupId, SerializeInputBE& offsets,
+            SerializeOutput& out);
+
+    /**
+     * Fetch offsets for the given group and serialize them to out. If any topics and partitions are specified only
+     * those offsets will be returned. Topic partitions are serialized in the kipling wire format
+     *
+     * @param requestVersion Version of the fetch request message
+     * @param groupId from which to fetch offsets
+     * @param topicPartitions serialized set of topics and partitions to fetch. If empty all are fetched
+     * @param out buffer where the response to the fetch will be serialized
+     */
+    void fetchOffsets(int16_t requestVersion, const NValue& groupId, SerializeInputBE& topicPartitions,
+            SerializeOutput& out);
+
+    // Satisfy the GroupTables interface
+    PersistentTable* getGroupTable() const override { return m_group; }
+    PersistentTable* getGroupMemberTable() const override { return m_groupMember; }
+    PersistentTable* getGroupOffsetTable() const override { return m_groupOffset; }
+
+private:
+    PersistentTable* m_group = nullptr;
+    PersistentTable* m_groupMember = nullptr;
+    PersistentTable* m_groupOffset = nullptr;
+};
+
+} }

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -117,6 +117,7 @@ SET (VOLTDB_MANUAL_SUCCEEDING_TEST_PROGRAMS
   indexes/index_test
   harness_test/harness_tester
   kipling/KiplingTableFactoryTest
+  kipling/GroupStoreTest
   kipling/orm/GroupOrmTest
   logging/logging_test
   memleaktests/no_losses

--- a/tests/ee/kipling/GroupStoreTest.cpp
+++ b/tests/ee/kipling/GroupStoreTest.cpp
@@ -1,0 +1,516 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2019 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "../../../src/ee/kipling/GroupStore.h"
+#include "kipling/GroupTestBase.h"
+#include "common/executorcontext.hpp"
+#include "storage/SystemTableFactory.h"
+#include "kipling/messages/OffsetCommit.h"
+#include "kipling/messages/OffsetFetch.h"
+#include "kipling/orm/Group.h"
+#include "kipling/orm/GroupOffset.h"
+
+using namespace voltdb;
+using namespace voltdb::kipling;
+
+class GroupStoreTest: public GroupTestBase {
+public:
+    using CommitOffsets = std::unordered_map<NValue, std::vector<OffsetCommitRequestPartition>>;
+    using FetchOffsets = std::unordered_map<NValue, std::vector<int32_t>>;
+
+    GroupStoreTest() {
+        srand(0);
+        m_topend = new DummyTopend();
+        m_pool = new Pool();
+        m_context = new ExecutorContext(0, 0, nullptr, m_topend, m_pool, nullptr, "", 0, NULL, NULL, 0);
+        m_groupStore.initialize(kipling::TableFactory::createGroup(m_factory),
+                kipling::TableFactory::createGroupMember(m_factory),
+                kipling::TableFactory::createGroupOffset(m_factory));
+    }
+
+    void upsertGroup(Group& update) {
+        char scratch[1024];
+        ReferenceSerializeOutput out(scratch, sizeof(scratch));
+        update.serialize(out);
+
+        ReferenceSerializeInputBE in(scratch, sizeof(scratch));
+        m_groupStore.storeGroup(in);
+
+        validateGroupCommited(m_groupStore, update);
+    }
+
+    void commitOffsets(const NValue& groupId, const CommitOffsets& offsets) {
+        char scratch[1024];
+        {
+            ReferenceSerializeOutput out(scratch, sizeof(scratch));
+            out.writeInt(offsets.size());
+            for (auto entry : offsets) {
+                ResponseComponent::writeString(entry.first, out);
+
+                out.writeInt(entry.second.size());
+                for (auto offset : entry.second) {
+                    out.writeInt(offset.partitionIndex());
+                    out.writeLong(offset.offset());
+                    out.writeInt(offset.leaderEpoch());
+                    ResponseComponent::writeString(offset.metadata(), out);
+                }
+            }
+        }
+
+        // It is ok if in == out since the write occurs after the complete read
+        ReferenceSerializeInputBE in(scratch, sizeof(scratch));
+        ReferenceSerializeOutput out(scratch, sizeof(scratch));
+        m_groupStore.commitOffsets(0L, static_cast<int16_t>(7), groupId, in, out);
+
+        for (auto entry : offsets) {
+            for (auto partition : entry.second) {
+                GroupOffset offset(m_groupStore, groupId, entry.first, partition.partitionIndex());
+                ASSERT_TRUE(offset.isInTable());
+                ASSERT_EQ(partition.offset(), offset.getOffset());
+                ASSERT_EQ(partition.leaderEpoch(), offset.getLeaderEpoch());
+                ASSERT_EQ(partition.metadata(), offset.getMetadata());
+            }
+        }
+    }
+
+    OffsetFetchResponse fetchOffsets(const NValue& groupId, FetchOffsets& offsets) {
+        int16_t version = 5;
+        char scratch[1024];
+        {
+            ReferenceSerializeOutput out(scratch, sizeof(scratch));
+            out.writeInt(offsets.size());
+            for (auto entry : offsets) {
+                ResponseComponent::writeString(entry.first, out);
+
+                out.writeInt(entry.second.size());
+                for (auto partition : entry.second) {
+                    out.writeInt(partition);
+                }
+            }
+        }
+
+        {
+            ReferenceSerializeInputBE in(scratch, sizeof(scratch));
+            ReferenceSerializeOutput out(scratch, sizeof(scratch));
+            m_groupStore.fetchOffsets(version, groupId, in, out);
+        }
+
+        {
+            ReferenceSerializeInputBE inTemp(scratch, sizeof(scratch));
+            int32_t actualLength = inTemp.readInt();
+            EXPECT_TRUE(actualLength < sizeof(scratch) - sizeof(int32_t));
+            ReferenceSerializeInputBE in(&scratch[sizeof(int32_t)], actualLength);
+            CheckedSerializeInput checkedIn(in);
+            OffsetFetchResponse response(version, checkedIn);
+            EXPECT_EQ(0, in.remaining());
+            return response;
+        }
+    }
+
+protected:
+    DummyTopend *m_topend;
+    Pool *m_pool;
+    ExecutorContext *m_context;
+    SystemTableFactory m_factory;
+    GroupStore m_groupStore;
+};
+
+/*
+ * Test the groups can be stored and updated
+ */
+TEST_F(GroupStoreTest, StoreGroup) {
+    NValue groupId = ValueFactory::getTempStringValue("groupId");
+    NValue leader = ValueFactory::getTempStringValue("leader");
+    NValue protocol = ValueFactory::getTempStringValue("protocol");
+
+    Group group(m_groupStore, groupId, 1000, 5, leader, protocol);
+
+    // Insert group
+    {
+        char scratch[128];
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+
+        ASSERT_EQ(0, m_groupStore.getGroupTable()->activeTupleCount());
+        ASSERT_EQ(0, m_groupStore.getGroupMemberTable()->activeTupleCount());
+
+        upsertGroup(group);
+
+        ASSERT_EQ(1, m_groupStore.getGroupTable()->activeTupleCount());
+        ASSERT_EQ(1, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    }
+
+    // Update group with one more member
+    {
+        char scratch[128];
+
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+
+        upsertGroup(group);
+
+        ASSERT_EQ(1, m_groupStore.getGroupTable()->activeTupleCount());
+        ASSERT_EQ(2, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    }
+
+    // Update group removing one member
+    {
+        group.getMembers()[0]->markForDelete();
+
+        upsertGroup(group);
+
+        ASSERT_EQ(1, m_groupStore.getGroupTable()->activeTupleCount());
+        ASSERT_EQ(1, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    }
+
+    // Add a second group
+    {
+        NValue groupId2 = ValueFactory::getTempStringValue("groupId2");
+        Group group2(m_groupStore, groupId2, 1000, 5, leader, protocol);
+
+        char scratch[128];
+        group2.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+        group2.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+
+        upsertGroup(group2);
+
+        ASSERT_EQ(2, m_groupStore.getGroupTable()->activeTupleCount());
+        ASSERT_EQ(3, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    }
+}
+
+/*
+ * Test that offsets can be committed
+ */
+TEST_F(GroupStoreTest, CommitOffsets) {
+    NValue groupId = ValueFactory::getTempStringValue("groupId");
+    CommitOffsets offsets;
+
+    std::vector<NValue> topics = { ValueFactory::getTempStringValue("topic1"), ValueFactory::getTempStringValue(
+            "topic2"), ValueFactory::getTempStringValue("topic3") };
+    {
+        std::vector<OffsetCommitRequestPartition> partitions = {
+                OffsetCommitRequestPartition(1, 200, 0, ""),
+                OffsetCommitRequestPartition(2, 500, 5, "mine"),
+                OffsetCommitRequestPartition(3, 600, -1, "something")};
+        for (auto topic : topics) {
+            offsets.emplace(topic, partitions);
+        }
+    }
+
+    ASSERT_EQ(0, m_groupStore.getGroupOffsetTable()->activeTupleCount());
+    commitOffsets(groupId, offsets);
+    ASSERT_EQ(9, m_groupStore.getGroupOffsetTable()->activeTupleCount());
+
+    {
+        std::vector<OffsetCommitRequestPartition> partitions = { OffsetCommitRequestPartition(1, 600, 1, ""),
+                OffsetCommitRequestPartition(5, 50, 5, "other") };
+        for (auto topic : topics) {
+            offsets.erase(topic);
+            offsets.emplace(topic, partitions);
+        }
+    }
+
+    commitOffsets(groupId, offsets);
+    ASSERT_EQ(12, m_groupStore.getGroupOffsetTable()->activeTupleCount());
+}
+
+/*
+ * Test that fetching offsets retunrs the appropriate responses
+ */
+TEST_F(GroupStoreTest, FetchOffsets) {
+    NValue groupId = ValueFactory::getTempStringValue("groupId");
+    CommitOffsets offsets;
+
+    std::vector<NValue> topics = { ValueFactory::getTempStringValue("topic1"), ValueFactory::getTempStringValue(
+            "topic2"), ValueFactory::getTempStringValue("topic3") };
+    {
+        std::vector<OffsetCommitRequestPartition> partitions = {
+                OffsetCommitRequestPartition(1, 200, 0, ""),
+                OffsetCommitRequestPartition(2, 500, 5, "mine"),
+                OffsetCommitRequestPartition(3, 600, -1, "something"),
+                OffsetCommitRequestPartition(4, 40, 2, "other")};
+        for (auto topic : topics) {
+            offsets.emplace(topic, partitions);
+        }
+    }
+    commitOffsets(groupId, offsets);
+
+    // Fetch all partitions from one topic
+    {
+        FetchOffsets fetch;
+        fetch[topics[0]] = { 1, 2, 3, 4 };
+        fetch[topics[1]] = { 1, 2, 3, 4 };
+
+        OffsetFetchResponse response = fetchOffsets(groupId, fetch);
+        auto responseTopics = response.topics();
+        ASSERT_EQ(2, responseTopics.size());
+        for (auto topic : responseTopics) {
+            ASSERT_TRUE(topic.topic() == topics[0] || topic.topic() == topics[1]);
+            ASSERT_EQ(4, topic.partitions().size());
+            for (auto partition : topic.partitions()) {
+                auto expected = offsets[topic.topic()][partition.partitionIndex() - 1];
+                ASSERT_EQ(expected.partitionIndex(), partition.partitionIndex());
+                ASSERT_EQ(expected.offset(), partition.offset());
+                ASSERT_EQ(expected.leaderEpoch(), partition.leaderEpoch());
+                ASSERT_EQ(expected.metadata(), partition.metadata());
+            }
+        }
+    }
+
+    // Fetching partitions/topics which do not exist return unknown offset value
+    {
+        FetchOffsets fetch;
+        fetch[topics[0]] = { 0, 5, 6 };
+        NValue unknownTopic = ValueFactory::getTempStringValue("unknown");
+        NValue unknownMetadata = ValueFactory::getTempStringValue("");
+        fetch[unknownTopic] = {1, 2, 3};
+
+        OffsetFetchResponse response = fetchOffsets(groupId, fetch);
+        auto responseTopics = response.topics();
+        ASSERT_EQ(2, responseTopics.size());
+        for (auto topic : responseTopics) {
+            ASSERT_TRUE(topic.topic() == topics[0] || topic.topic() == unknownTopic);
+            ASSERT_EQ(3, topic.partitions().size());
+            for (auto partition : topic.partitions()) {
+                ASSERT_EQ(-1, partition.offset());
+                ASSERT_EQ(-1, partition.leaderEpoch());
+                ASSERT_EQ(unknownMetadata, partition.metadata());
+            }
+        }
+    }
+
+    // Fetch of no topics returns all
+    {
+        FetchOffsets fetch;
+        OffsetFetchResponse response = fetchOffsets(groupId, fetch);
+        auto responseTopics = response.topics();
+        ASSERT_EQ(3, responseTopics.size());
+        for (auto topic : responseTopics) {
+            ASSERT_NE(topics.end(), std::find(topics.begin(), topics.end(), topic.topic()));
+            ASSERT_EQ(4, topic.partitions().size());
+            for (auto partition : topic.partitions()) {
+                auto expected = offsets[topic.topic()][partition.partitionIndex() - 1];
+                ASSERT_EQ(expected.partitionIndex(), partition.partitionIndex());
+                ASSERT_EQ(expected.offset(), partition.offset());
+                ASSERT_EQ(expected.leaderEpoch(), partition.leaderEpoch());
+                ASSERT_EQ(expected.metadata(), partition.metadata());
+            }
+        }
+    }
+
+}
+
+/*
+ * Test that deleting a group deletes the group all members and all offsets
+ */
+TEST_F(GroupStoreTest, DeleteGroup) {
+    NValue groupId = ValueFactory::getTempStringValue("groupId");
+    NValue groupId2 = ValueFactory::getTempStringValue("groupId2");
+    NValue leader = ValueFactory::getTempStringValue("leader");
+    NValue protocol = ValueFactory::getTempStringValue("protocol");
+
+    // Insert group and offsets
+    char scratch[128];
+    std::vector<NValue> topics = { ValueFactory::getTempStringValue("topic1"), ValueFactory::getTempStringValue(
+            "topic2"), ValueFactory::getTempStringValue("topic3") };
+    std::vector<OffsetCommitRequestPartition> partitions = {
+            OffsetCommitRequestPartition(1, 200, 0, ""),
+            OffsetCommitRequestPartition(2, 500, 5, "mine"),
+            OffsetCommitRequestPartition(3, 600, -1, "something"),
+            OffsetCommitRequestPartition(4, 40, 2, "other")};
+
+    {
+        Group group(m_groupStore, groupId, 1000, 5, leader, protocol);
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+
+        upsertGroup(group);
+
+        CommitOffsets offsets;
+
+
+        for (auto topic : topics) {
+            offsets.emplace(topic, partitions);
+        }
+        commitOffsets(groupId, offsets);
+    }
+
+    // Create a second group and offsets
+    {
+        Group group(m_groupStore, groupId2, 1000, 5, leader, protocol);
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+        group.getOrCreateMember(generateGroupMemberid()).update(1000, 2000, ValueFactory::getNullStringValue(),
+                ValueFactory::getTempBinaryValue(scratch, 64), ValueFactory::getTempBinaryValue(&scratch[64], 64));
+
+        upsertGroup(group);
+
+        CommitOffsets offsets;
+
+
+        for (auto topic : topics) {
+            offsets.emplace(topic, partitions);
+        }
+        commitOffsets(groupId2, offsets);
+    }
+
+    ASSERT_EQ(2, m_groupStore.getGroupTable()->activeTupleCount());
+    ASSERT_EQ(4, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    ASSERT_EQ(24, m_groupStore.getGroupOffsetTable()->activeTupleCount());
+
+    m_groupStore.deleteGroup(groupId);
+
+    ASSERT_EQ(1, m_groupStore.getGroupTable()->activeTupleCount());
+    ASSERT_EQ(2, m_groupStore.getGroupMemberTable()->activeTupleCount());
+    ASSERT_EQ(12, m_groupStore.getGroupOffsetTable()->activeTupleCount());
+
+    ASSERT_FALSE(Group(m_groupStore, groupId).isInTable());
+    FetchOffsets fetch;
+    ASSERT_EQ(0, fetchOffsets(groupId, fetch).topics().size());
+
+    Group group2(m_groupStore, groupId2);
+    ASSERT_TRUE(group2.isInTable());
+    ASSERT_EQ(2, group2.getMembers().size());
+    OffsetFetchResponse response = fetchOffsets(groupId2, fetch);
+    ASSERT_EQ(3, response.topics().size());
+    for (auto topic : response.topics()) {
+        ASSERT_EQ(4, topic.partitions().size());
+    }
+}
+
+/*
+ * Test that fetch groups returns all groups and only as much as requested by the caller
+ */
+TEST_F(GroupStoreTest, FetchGroups) {
+    std::unordered_map<NValue, std::unique_ptr<Group>> groups;
+
+    int maxSize = 0;
+    int totalSize = 0;
+    for (int i = 0; i < 20; ++i) {
+        char scratch[128];
+
+        int len = ::snprintf(scratch, sizeof(scratch), "groupId_%d", i);
+        NValue groupId = ValueFactory::getTempStringValue(scratch, len);
+        len = ::snprintf(scratch, sizeof(scratch), "leaderId_%d", i);
+        NValue leader = ValueFactory::getTempStringValue(scratch, len);;
+        len = ::snprintf(scratch, sizeof(scratch), "protocol_%d", i);
+        NValue protocol = ValueFactory::getTempStringValue(scratch, len);
+        Group* group = new Group(m_groupStore, groupId, 1000, 5, leader, protocol);
+        groups[group->getGroupId()].reset(group);
+
+        for (int j = 0 ; j < 10; ++j) {
+            int len = ::snprintf(scratch, sizeof(scratch), "memberId_%d", i);
+            NValue memberId = ValueFactory::getTempStringValue(scratch, len);
+            group->getOrCreateMember(memberId).update(200, 500, memberId,
+                    ValueFactory::getTempBinaryValue(scratch, sizeof(scratch) - j),
+                    ValueFactory::getTempBinaryValue(scratch, sizeof(scratch) - (j * 2)));
+        }
+
+        int serializedSize = group->serializedSize();
+        totalSize += serializedSize;
+        if (serializedSize > maxSize) {
+            maxSize = serializedSize;
+        }
+        upsertGroup(*group);
+    }
+
+    char buffer[totalSize + 128];
+
+    {
+        ReferenceSerializeOutput out(buffer, sizeof(buffer));
+        int res = m_groupStore.fetchGroups(sizeof(buffer), ValueFactory::getNullStringValue(), out);
+        ASSERT_EQ(0, res);
+    }
+
+    // Big enough fetch should get all groups
+    {
+        ReferenceSerializeInputBE in(buffer, sizeof(buffer));
+        ASSERT_EQ(totalSize + sizeof(int32_t), in.readInt());
+        int count = in.readInt();
+        ASSERT_EQ(groups.size(), count);
+    }
+
+    // Small fetch should only have one group and iterate through them
+    {
+        int loops = 0;
+        NValue groupId = ValueFactory::getNullStringValue();
+        int res;
+        do {
+            ++loops;
+            ReferenceSerializeOutput out(buffer, sizeof(buffer));
+            res = m_groupStore.fetchGroups(maxSize * 2 - 10, groupId, out);
+            ASSERT_EQ(loops == groups.size() ? 0 : 1, res);
+            ReferenceSerializeInputBE in(buffer, sizeof(buffer));
+            int lenGroup = in.readInt();
+            ASSERT_EQ(1, in.readInt());
+
+            int lengroupId = in.readInt();
+            char groupIdBytes[lengroupId];
+            in.readBytes(groupIdBytes, lengroupId);
+            groupId = ValueFactory::getTempStringValue(groupIdBytes, lengroupId);
+
+            auto group = groups.find(groupId);
+            ASSERT_NE(group, groups.end());
+            ASSERT_EQ(group->second->serializedSize() + sizeof(int32_t), lenGroup);
+        } while(res == 1);
+    }
+}
+
+/*
+ * Test that when bad messages are received exceptions are thrown
+ */
+TEST_F(GroupStoreTest, BadMessages) {
+    char scratch[256];
+    ReferenceSerializeOutput message(scratch, sizeof(scratch));
+    message.writeInt(3);
+    message.writeInt(50);
+    message.writeTextString("abc");
+
+    char outScratch[256];
+    ReferenceSerializeOutput out(outScratch, sizeof(outScratch));
+
+    // try commit
+    try {
+        ReferenceSerializeInputBE in(scratch, message.position());
+        m_groupStore.commitOffsets(0, 7, ValueFactory::getTempStringValue("groupId"), in, out);
+        FAIL("should have thrown SerializableEEException");
+    } catch (const SerializableEEException &e) {}
+    ASSERT_EQ(0, out.position());
+
+    // try fetch
+    try {
+        ReferenceSerializeInputBE in(scratch, message.position());
+        m_groupStore.fetchOffsets(7, ValueFactory::getTempStringValue("groupId"), in, out);
+        FAIL("should have thrown SerializableEEException");
+    } catch (const SerializableEEException &e) {}
+    ASSERT_EQ(0, out.position());
+}
+
+int main() {
+    return TestSuite::globalInstance()->runAll();
+}


### PR DESCRIPTION
Add a group coordinator into the EE layer which is the interface to
managing the data in the kipling system tables. This supports four
opperations: storeGroup, deleteGroup, fetchGroups, commitOffsets and fetchOffsets.