### PR TITLE
ENG-18993 & ENG-18994: Add kipling group store to engine and system procedures

### DIFF
--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -233,6 +233,12 @@ public:
         return m_end - m_current;
     }
 
+    // Reduce the size of this input down to limit. Limit must be less then current end
+    void limit(size_t limit) {
+        vassert(m_current + limit <= m_end);
+        m_end = m_current + limit;
+    }
+
 private:
     template <typename T>
     T readPrimitive() {

--- a/src/ee/kipling/GroupStore.cpp
+++ b/src/ee/kipling/GroupStore.cpp
@@ -100,7 +100,6 @@ bool GroupStore::fetchGroups(int maxResultSize, const NValue& startGroupId, Seri
 
 void GroupStore::commitOffsets(int64_t spUniqueId, int16_t requestVersion, const NValue& groupId,
         SerializeInputBE& offsets, SerializeOutput& out) {
-
     OffsetCommitResponse response;
     CheckedSerializeInput checkedIn(offsets);
 

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -370,13 +370,11 @@ public final class InvocationDispatcher {
         // check for allPartition invocation and provide a nice error if it's misused
         if (task.hasPartitionDestination()) {
             if (!catProc.getSinglepartition()
-                    || (catProc.getPartitionparameter() != 0 && catProc.getPartitionparameter() != -1)
-                    || catProc.getSystemproc()) {
+                    || (catProc.getPartitionparameter() != 0 && catProc.getPartitionparameter() != -1)) {
                 return new ClientResponseImpl(ClientResponseImpl.GRACEFUL_FAILURE, new VoltTable[0],
                         "Invalid procedure for all-partition execution. "
                                 + "Targeted procedure must be partitioned on the first parameter "
-                                + "or be a directed procedure, "
-                                + "and must not be a system procedure.",
+                                + "or be a directed procedure.",
                         task.clientHandle);
             }
 
@@ -387,7 +385,7 @@ public final class InvocationDispatcher {
             }
 
             if (catProc.getPartitionparameter() == -1
-                    && task.getParams().size() == catProc.getParameters().size() + 1) {
+                    && !catProc.getSystemproc() && task.getParams().size() == catProc.getParameters().size() + 1) {
                 // Client provided a partition parameter for backwards compatibility so strip off the first parameter
                 Object[] params = task.getParams().toArray();
                 task.setParams(Arrays.copyOfRange(params, 1, params.length));

--- a/src/frontend/org/voltdb/KiplingSystemTableConnection.java
+++ b/src/frontend/org/voltdb/KiplingSystemTableConnection.java
@@ -1,0 +1,68 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb;
+
+import org.voltcore.utils.Pair;
+
+public interface KiplingSystemTableConnection {
+    /**
+     * Store a kipling group and its members in the system tables
+     *
+     * @param serializedGroup kipling group serialized into a byte[]
+     */
+    void storeGroup(byte[] groupMetadata);
+
+    /**
+     * Delete a kiplng group, all members and all offsets
+     *
+     * @param groupId ID of group to be dleted
+     */
+    void deleteGroup(String groupId);
+
+    /**
+     * Start or continue a fetch of all groups from this site.
+     *
+     * If the Boolean in the return is {@code true} then there are more groups to fetch and this method should be called
+     * repeatedly with the last groupId returned until {@code false} is returned.
+     *
+     * @param maxResultSize for any result returned by this fetch
+     * @param groupId       non-inclusive start point for iterating over groups. {@code null} means start at begining
+     * @return A {@link Pair} indicating if there are more groups and the serialized groups
+     */
+    Pair<Boolean, byte[]> fetchGroups(int maxResultSize, String startGroupId);
+
+    /**
+     * Commit topic partition offsets for a kipling group in the system tables
+     *
+     * @param spHandle       for this transaction
+     * @param requestVersion Version of the kipling message making this request
+     * @param groupId        ID of the group
+     * @param offsets        serialized offsets to be stored
+     * @return response to requester
+     */
+    byte[] commitGroupOffsets(long spHandle, short requestVersion, String groupId, byte[] offsets);
+
+    /**
+     * Fetch topic partition offsets for a kipling group from the system tables
+     *
+     * @param requestVersion version of the kipling message making this request
+     * @param groupId        IF of group
+     * @param offsets        serialized offsets being requested
+     * @return response to requester
+     */
+    byte[] fetchGroupOffsets(short requestVersion, String groupId, byte[] offsets);
+}

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -75,7 +75,7 @@ public class SystemProcedureCatalog {
         private Durability durable = Durability.DURABLE;
         private boolean allowedInShutdown = false;
         private final boolean transactional;
-        private Restartability restartable;
+        private final Restartability restartable;
 
         static Builder createSp(String className, VoltType partitionParamType) {
             return createSp(className, 0, partitionParamType);
@@ -672,6 +672,19 @@ public class SystemProcedureCatalog {
                         false, false, false,  0, VoltType.INVALID,
                         true, false, true, Durability.NOT_DURABLE,
                         false, true, Restartability.RESTARTABLE));
+        builder.put("@StoreKiplingGroup", Builder
+                .createSp("org.voltdb.sysprocs.KiplingProcedures$StoreGroup", VoltType.STRING).commercial().build());
+        builder.put("@DeleteKiplingGroup", Builder
+                .createSp("org.voltdb.sysprocs.KiplingProcedures$DeleteGroup", VoltType.STRING).commercial().build());
+        builder.put("@FetchKiplingGroups",
+                Builder.createSp("org.voltdb.sysprocs.KiplingProcedures$FetchGroups", -1, VoltType.INVALID).commercial()
+                        .readOnly().notDurable().build());
+        builder.put("@CommitKiplingGroupOffsets",
+                Builder.createSp("org.voltdb.sysprocs.KiplingProcedures$CommitGroupOffsets", VoltType.STRING)
+                        .commercial().build());
+        builder.put("@FetchKiplingGroupOffsets",
+                Builder.createSp("org.voltdb.sysprocs.KiplingProcedures$FetchGroupOffsets", VoltType.STRING)
+                        .commercial().readOnly().build());
 
         listing = builder.build();
     }

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -131,4 +131,6 @@ public interface SystemProcedureExecutionContext {
     public InitiatorMailbox getInitiatorMailbox();
 
     void decommissionSite(boolean remove, boolean promote, int newSitePerHost);
+
+    KiplingSystemTableConnection getKiplingSystemTableConnection();
 }

--- a/src/frontend/org/voltdb/exceptions/InvalidMessageException.java
+++ b/src/frontend/org/voltdb/exceptions/InvalidMessageException.java
@@ -1,0 +1,30 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.exceptions;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An exception which is thrown by the EE when a raw client serialized message could not be deserialized
+ */
+public class InvalidMessageException extends SerializableException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidMessageException(ByteBuffer b) {
+        super(b);
+    }
+}

--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -123,6 +123,12 @@ public class SerializableException extends VoltProcedure.VoltAbortException impl
             protected SerializableException deserializeException(ByteBuffer b) {
                 return new DRTableNotFoundException(b);
             }
+        },
+        InvalidMessage() {
+            @Override
+            protected SerializableException deserializeException(ByteBuffer b) {
+                return new InvalidMessageException(b);
+            }
         };
 
         abstract protected SerializableException deserializeException(ByteBuffer b);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -364,6 +364,11 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
         public void decommissionSite(boolean remove, boolean promote, int newSitePerHost) {
             throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
         }
+
+        @Override
+        public org.voltdb.KiplingSystemTableConnection getKiplingSystemTableConnection() {
+            throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
+        };
     };
 
     /** Create a new RO MP execution site */

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -280,4 +280,31 @@ public class MockExecutionEngine extends ExecutionEngine {
     public boolean externalStreamsEnabled() {
         return true;
     }
+
+    @Override
+    public void storeKiplingGroup(long undoToken, byte[] serializedGroup) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteKiplingGroup(long undoToken, String groupId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Pair<Boolean, byte[]> fetchKiplingGroups(int maxResultSize, String startGroupId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] commitKiplingGroupOffsets(long spUniqueId, long undoToken, short requestVersion, String groupId,
+            byte[] offsets) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] fetchKiplingGroupOffsets(short requestVersion, String groupId, byte[] offsets) {
+        throw new UnsupportedOperationException();
+    }
+
 }


### PR DESCRIPTION
Add the kipling GroupStore to the execution engine and a getter so
it can be accessed by the different interfaces.

Add a connector to the site which can be used to interact with the
kipling system tests.