### PR TITLE
APIs for insertion undo/schema update (a.k.a. light weight removals)

### DIFF
--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -294,6 +294,7 @@ namespace voltdb {
             bool m_frozen = false;
         public:
             explicit CompactingStorageTrait(list_type*) noexcept;
+            bool frozen() const noexcept;
             void freeze(); void thaw();
             /**
              * post-action when free() is called, only useful when shrinking
@@ -421,12 +422,12 @@ namespace voltdb {
             /**
              * Queries
              */
-            bool frozen() const noexcept;
             size_t chunks() const noexcept;            // number of chunks
             size_t size() const noexcept;              // number of allocation requested
             size_t id() const noexcept;
             using list_type::tupleSize; using list_type::chunkSize;
             using list_type::empty; using list_type::begin; using list_type::end;
+            using CompactingStorageTrait::frozen;
 
             // search in txn memory region (i.e. excludes snapshot-related, front portion of list)
             list_type::iterator const* find(void const*) const noexcept;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -979,6 +979,16 @@ void testHookedCompactingChunksBatchRemove_single3() {         // correctness on
 }
 
 template<typename Chunk, gc_policy pol>
+void testHookedCompactingChunksBatchRemove_single4() {         // correctness on txn view: single elem table, remove the only row
+    using HookAlloc = NonCompactingChunks<Chunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    Alloc alloc(TupleSize);
+    alloc.remove(set<void*>{alloc.allocate()}, [](map<void*, void*> const&){});
+    assert(alloc.empty());
+}
+
+template<typename Chunk, gc_policy pol>
 void testHookedCompactingChunksBatchRemove_multi1() {
     using HookAlloc = NonCompactingChunks<Chunk>;
     using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<pol>>;
@@ -1136,6 +1146,7 @@ template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
         testHookedCompactingChunksBatchRemove_single1<Chunk, pol>();
         testHookedCompactingChunksBatchRemove_single2<Chunk, pol>();
         testHookedCompactingChunksBatchRemove_single3<Chunk, pol>();
+        testHookedCompactingChunksBatchRemove_single4<Chunk, pol>();
         testHookedCompactingChunksBatchRemove_multi1<Chunk, pol>();
         testHookedCompactingChunksBatchRemove_multi2<Chunk, pol>();
     }


### PR DESCRIPTION
Light weight removing from head (for schema update), or from tail (for insertion undo).
Testing finished for head removal; not yet started for tail removal. Use at your own risk.
Read the document for caveat on head removal.