### PR TITLE
ENG-18967-insert-undo-API

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -238,6 +238,12 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::add(
     m_byId.emplace(iter->id(), iter);
 }
 
+template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::remove(
+        typename ChunkList<Chunk, E>::iterator iter) {
+    m_byAddr.erase(iter->begin());
+    m_byId.erase(iter->id());
+}
+
 template<typename Chunk, typename E>
 template<typename... Args>
 inline typename ChunkList<Chunk, E>::iterator ChunkList<Chunk, E>::emplace_back(Args&&... args) {
@@ -265,6 +271,21 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front(
     }
 }
 
+template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back() {
+    if (super::empty()) {
+        throw underflow_error("pop_back() called on empty chunk list");
+    } else {
+        auto const* iterp = find(m_back->id() - 1);
+        if (iterp != nullptr) {            // original list contains more than 1 nodes
+            remove(m_back);
+            super::erase_after(m_back = *iterp);
+            --lastChunkId();
+        } else {
+            clear();
+        }
+    }
+}
+
 template<typename Chunk, typename E>
 template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
@@ -286,6 +307,8 @@ inline void ChunkList<Chunk, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();
+    m_back = end();
+    lastChunkId() = 0;
 }
 
 template<typename C, typename E> inline
@@ -374,9 +397,11 @@ inline void CompactingStorageTrait::freeze() {
 
 inline void CompactingStorageTrait::thaw() {
     if (m_frozen) {                        // release all chunks invisible to txn
-        auto const stop = reinterpret_cast<CompactingChunks const*>(m_storage)->beginTxn().first->id();
-        while (! m_storage->empty() && less_rolling(m_storage->front().id(), stop)) {
-            m_storage->pop_front();
+        if (! m_storage->empty()) {
+            auto const stop = reinterpret_cast<CompactingChunks const*>(m_storage)->beginTxn().first->id();
+            while (! m_storage->empty() && less_rolling(m_storage->front().id(), stop)) {
+                m_storage->pop_front();
+            }
         }
         m_frozen = false;
     } else {
@@ -1368,6 +1393,9 @@ HookedCompactingChunks<Hook, E>::remove(void* dst) {
 template<typename Hook, typename E> inline void
 HookedCompactingChunks<Hook, E>::remove(
         typename HookedCompactingChunks<Hook, E>::remove_direction dir, void const* p) {
+    if (frozen()) {
+        throw logic_error("Cannot remove from head or tail when frozen");
+    }
     switch (dir) {
         case remove_direction::from_head:
             // Schema change: it is called in the same
@@ -1376,9 +1404,7 @@ HookedCompactingChunks<Hook, E>::remove(
             // NOTE: since we only do chunk-wise drop, any reads
             // from the allocator when these dispersed calls are
             // occurring *will* get spurious data.
-            if(frozen()) {
-                throw logic_error("Cannot remove from head when frozen");
-            } else if (p == nullptr) {                         // marks completion
+            if (p == nullptr) {                         // marks completion
                 if (m_lastFreeFromHead != nullptr && beginTxn().first->contains(m_lastFreeFromHead)) {
                     // effects deletions in 1st chunk
                     auto& iter = beginTxn().first;
@@ -1423,14 +1449,8 @@ HookedCompactingChunks<Hook, E>::remove(
                 throw underflow_error(buf);
             } else {
                 vassert(reinterpret_cast<char const*>(p) + tupleSize() == last()->next());
-                if (frozen()) {
-                    release(p);
-                }
-                if (last()->begin() == (last()->m_next = const_cast<void*>(p))) {
-                    // delete last chunk
-                    auto const* iter = CompactingChunks::find(last()->id() - 1);
-                    vassert(iter != nullptr || empty());
-                    last() = iter == nullptr ? end() : *iter;
+                if (last()->begin() == (last()->m_next = const_cast<void*>(p))) { // delete last chunk
+                    pop_back();
                 }
                 --CompactingChunks::m_allocs;
             }

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -182,6 +182,7 @@ namespace voltdb {
             map<void const*, typename super::iterator> m_byAddr{};
             map<size_t, typename super::iterator> m_byId{};
             void add(typename super::iterator);
+            void remove(typename super::iterator);
         protected:
             size_t& lastChunkId();
             template<typename Pred> void remove_if(Pred p);
@@ -195,6 +196,7 @@ namespace voltdb {
             // "override" writing behavior
             template<typename... Args> iterator emplace_back(Args&&...);
             void pop_front();
+            void pop_back();
             void clear() noexcept;
             using super::begin; using super::end; using super::cbegin; using super::cend;
             using super::empty; using super::front;
@@ -416,6 +418,7 @@ namespace voltdb {
                 size_t force(bool);
             } m_batched;
             using list_type::last;
+            using list_type::pop_back;
         public:
             using Compact = integral_constant<bool, true>;
             CompactingChunks(size_t tupleSize) noexcept;


### PR DESCRIPTION
Finished no-compaction-removal from both ends.
**Do not merge! The eecheck is failing on U14.04 and OSX10.6 (but succeeds on U18.4, U16.4 and C7)**