### PR TITLE
ENG-18751-copyright-update:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/bin/csvloader
+++ b/bin/csvloader
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/jdbcloader
+++ b/bin/jdbcloader
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/kafkaloader
+++ b/bin/kafkaloader
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/kafkaloader10
+++ b/bin/kafkaloader10
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/rabbitmqloader
+++ b/bin/rabbitmqloader
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/snapshotconvert
+++ b/bin/snapshotconvert
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/snapshotverifier
+++ b/bin/snapshotverifier
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/sqlcmd
+++ b/bin/sqlcmd
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/voltadmin
+++ b/bin/voltadmin
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/voltdb
+++ b/bin/voltdb
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/bin/voltsql
+++ b/bin/voltsql
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/HOWTOs/bulkloader/ExampleApp.java
+++ b/examples/HOWTOs/bulkloader/ExampleApp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/adperformance/client/adperformance/AdTrackingBenchmark.java
+++ b/examples/adperformance/client/adperformance/AdTrackingBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/adperformance/procedures/adperformance/InitializeCreatives.java
+++ b/examples/adperformance/procedures/adperformance/InitializeCreatives.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/adperformance/procedures/adperformance/TrackEvent.java
+++ b/examples/adperformance/procedures/adperformance/TrackEvent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/bank-offers/client/bankoffers/OfferBenchmark.java
+++ b/examples/bank-offers/client/bankoffers/OfferBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/bank-offers/client/bankoffers/PersonGenerator.java
+++ b/examples/bank-offers/client/bankoffers/PersonGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/bank-offers/procedures/bankoffers/CheckForOffers.java
+++ b/examples/bank-offers/procedures/bankoffers/CheckForOffers.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/CallCenterApp.java
+++ b/examples/callcenter/client/callcenter/CallCenterApp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/CallEvent.java
+++ b/examples/callcenter/client/callcenter/CallEvent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/CallSimulator.java
+++ b/examples/callcenter/client/callcenter/CallSimulator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/DelayedQueue.java
+++ b/examples/callcenter/client/callcenter/DelayedQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/EventSource.java
+++ b/examples/callcenter/client/callcenter/EventSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/client/callcenter/NetworkSadnessTransformer.java
+++ b/examples/callcenter/client/callcenter/NetworkSadnessTransformer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/procedures/callcenter/BeginCall.java
+++ b/examples/callcenter/procedures/callcenter/BeginCall.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/procedures/callcenter/BeginOrEndCallBase.java
+++ b/examples/callcenter/procedures/callcenter/BeginOrEndCallBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/callcenter/procedures/callcenter/EndCall.java
+++ b/examples/callcenter/procedures/callcenter/EndCall.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/contentionmark/ContentionMark.java
+++ b/examples/contentionmark/ContentionMark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/client/frauddetection/CardGenerator.java
+++ b/examples/fraud-detection/client/frauddetection/CardGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/client/frauddetection/FraudSimulation.java
+++ b/examples/fraud-detection/client/frauddetection/FraudSimulation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/procedures/frauddetection/CardSwipe.java
+++ b/examples/fraud-detection/procedures/frauddetection/CardSwipe.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/procedures/frauddetection/GetCardAcceptanceRate.java
+++ b/examples/fraud-detection/procedures/frauddetection/GetCardAcceptanceRate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/procedures/frauddetection/TrainActivity.java
+++ b/examples/fraud-detection/procedures/frauddetection/TrainActivity.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/procedures/frauddetection/UpdateWaitTime.java
+++ b/examples/fraud-detection/procedures/frauddetection/UpdateWaitTime.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/fraud-detection/procedures/frauddetection/UpdateWaitTimeForStation.java
+++ b/examples/fraud-detection/procedures/frauddetection/UpdateWaitTimeForStation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/client/geospatial/AdBrokerBenchmark.java
+++ b/examples/geospatial/client/geospatial/AdBrokerBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/client/geospatial/BidGenerator.java
+++ b/examples/geospatial/client/geospatial/BidGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/client/geospatial/NibbleDeleter.java
+++ b/examples/geospatial/client/geospatial/NibbleDeleter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/client/geospatial/Regions.java
+++ b/examples/geospatial/client/geospatial/Regions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/procedures/geospatial/DeleteOldAdRequests.java
+++ b/examples/geospatial/procedures/geospatial/DeleteOldAdRequests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/procedures/geospatial/GetHighestBidForLocation.java
+++ b/examples/geospatial/procedures/geospatial/GetHighestBidForLocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/geospatial/procedures/geospatial/GetStats.java
+++ b/examples/geospatial/procedures/geospatial/GetStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/client/jsonsessions/BlogSession.java
+++ b/examples/json-sessions/client/jsonsessions/BlogSession.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/client/jsonsessions/ForumSession.java
+++ b/examples/json-sessions/client/jsonsessions/ForumSession.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/client/jsonsessions/JSONClient.java
+++ b/examples/json-sessions/client/jsonsessions/JSONClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/client/jsonsessions/ManagementSession.java
+++ b/examples/json-sessions/client/jsonsessions/ManagementSession.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/client/jsonsessions/SessionBase.java
+++ b/examples/json-sessions/client/jsonsessions/SessionBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/json-sessions/procedures/jsonsessions/Login.java
+++ b/examples/json-sessions/procedures/jsonsessions/Login.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/metrocard/client/metrocard/MetroBenchmark.java
+++ b/examples/metrocard/client/metrocard/MetroBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/metrocard/exportServer.py
+++ b/examples/metrocard/exportServer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/examples/metrocard/procedures/metrocard/CardSwipe.java
+++ b/examples/metrocard/procedures/metrocard/CardSwipe.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/metrocard/procedures/metrocard/GetBusiestStationInLastMinute.java
+++ b/examples/metrocard/procedures/metrocard/GetBusiestStationInLastMinute.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/metrocard/procedures/metrocard/GetSwipesPerSecond.java
+++ b/examples/metrocard/procedures/metrocard/GetSwipesPerSecond.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/nbbo/client/nbbo/NbboBenchmark.java
+++ b/examples/nbbo/client/nbbo/NbboBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/nbbo/client/nbbo/Symbols.java
+++ b/examples/nbbo/client/nbbo/Symbols.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/nbbo/procedures/nbbo/ProcessTick.java
+++ b/examples/nbbo/procedures/nbbo/ProcessTick.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/positionkeeper/client/positionkeeper/PositionsBenchmark.java
+++ b/examples/positionkeeper/client/positionkeeper/PositionsBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/positionkeeper/procedures/positionkeeper/OrderInsert.java
+++ b/examples/positionkeeper/procedures/positionkeeper/OrderInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/positionkeeper/procedures/positionkeeper/PriceInsert.java
+++ b/examples/positionkeeper/procedures/positionkeeper/PriceInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/positionkeeper/procedures/positionkeeper/TradeInsert.java
+++ b/examples/positionkeeper/procedures/positionkeeper/TradeInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/simple/client/src/Benchmark.java
+++ b/examples/simple/client/src/Benchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/simple/client/src/util/BenchmarkCallback.java
+++ b/examples/simple/client/src/util/BenchmarkCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/simple/client/src/util/BenchmarkStats.java
+++ b/examples/simple/client/src/util/BenchmarkStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/simple/procedures/src/simple/SelectDeviceSessions.java
+++ b/examples/simple/procedures/src/simple/SelectDeviceSessions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/client/uniquedevices/UniqueDevicesClient.java
+++ b/examples/uniquedevices/client/uniquedevices/UniqueDevicesClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/client/uniquedevices/UniqueIdGenerator.java
+++ b/examples/uniquedevices/client/uniquedevices/UniqueIdGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/HyperLogLog.java
+++ b/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/HyperLogLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/MurmurHash.java
+++ b/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/MurmurHash.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/RegisterSet.java
+++ b/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/RegisterSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/TestHyperLogLog.java
+++ b/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/TestHyperLogLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/TestRegisterSet.java
+++ b/examples/uniquedevices/hyperloglogsrc/org/voltdb_hll/TestRegisterSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/examples/uniquedevices/procedures/uniquedevices/CountDeviceEstimate.java
+++ b/examples/uniquedevices/procedures/uniquedevices/CountDeviceEstimate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/procedures/uniquedevices/CountDeviceExact.java
+++ b/examples/uniquedevices/procedures/uniquedevices/CountDeviceExact.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/procedures/uniquedevices/CountDeviceHybrid.java
+++ b/examples/uniquedevices/procedures/uniquedevices/CountDeviceHybrid.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/uniquedevices/web/js/voltdb-dashboard.js
+++ b/examples/uniquedevices/web/js/voltdb-dashboard.js
@@ -1,6 +1,6 @@
 /*
  This file is part of VoltDB.
- Copyright (C) 2008-2019 VoltDB Inc.
+ Copyright (C) 2008-2020 VoltDB Inc.
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as

--- a/examples/uniquedevices/web/js/voltdb.js
+++ b/examples/uniquedevices/web/js/voltdb.js
@@ -1,6 +1,6 @@
 /*
  This file is part of VoltDB.
- Copyright (C) 2008-2019 VoltDB Inc.
+ Copyright (C) 2008-2020 VoltDB Inc.
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU Affero General Public License as

--- a/examples/voltkv/client/voltkv/AsyncBenchmark.java
+++ b/examples/voltkv/client/voltkv/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voltkv/client/voltkv/JDBCBenchmark.java
+++ b/examples/voltkv/client/voltkv/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voltkv/client/voltkv/PayloadProcessor.java
+++ b/examples/voltkv/client/voltkv/PayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voltkv/client/voltkv/SyncBenchmark.java
+++ b/examples/voltkv/client/voltkv/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/client/voter/AsyncBenchmark.java
+++ b/examples/voter/client/voter/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/client/voter/JDBCBenchmark.java
+++ b/examples/voter/client/voter/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/client/voter/PhoneCallGenerator.java
+++ b/examples/voter/client/voter/PhoneCallGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/client/voter/SimpleBenchmark.java
+++ b/examples/voter/client/voter/SimpleBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/client/voter/SyncBenchmark.java
+++ b/examples/voter/client/voter/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/procedures/voter/ContestantWinningStates.java
+++ b/examples/voter/procedures/voter/ContestantWinningStates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/procedures/voter/GetStateHeatmap.java
+++ b/examples/voter/procedures/voter/GetStateHeatmap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/procedures/voter/Initialize.java
+++ b/examples/voter/procedures/voter/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/procedures/voter/Results.java
+++ b/examples/voter/procedures/voter/Results.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/voter/procedures/voter/Vote.java
+++ b/examples/voter/procedures/voter/Vote.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing-with-ddl/client/ddlwindowing/MaxTracker.java
+++ b/examples/windowing-with-ddl/client/ddlwindowing/MaxTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing-with-ddl/client/ddlwindowing/PartitionDataTracker.java
+++ b/examples/windowing-with-ddl/client/ddlwindowing/PartitionDataTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing-with-ddl/client/ddlwindowing/RandomDataInserter.java
+++ b/examples/windowing-with-ddl/client/ddlwindowing/RandomDataInserter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing-with-ddl/client/ddlwindowing/Reporter.java
+++ b/examples/windowing-with-ddl/client/ddlwindowing/Reporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing-with-ddl/client/ddlwindowing/WindowingApp.java
+++ b/examples/windowing-with-ddl/client/ddlwindowing/WindowingApp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/client/windowing/ContinuousDeleter.java
+++ b/examples/windowing/client/windowing/ContinuousDeleter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/client/windowing/MaxTracker.java
+++ b/examples/windowing/client/windowing/MaxTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/client/windowing/RandomDataInserter.java
+++ b/examples/windowing/client/windowing/RandomDataInserter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/client/windowing/Reporter.java
+++ b/examples/windowing/client/windowing/Reporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/client/windowing/WindowingApp.java
+++ b/examples/windowing/client/windowing/WindowingApp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/procedures/windowing/DeleteAfterDate.java
+++ b/examples/windowing/procedures/windowing/DeleteAfterDate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/procedures/windowing/DeleteOldestToTarget.java
+++ b/examples/windowing/procedures/windowing/DeleteOldestToTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/procedures/windowing/InsertAndDeleteAfterDate.java
+++ b/examples/windowing/procedures/windowing/InsertAndDeleteAfterDate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/examples/windowing/procedures/windowing/InsertAndDeleteOldestToTarget.java
+++ b/examples/windowing/procedures/windowing/InsertAndDeleteOldestToTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/lib/python/Query.py
+++ b/lib/python/Query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/XMLUtils.py
+++ b/lib/python/XMLUtils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/__init__.py
+++ b/lib/python/voltcli/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/checkconfig.py
+++ b/lib/python/voltcli/checkconfig.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/checkstats.py
+++ b/lib/python/voltcli/checkstats.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/cli.py
+++ b/lib/python/voltcli/cli.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/clusterinfo.py
+++ b/lib/python/voltcli/clusterinfo.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/daemon.py
+++ b/lib/python/voltcli/daemon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/environment.py
+++ b/lib/python/voltcli/environment.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/future.d/config.py
+++ b/lib/python/voltcli/future.d/config.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/future.d/csvload.py
+++ b/lib/python/voltcli/future.d/csvload.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/future.d/show.py
+++ b/lib/python/voltcli/future.d/show.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/future.d/sql.py
+++ b/lib/python/voltcli/future.d/sql.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/future.d/start.py
+++ b/lib/python/voltcli/future.d/start.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/hostinfo.py
+++ b/lib/python/voltcli/hostinfo.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/runner.py
+++ b/lib/python/voltcli/runner.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/utility.py
+++ b/lib/python/voltcli/utility.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/verbs.py
+++ b/lib/python/voltcli/verbs.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/dr.py
+++ b/lib/python/voltcli/voltadmin.d/dr.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/export.py
+++ b/lib/python/voltcli/voltadmin.d/export.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/jstack.py
+++ b/lib/python/voltcli/voltadmin.d/jstack.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/log4j.py
+++ b/lib/python/voltcli/voltadmin.d/log4j.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/pause.py
+++ b/lib/python/voltcli/voltadmin.d/pause.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/plan_upgrade.py
+++ b/lib/python/voltcli/voltadmin.d/plan_upgrade.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/promote.py
+++ b/lib/python/voltcli/voltadmin.d/promote.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/resize.py
+++ b/lib/python/voltcli/voltadmin.d/resize.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/restore.py
+++ b/lib/python/voltcli/voltadmin.d/restore.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/resume.py
+++ b/lib/python/voltcli/voltadmin.d/resume.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/save.py
+++ b/lib/python/voltcli/voltadmin.d/save.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/show.py
+++ b/lib/python/voltcli/voltadmin.d/show.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/shutdown.py
+++ b/lib/python/voltcli/voltadmin.d/shutdown.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/status.py
+++ b/lib/python/voltcli/voltadmin.d/status.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/stop.py
+++ b/lib/python/voltcli/voltadmin.d/stop.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/update.py
+++ b/lib/python/voltcli/voltadmin.d/update.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltadmin.d/validate.py
+++ b/lib/python/voltcli/voltadmin.d/validate.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/add.py
+++ b/lib/python/voltcli/voltdb.d/add.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/check.py
+++ b/lib/python/voltcli/voltdb.d/check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/collect.py
+++ b/lib/python/voltcli/voltdb.d/collect.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/compile.py
+++ b/lib/python/voltcli/voltdb.d/compile.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/create.py
+++ b/lib/python/voltcli/voltdb.d/create.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/get.py
+++ b/lib/python/voltcli/voltdb.d/get.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/legacycompile.py
+++ b/lib/python/voltcli/voltdb.d/legacycompile.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/mask.py
+++ b/lib/python/voltcli/voltdb.d/mask.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/recover.py
+++ b/lib/python/voltcli/voltdb.d/recover.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/rejoin.py
+++ b/lib/python/voltcli/voltdb.d/rejoin.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/start.py
+++ b/lib/python/voltcli/voltdb.d/start.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltcli/voltdb.d/stop.py
+++ b/lib/python/voltcli/voltdb.d/stop.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/__init__.py
+++ b/lib/python/voltsql/tests/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/parseutils/__init__.py
+++ b/lib/python/voltsql/tests/parseutils/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/parseutils/test_ctes.py
+++ b/lib/python/voltsql/tests/parseutils/test_ctes.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/parseutils/test_parseutils.py
+++ b/lib/python/voltsql/tests/parseutils/test_parseutils.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/test_fuzzy_completion.py
+++ b/lib/python/voltsql/tests/test_fuzzy_completion.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/test_naive_completion.py
+++ b/lib/python/voltsql/tests/test_naive_completion.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/test_prioritization.py
+++ b/lib/python/voltsql/tests/test_prioritization.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/test_refresher.py
+++ b/lib/python/voltsql/tests/test_refresher.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/test_smart_completion.py
+++ b/lib/python/voltsql/tests/test_smart_completion.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/tests/utils.py
+++ b/lib/python/voltsql/tests/utils.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql.sh
+++ b/lib/python/voltsql/voltsql.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/__init__.py
+++ b/lib/python/voltsql/voltsql/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/parseutils/__init__.py
+++ b/lib/python/voltsql/voltsql/parseutils/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/parseutils/ctes.py
+++ b/lib/python/voltsql/voltsql/parseutils/ctes.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/parseutils/meta.py
+++ b/lib/python/voltsql/voltsql/parseutils/meta.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/parseutils/tables.py
+++ b/lib/python/voltsql/voltsql/parseutils/tables.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/parseutils/utils.py
+++ b/lib/python/voltsql/voltsql/parseutils/utils.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/prioritization.py
+++ b/lib/python/voltsql/voltsql/prioritization.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/sqlcompletion.py
+++ b/lib/python/voltsql/voltsql/sqlcompletion.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltcompleter.py
+++ b/lib/python/voltsql/voltsql/voltcompleter.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltdbclient.py
+++ b/lib/python/voltsql/voltsql/voltdbclient.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltexecutor.py
+++ b/lib/python/voltsql/voltsql/voltexecutor.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltliterals/__init__.py
+++ b/lib/python/voltsql/voltsql/voltliterals/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltliterals/literals.py
+++ b/lib/python/voltsql/voltsql/voltliterals/literals.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltreadme.py
+++ b/lib/python/voltsql/voltsql/voltreadme.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltrefresher.py
+++ b/lib/python/voltsql/voltsql/voltrefresher.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/lib/python/voltsql/voltsql/voltsql.py
+++ b/lib/python/voltsql/voltsql/voltsql.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/catgen/catalog.py
+++ b/src/catgen/catalog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/catgen/catalog_utils/__init__.py
+++ b/src/catgen/catalog_utils/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/catgen/catalog_utils/parser.py
+++ b/src/catgen/catalog_utils/parser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/catgen/catalog_utils/strings.py
+++ b/src/catgen/catalog_utils/strings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -18,7 +18,7 @@
 
 gpl_header = \
 """/* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/catalog_utils/testdata.py
+++ b/src/catgen/catalog_utils/testdata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/cppsrc/catalog.cpp
+++ b/src/catgen/in/cppsrc/catalog.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/cppsrc/catalog.h
+++ b/src/catgen/in/cppsrc/catalog.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/cppsrc/catalogmap.h
+++ b/src/catgen/in/cppsrc/catalogmap.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/cppsrc/catalogtype.cpp
+++ b/src/catgen/in/cppsrc/catalogtype.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/cppsrc/catalogtype.h
+++ b/src/catgen/in/cppsrc/catalogtype.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/Catalog.java
+++ b/src/catgen/in/javasrc/Catalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogChangeGroup.java
+++ b/src/catgen/in/javasrc/CatalogChangeGroup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/CatalogDiffEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogException.java
+++ b/src/catgen/in/javasrc/CatalogException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogMap.java
+++ b/src/catgen/in/javasrc/CatalogMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogOperator.java
+++ b/src/catgen/in/javasrc/CatalogOperator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogSerializer.java
+++ b/src/catgen/in/javasrc/CatalogSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogType.java
+++ b/src/catgen/in/javasrc/CatalogType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/CatalogVisitor.java
+++ b/src/catgen/in/javasrc/CatalogVisitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/DRCatalogCommands.java
+++ b/src/catgen/in/javasrc/DRCatalogCommands.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/DRCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/DRCatalogDiffEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/DatabaseConfiguration.java
+++ b/src/catgen/in/javasrc/DatabaseConfiguration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/in/javasrc/FilteredCatalogDiffEngine.java
+++ b/src/catgen/in/javasrc/FilteredCatalogDiffEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/catgen/install.py
+++ b/src/catgen/install.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/ee/CMakeLists.txt
+++ b/src/ee/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/CatalogUtil.h
+++ b/src/ee/common/CatalogUtil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ElasticHashinator.h
+++ b/src/ee/common/ElasticHashinator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ExecuteWithMpMemory.cpp
+++ b/src/ee/common/ExecuteWithMpMemory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ExecuteWithMpMemory.h
+++ b/src/ee/common/ExecuteWithMpMemory.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ExportSerializeIo.h
+++ b/src/ee/common/ExportSerializeIo.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/FailureInjection.h
+++ b/src/ee/common/FailureInjection.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/FatalException.cpp
+++ b/src/ee/common/FatalException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/FatalException.hpp
+++ b/src/ee/common/FatalException.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/GeographyPointValue.hpp
+++ b/src/ee/common/GeographyPointValue.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/GeographyValue.hpp
+++ b/src/ee/common/GeographyValue.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/InterruptException.cpp
+++ b/src/ee/common/InterruptException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/InterruptException.h
+++ b/src/ee/common/InterruptException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/LargeTempTableBlockCache.cpp
+++ b/src/ee/common/LargeTempTableBlockCache.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/LargeTempTableBlockCache.h
+++ b/src/ee/common/LargeTempTableBlockCache.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/LargeTempTableBlockId.hpp
+++ b/src/ee/common/LargeTempTableBlockId.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/MiscUtil.cpp
+++ b/src/ee/common/MiscUtil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/MiscUtil.h
+++ b/src/ee/common/MiscUtil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/PlannerDomValue.cpp
+++ b/src/ee/common/PlannerDomValue.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/PlannerDomValue.h
+++ b/src/ee/common/PlannerDomValue.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/Pool.cpp
+++ b/src/ee/common/Pool.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/Pool.hpp
+++ b/src/ee/common/Pool.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SQLException.cpp
+++ b/src/ee/common/SQLException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SQLException.h
+++ b/src/ee/common/SQLException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SegvException.cpp
+++ b/src/ee/common/SegvException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SegvException.hpp
+++ b/src/ee/common/SegvException.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SerializableEEException.cpp
+++ b/src/ee/common/SerializableEEException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SerializableEEException.h
+++ b/src/ee/common/SerializableEEException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StackTrace.cpp
+++ b/src/ee/common/StackTrace.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StackTrace.h
+++ b/src/ee/common/StackTrace.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StlFriendlyNValue.h
+++ b/src/ee/common/StlFriendlyNValue.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StreamBlock.h
+++ b/src/ee/common/StreamBlock.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StreamPredicateList.cpp
+++ b/src/ee/common/StreamPredicateList.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StreamPredicateList.h
+++ b/src/ee/common/StreamPredicateList.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StringRef.cpp
+++ b/src/ee/common/StringRef.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/StringRef.h
+++ b/src/ee/common/StringRef.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TheHashinator.h
+++ b/src/ee/common/TheHashinator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ThreadLocalPool.cpp
+++ b/src/ee/common/ThreadLocalPool.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ThreadLocalPool.h
+++ b/src/ee/common/ThreadLocalPool.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleOutputStream.cpp
+++ b/src/ee/common/TupleOutputStream.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleOutputStream.h
+++ b/src/ee/common/TupleOutputStream.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleOutputStreamProcessor.cpp
+++ b/src/ee/common/TupleOutputStreamProcessor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleOutputStreamProcessor.h
+++ b/src/ee/common/TupleOutputStreamProcessor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleSchema.cpp
+++ b/src/ee/common/TupleSchema.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleSchema.h
+++ b/src/ee/common/TupleSchema.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/TupleSchemaBuilder.h
+++ b/src/ee/common/TupleSchemaBuilder.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoLog.cpp
+++ b/src/ee/common/UndoLog.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoLog.h
+++ b/src/ee/common/UndoLog.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoQuantum.h
+++ b/src/ee/common/UndoQuantum.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoQuantumReleaseInterest.h
+++ b/src/ee/common/UndoQuantumReleaseInterest.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoReleaseAction.cpp
+++ b/src/ee/common/UndoReleaseAction.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UndoReleaseAction.h
+++ b/src/ee/common/UndoReleaseAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/UniqueId.hpp
+++ b/src/ee/common/UniqueId.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ValueFactory.cpp
+++ b/src/ee/common/ValueFactory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ValueFactory.hpp
+++ b/src/ee/common/ValueFactory.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ValuePeeker.hpp
+++ b/src/ee/common/ValuePeeker.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/VoltContainer.hpp
+++ b/src/ee/common/VoltContainer.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/bytearray.h
+++ b/src/ee/common/bytearray.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/common.h
+++ b/src/ee/common/common.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/debuglog.cpp
+++ b/src/ee/common/debuglog.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/debuglog.h
+++ b/src/ee/common/debuglog.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/executorcontext.hpp
+++ b/src/ee/common/executorcontext.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/ids.h
+++ b/src/ee/common/ids.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/iosflagsaver.h
+++ b/src/ee/common/iosflagsaver.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/serializeio.cpp
+++ b/src/ee/common/serializeio.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/subquerycontext.h
+++ b/src/ee/common/subquerycontext.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/tabletuple.cpp
+++ b/src/ee/common/tabletuple.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/tabletuple.h
+++ b/src/ee/common/tabletuple.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/types.cpp
+++ b/src/ee/common/types.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/common/value_defs.h
+++ b/src/ee/common/value_defs.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/common/valuevector.h
+++ b/src/ee/common/valuevector.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/execution/ExecutorVector.cpp
+++ b/src/ee/execution/ExecutorVector.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/execution/ExecutorVector.h
+++ b/src/ee/execution/ExecutorVector.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/execution/FragmentManager.cpp
+++ b/src/ee/execution/FragmentManager.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/FragmentManager.h
+++ b/src/ee/execution/FragmentManager.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/ProgressMonitorProxy.cpp
+++ b/src/ee/execution/ProgressMonitorProxy.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/ProgressMonitorProxy.h
+++ b/src/ee/execution/ProgressMonitorProxy.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/OptimizedProjector.cpp
+++ b/src/ee/executors/OptimizedProjector.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/OptimizedProjector.hpp
+++ b/src/ee/executors/OptimizedProjector.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/abstractexecutor.cpp
+++ b/src/ee/executors/abstractexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/abstractexecutor.h
+++ b/src/ee/executors/abstractexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/abstractjoinexecutor.cpp
+++ b/src/ee/executors/abstractjoinexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/abstractjoinexecutor.h
+++ b/src/ee/executors/abstractjoinexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/aggregateexecutor.cpp
+++ b/src/ee/executors/aggregateexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/aggregateexecutor.h
+++ b/src/ee/executors/aggregateexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/commontableexecutor.cpp
+++ b/src/ee/executors/commontableexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/commontableexecutor.h
+++ b/src/ee/executors/commontableexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/deleteexecutor.h
+++ b/src/ee/executors/deleteexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/executorfactory.cpp
+++ b/src/ee/executors/executorfactory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/executorfactory.h
+++ b/src/ee/executors/executorfactory.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/executorutil.cpp
+++ b/src/ee/executors/executorutil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/executorutil.h
+++ b/src/ee/executors/executorutil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/indexcountexecutor.cpp
+++ b/src/ee/executors/indexcountexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/indexcountexecutor.h
+++ b/src/ee/executors/indexcountexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/indexscanexecutor.cpp
+++ b/src/ee/executors/indexscanexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/indexscanexecutor.h
+++ b/src/ee/executors/indexscanexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/insertexecutor.cpp
+++ b/src/ee/executors/insertexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/insertexecutor.h
+++ b/src/ee/executors/insertexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/largeorderbyexecutor.cpp
+++ b/src/ee/executors/largeorderbyexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/largeorderbyexecutor.h
+++ b/src/ee/executors/largeorderbyexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/limitexecutor.cpp
+++ b/src/ee/executors/limitexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/limitexecutor.h
+++ b/src/ee/executors/limitexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/materializedscanexecutor.cpp
+++ b/src/ee/executors/materializedscanexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/materializedscanexecutor.h
+++ b/src/ee/executors/materializedscanexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/materializeexecutor.cpp
+++ b/src/ee/executors/materializeexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/materializeexecutor.h
+++ b/src/ee/executors/materializeexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/mergejoinexecutor.cpp
+++ b/src/ee/executors/mergejoinexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/mergejoinexecutor.h
+++ b/src/ee/executors/mergejoinexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/mergereceiveexecutor.cpp
+++ b/src/ee/executors/mergereceiveexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/mergereceiveexecutor.h
+++ b/src/ee/executors/mergereceiveexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/migrateexecutor.cpp
+++ b/src/ee/executors/migrateexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/migrateexecutor.h
+++ b/src/ee/executors/migrateexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/nestloopexecutor.cpp
+++ b/src/ee/executors/nestloopexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/nestloopexecutor.h
+++ b/src/ee/executors/nestloopexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/nestloopindexexecutor.cpp
+++ b/src/ee/executors/nestloopindexexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/nestloopindexexecutor.h
+++ b/src/ee/executors/nestloopindexexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/orderbyexecutor.cpp
+++ b/src/ee/executors/orderbyexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/orderbyexecutor.h
+++ b/src/ee/executors/orderbyexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/projectionexecutor.cpp
+++ b/src/ee/executors/projectionexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/projectionexecutor.h
+++ b/src/ee/executors/projectionexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/receiveexecutor.cpp
+++ b/src/ee/executors/receiveexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/receiveexecutor.h
+++ b/src/ee/executors/receiveexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/sendexecutor.cpp
+++ b/src/ee/executors/sendexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/sendexecutor.h
+++ b/src/ee/executors/sendexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/seqscanexecutor.cpp
+++ b/src/ee/executors/seqscanexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/seqscanexecutor.h
+++ b/src/ee/executors/seqscanexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/swaptablesexecutor.cpp
+++ b/src/ee/executors/swaptablesexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/swaptablesexecutor.h
+++ b/src/ee/executors/swaptablesexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/tablecountexecutor.cpp
+++ b/src/ee/executors/tablecountexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/tablecountexecutor.h
+++ b/src/ee/executors/tablecountexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/tuplescanexecutor.cpp
+++ b/src/ee/executors/tuplescanexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/tuplescanexecutor.h
+++ b/src/ee/executors/tuplescanexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/unionexecutor.cpp
+++ b/src/ee/executors/unionexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/unionexecutor.h
+++ b/src/ee/executors/unionexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/updateexecutor.cpp
+++ b/src/ee/executors/updateexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/updateexecutor.h
+++ b/src/ee/executors/updateexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/executors/windowfunctionexecutor.cpp
+++ b/src/ee/executors/windowfunctionexecutor.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/executors/windowfunctionexecutor.h
+++ b/src/ee/executors/windowfunctionexecutor.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/abstractexpression.cpp
+++ b/src/ee/expressions/abstractexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/abstractexpression.h
+++ b/src/ee/expressions/abstractexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/bitwisefunctions.h
+++ b/src/ee/expressions/bitwisefunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/comparisonexpression.h
+++ b/src/ee/expressions/comparisonexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/conjunctionexpression.h
+++ b/src/ee/expressions/conjunctionexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/constantvalueexpression.h
+++ b/src/ee/expressions/constantvalueexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/dateconstants.h
+++ b/src/ee/expressions/dateconstants.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/datefunctions.h
+++ b/src/ee/expressions/datefunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/expressions.h
+++ b/src/ee/expressions/expressions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/expressionutil.cpp
+++ b/src/ee/expressions/expressionutil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/expressionutil.h
+++ b/src/ee/expressions/expressionutil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/functionexpression.cpp
+++ b/src/ee/expressions/functionexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/functionexpression.h
+++ b/src/ee/expressions/functionexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/geofunctions.cpp
+++ b/src/ee/expressions/geofunctions.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/geofunctions.h
+++ b/src/ee/expressions/geofunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/hashrangeexpression.h
+++ b/src/ee/expressions/hashrangeexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/jsonfunctions.h
+++ b/src/ee/expressions/jsonfunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/logicfunctions.h
+++ b/src/ee/expressions/logicfunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/numericfunctions.h
+++ b/src/ee/expressions/numericfunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/operatorexpression.cpp
+++ b/src/ee/expressions/operatorexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/operatorexpression.h
+++ b/src/ee/expressions/operatorexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/parametervalueexpression.cpp
+++ b/src/ee/expressions/parametervalueexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/parametervalueexpression.h
+++ b/src/ee/expressions/parametervalueexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/scalarvalueexpression.cpp
+++ b/src/ee/expressions/scalarvalueexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/scalarvalueexpression.h
+++ b/src/ee/expressions/scalarvalueexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/stringfunctions.h
+++ b/src/ee/expressions/stringfunctions.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/subqueryexpression.cpp
+++ b/src/ee/expressions/subqueryexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/subqueryexpression.h
+++ b/src/ee/expressions/subqueryexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/expressions/tupleaddressexpression.cpp
+++ b/src/ee/expressions/tupleaddressexpression.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/tupleaddressexpression.h
+++ b/src/ee/expressions/tupleaddressexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/tuplevalueexpression.h
+++ b/src/ee/expressions/tuplevalueexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/vectorcomparisonexpression.hpp
+++ b/src/ee/expressions/vectorcomparisonexpression.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/expressions/vectorexpression.h
+++ b/src/ee/expressions/vectorexpression.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/indexes/CompactingHashMultiMapIndex.h
+++ b/src/ee/indexes/CompactingHashMultiMapIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/CompactingHashUniqueIndex.h
+++ b/src/ee/indexes/CompactingHashUniqueIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/CompactingTreeMultiMapIndex.h
+++ b/src/ee/indexes/CompactingTreeMultiMapIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/CompactingTreeUniqueIndex.h
+++ b/src/ee/indexes/CompactingTreeUniqueIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/CoveringCellIndex.cpp
+++ b/src/ee/indexes/CoveringCellIndex.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/indexes/CoveringCellIndex.h
+++ b/src/ee/indexes/CoveringCellIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/indexes/IndexStats.cpp
+++ b/src/ee/indexes/IndexStats.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/indexes/IndexStats.h
+++ b/src/ee/indexes/IndexStats.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/indexes/indexkey.h
+++ b/src/ee/indexes/indexkey.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/tableindex.cpp
+++ b/src/ee/indexes/tableindex.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/tableindex.h
+++ b/src/ee/indexes/tableindex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/tableindexfactory.cpp
+++ b/src/ee/indexes/tableindexfactory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/indexes/tableindexfactory.h
+++ b/src/ee/indexes/tableindexfactory.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/logging/JNILogProxy.cpp
+++ b/src/ee/logging/JNILogProxy.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/JNILogProxy.h
+++ b/src/ee/logging/JNILogProxy.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/LogDefs.h
+++ b/src/ee/logging/LogDefs.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/LogManager.cpp
+++ b/src/ee/logging/LogManager.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/LogManager.h
+++ b/src/ee/logging/LogManager.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/LogProxy.h
+++ b/src/ee/logging/LogProxy.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/Logger.h
+++ b/src/ee/logging/Logger.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/logging/StdoutLogProxy.h
+++ b/src/ee/logging/StdoutLogProxy.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/SchemaColumn.cpp
+++ b/src/ee/plannodes/SchemaColumn.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/SchemaColumn.h
+++ b/src/ee/plannodes/SchemaColumn.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/abstractjoinnode.cpp
+++ b/src/ee/plannodes/abstractjoinnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractjoinnode.h
+++ b/src/ee/plannodes/abstractjoinnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractoperationnode.cpp
+++ b/src/ee/plannodes/abstractoperationnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractoperationnode.h
+++ b/src/ee/plannodes/abstractoperationnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractplannode.cpp
+++ b/src/ee/plannodes/abstractplannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractplannode.h
+++ b/src/ee/plannodes/abstractplannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractreceivenode.cpp
+++ b/src/ee/plannodes/abstractreceivenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractreceivenode.h
+++ b/src/ee/plannodes/abstractreceivenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractscannode.cpp
+++ b/src/ee/plannodes/abstractscannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/abstractscannode.h
+++ b/src/ee/plannodes/abstractscannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/aggregatenode.cpp
+++ b/src/ee/plannodes/aggregatenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/aggregatenode.h
+++ b/src/ee/plannodes/aggregatenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/commontablenode.cpp
+++ b/src/ee/plannodes/commontablenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/commontablenode.h
+++ b/src/ee/plannodes/commontablenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/deletenode.cpp
+++ b/src/ee/plannodes/deletenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/deletenode.h
+++ b/src/ee/plannodes/deletenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/indexcountnode.cpp
+++ b/src/ee/plannodes/indexcountnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/indexcountnode.h
+++ b/src/ee/plannodes/indexcountnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/indexscannode.cpp
+++ b/src/ee/plannodes/indexscannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/indexscannode.h
+++ b/src/ee/plannodes/indexscannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/insertnode.cpp
+++ b/src/ee/plannodes/insertnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/insertnode.h
+++ b/src/ee/plannodes/insertnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/limitnode.cpp
+++ b/src/ee/plannodes/limitnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/limitnode.h
+++ b/src/ee/plannodes/limitnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/materializedscanplannode.cpp
+++ b/src/ee/plannodes/materializedscanplannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/materializedscanplannode.h
+++ b/src/ee/plannodes/materializedscanplannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/materializenode.cpp
+++ b/src/ee/plannodes/materializenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/materializenode.h
+++ b/src/ee/plannodes/materializenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/mergejoinnode.cpp
+++ b/src/ee/plannodes/mergejoinnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/mergejoinnode.h
+++ b/src/ee/plannodes/mergejoinnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/mergereceivenode.cpp
+++ b/src/ee/plannodes/mergereceivenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/mergereceivenode.h
+++ b/src/ee/plannodes/mergereceivenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/migratenode.cpp
+++ b/src/ee/plannodes/migratenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/migratenode.h
+++ b/src/ee/plannodes/migratenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/nestloopindexnode.cpp
+++ b/src/ee/plannodes/nestloopindexnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/nestloopindexnode.h
+++ b/src/ee/plannodes/nestloopindexnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/nestloopnode.cpp
+++ b/src/ee/plannodes/nestloopnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/nestloopnode.h
+++ b/src/ee/plannodes/nestloopnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/orderbynode.cpp
+++ b/src/ee/plannodes/orderbynode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/orderbynode.h
+++ b/src/ee/plannodes/orderbynode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/plannodefragment.cpp
+++ b/src/ee/plannodes/plannodefragment.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/plannodefragment.h
+++ b/src/ee/plannodes/plannodefragment.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/plannodeutil.cpp
+++ b/src/ee/plannodes/plannodeutil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/plannodeutil.h
+++ b/src/ee/plannodes/plannodeutil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/projectionnode.cpp
+++ b/src/ee/plannodes/projectionnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/projectionnode.h
+++ b/src/ee/plannodes/projectionnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/receivenode.cpp
+++ b/src/ee/plannodes/receivenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/receivenode.h
+++ b/src/ee/plannodes/receivenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/sendnode.cpp
+++ b/src/ee/plannodes/sendnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/sendnode.h
+++ b/src/ee/plannodes/sendnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/seqscannode.cpp
+++ b/src/ee/plannodes/seqscannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/seqscannode.h
+++ b/src/ee/plannodes/seqscannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/swaptablesnode.cpp
+++ b/src/ee/plannodes/swaptablesnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/swaptablesnode.h
+++ b/src/ee/plannodes/swaptablesnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/tablecountnode.cpp
+++ b/src/ee/plannodes/tablecountnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/tablecountnode.h
+++ b/src/ee/plannodes/tablecountnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/tuplescannode.cpp
+++ b/src/ee/plannodes/tuplescannode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/tuplescannode.h
+++ b/src/ee/plannodes/tuplescannode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/unionnode.cpp
+++ b/src/ee/plannodes/unionnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/unionnode.h
+++ b/src/ee/plannodes/unionnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/updatenode.cpp
+++ b/src/ee/plannodes/updatenode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/updatenode.h
+++ b/src/ee/plannodes/updatenode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/plannodes/windowfunctionnode.cpp
+++ b/src/ee/plannodes/windowfunctionnode.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/plannodes/windowfunctionnode.h
+++ b/src/ee/plannodes/windowfunctionnode.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/stats/StatsAgent.h
+++ b/src/ee/stats/StatsAgent.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/stats/StatsSource.cpp
+++ b/src/ee/stats/StatsSource.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/stats/StatsSource.h
+++ b/src/ee/stats/StatsSource.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/AbstractDRTupleStream.cpp
+++ b/src/ee/storage/AbstractDRTupleStream.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/AbstractTempTable.hpp
+++ b/src/ee/storage/AbstractTempTable.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/BinaryLogSinkWrapper.cpp
+++ b/src/ee/storage/BinaryLogSinkWrapper.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/BinaryLogSinkWrapper.h
+++ b/src/ee/storage/BinaryLogSinkWrapper.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ConstraintFailureException.cpp
+++ b/src/ee/storage/ConstraintFailureException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ConstraintFailureException.h
+++ b/src/ee/storage/ConstraintFailureException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/CopyOnWriteContext.h
+++ b/src/ee/storage/CopyOnWriteContext.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/CopyOnWriteIterator.cpp
+++ b/src/ee/storage/CopyOnWriteIterator.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/CopyOnWriteIterator.h
+++ b/src/ee/storage/CopyOnWriteIterator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/DRTableNotFoundException.cpp
+++ b/src/ee/storage/DRTableNotFoundException.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/DRTableNotFoundException.h
+++ b/src/ee/storage/DRTableNotFoundException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/DRTupleStream.cpp
+++ b/src/ee/storage/DRTupleStream.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/DRTupleStream.h
+++ b/src/ee/storage/DRTupleStream.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/DRTupleStreamUndoAction.h
+++ b/src/ee/storage/DRTupleStreamUndoAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticContext.cpp
+++ b/src/ee/storage/ElasticContext.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticContext.h
+++ b/src/ee/storage/ElasticContext.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticIndex.cpp
+++ b/src/ee/storage/ElasticIndex.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticIndex.h
+++ b/src/ee/storage/ElasticIndex.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticIndexReadContext.cpp
+++ b/src/ee/storage/ElasticIndexReadContext.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticIndexReadContext.h
+++ b/src/ee/storage/ElasticIndexReadContext.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticScanner.cpp
+++ b/src/ee/storage/ElasticScanner.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ElasticScanner.h
+++ b/src/ee/storage/ElasticScanner.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ExecuteTaskUndoGenerateDREventAction.h
+++ b/src/ee/storage/ExecuteTaskUndoGenerateDREventAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/LargeTempTable.cpp
+++ b/src/ee/storage/LargeTempTable.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/LargeTempTable.h
+++ b/src/ee/storage/LargeTempTable.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/LargeTempTableBlock.cpp
+++ b/src/ee/storage/LargeTempTableBlock.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/LargeTempTableBlock.h
+++ b/src/ee/storage/LargeTempTableBlock.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewHandler.cpp
+++ b/src/ee/storage/MaterializedViewHandler.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewHandler.h
+++ b/src/ee/storage/MaterializedViewHandler.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewTriggerForInsert.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewTriggerForInsert.h
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewTriggerForWrite.cpp
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/MaterializedViewTriggerForWrite.h
+++ b/src/ee/storage/MaterializedViewTriggerForWrite.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableStats.cpp
+++ b/src/ee/storage/PersistentTableStats.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableStats.h
+++ b/src/ee/storage/PersistentTableStats.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableUndoDeleteAction.h
+++ b/src/ee/storage/PersistentTableUndoDeleteAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableUndoInsertAction.h
+++ b/src/ee/storage/PersistentTableUndoInsertAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableUndoSwapTableAction.h
+++ b/src/ee/storage/PersistentTableUndoSwapTableAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableUndoTruncateTableAction.h
+++ b/src/ee/storage/PersistentTableUndoTruncateTableAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/PersistentTableUndoUpdateAction.h
+++ b/src/ee/storage/PersistentTableUndoUpdateAction.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/StreamedTableStats.cpp
+++ b/src/ee/storage/StreamedTableStats.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/StreamedTableStats.h
+++ b/src/ee/storage/StreamedTableStats.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/StreamedTableUndoAction.hpp
+++ b/src/ee/storage/StreamedTableUndoAction.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableCatalogDelegate.hpp
+++ b/src/ee/storage/TableCatalogDelegate.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStats.cpp
+++ b/src/ee/storage/TableStats.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStats.h
+++ b/src/ee/storage/TableStats.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStreamer.cpp
+++ b/src/ee/storage/TableStreamer.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStreamer.h
+++ b/src/ee/storage/TableStreamer.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStreamerContext.cpp
+++ b/src/ee/storage/TableStreamerContext.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableStreamerInterface.h
+++ b/src/ee/storage/TableStreamerInterface.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TempTableLimits.cpp
+++ b/src/ee/storage/TempTableLimits.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TempTableLimits.h
+++ b/src/ee/storage/TempTableLimits.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TupleBlock.cpp
+++ b/src/ee/storage/TupleBlock.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TupleBlock.h
+++ b/src/ee/storage/TupleBlock.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TupleIterator.h
+++ b/src/ee/storage/TupleIterator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TupleStreamBase.h
+++ b/src/ee/storage/TupleStreamBase.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/TupleStreamException.h
+++ b/src/ee/storage/TupleStreamException.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/constraintutil.cpp
+++ b/src/ee/storage/constraintutil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/constraintutil.h
+++ b/src/ee/storage/constraintutil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/storage/table.cpp
+++ b/src/ee/storage/table.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tablefactory.h
+++ b/src/ee/storage/tablefactory.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tableiterator.h
+++ b/src/ee/storage/tableiterator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tabletuplefilter.cpp
+++ b/src/ee/storage/tabletuplefilter.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tabletuplefilter.h
+++ b/src/ee/storage/tabletuplefilter.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tableutil.cpp
+++ b/src/ee/storage/tableutil.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/tableutil.h
+++ b/src/ee/storage/tableutil.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/temptable.cpp
+++ b/src/ee/storage/temptable.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/ee/structures/CompactingHashTable.h
+++ b/src/ee/structures/CompactingHashTable.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/CompactingPool.cpp
+++ b/src/ee/structures/CompactingPool.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/CompactingPool.h
+++ b/src/ee/structures/CompactingPool.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/CompactingSet.h
+++ b/src/ee/structures/CompactingSet.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/ContiguousAllocator.cpp
+++ b/src/ee/structures/ContiguousAllocator.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/structures/ContiguousAllocator.h
+++ b/src/ee/structures/ContiguousAllocator.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/frontend/org/apache/calcite/sql/ddl/SqlColumnDeclarationWithExpression.java
+++ b/src/frontend/org/apache/calcite/sql/ddl/SqlColumnDeclarationWithExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/apache/calcite/sql/dialect/VoltSqlDialect.java
+++ b/src/frontend/org/apache/calcite/sql/dialect/VoltSqlDialect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/TransactionIdManager.java
+++ b/src/frontend/org/voltcore/TransactionIdManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/AgreementSeeker.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSeeker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/AgreementSite.java
+++ b/src/frontend/org/voltcore/agreement/AgreementSite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/AgreementTxnIdSafetyState.java
+++ b/src/frontend/org/voltcore/agreement/AgreementTxnIdSafetyState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/ArbitrationStrategy.java
+++ b/src/frontend/org/voltcore/agreement/ArbitrationStrategy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/DtxnConstants.java
+++ b/src/frontend/org/voltcore/agreement/DtxnConstants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/InterfaceToMessenger.java
+++ b/src/frontend/org/voltcore/agreement/InterfaceToMessenger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/MeshAide.java
+++ b/src/frontend/org/voltcore/agreement/MeshAide.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/MeshArbiter.java
+++ b/src/frontend/org/voltcore/agreement/MeshArbiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/OrderableTransaction.java
+++ b/src/frontend/org/voltcore/agreement/OrderableTransaction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/agreement/RestrictedPriorityQueue.java
+++ b/src/frontend/org/voltcore/agreement/RestrictedPriorityQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/common/Constants.java
+++ b/src/frontend/org/voltcore/common/Constants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/logging/Level.java
+++ b/src/frontend/org/voltcore/logging/Level.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/logging/VoltLog4jLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltLog4jLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/logging/VoltLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/logging/VoltNullLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltNullLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/logging/VoltUtilLoggingLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltUtilLoggingLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/AgreementTaskMessage.java
+++ b/src/frontend/org/voltcore/messaging/AgreementTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/BinaryPayloadMessage.java
+++ b/src/frontend/org/voltcore/messaging/BinaryPayloadMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/DisconnectFailedHostsCallback.java
+++ b/src/frontend/org/voltcore/messaging/DisconnectFailedHostsCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/FaultMessage.java
+++ b/src/frontend/org/voltcore/messaging/FaultMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/ForeignHost.java
+++ b/src/frontend/org/voltcore/messaging/ForeignHost.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/HeartbeatMessage.java
+++ b/src/frontend/org/voltcore/messaging/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/HeartbeatResponseMessage.java
+++ b/src/frontend/org/voltcore/messaging/HeartbeatResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/HostMessenger.java
+++ b/src/frontend/org/voltcore/messaging/HostMessenger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/JoinAcceptor.java
+++ b/src/frontend/org/voltcore/messaging/JoinAcceptor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/LocalObjectMessage.java
+++ b/src/frontend/org/voltcore/messaging/LocalObjectMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/Mailbox.java
+++ b/src/frontend/org/voltcore/messaging/Mailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/RecoveryMessage.java
+++ b/src/frontend/org/voltcore/messaging/RecoveryMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/RecoveryMessageType.java
+++ b/src/frontend/org/voltcore/messaging/RecoveryMessageType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/SiteFailureForwardMessage.java
+++ b/src/frontend/org/voltcore/messaging/SiteFailureForwardMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/SiteFailureMessage.java
+++ b/src/frontend/org/voltcore/messaging/SiteFailureMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/SiteMailbox.java
+++ b/src/frontend/org/voltcore/messaging/SiteMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/Subconnection.java
+++ b/src/frontend/org/voltcore/messaging/Subconnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/Subject.java
+++ b/src/frontend/org/voltcore/messaging/Subject.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/TransactionInfoBaseMessage.java
+++ b/src/frontend/org/voltcore/messaging/TransactionInfoBaseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/VoltMessage.java
+++ b/src/frontend/org/voltcore/messaging/VoltMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/messaging/VoltMessageFactory.java
+++ b/src/frontend/org/voltcore/messaging/VoltMessageFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/CipherExecutor.java
+++ b/src/frontend/org/voltcore/network/CipherExecutor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/Connection.java
+++ b/src/frontend/org/voltcore/network/Connection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/InputHandler.java
+++ b/src/frontend/org/voltcore/network/InputHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/NIOReadStream.java
+++ b/src/frontend/org/voltcore/network/NIOReadStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/frontend/org/voltcore/network/NIOWriteStreamBase.java
+++ b/src/frontend/org/voltcore/network/NIOWriteStreamBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/NetworkDBBPool.java
+++ b/src/frontend/org/voltcore/network/NetworkDBBPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/PicoNIOWriteStream.java
+++ b/src/frontend/org/voltcore/network/PicoNIOWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following
@@ -43,7 +43,7 @@
  */
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/QueueMonitor.java
+++ b/src/frontend/org/voltcore/network/QueueMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/ReverseDNSCache.java
+++ b/src/frontend/org/voltcore/network/ReverseDNSCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/ReverseDNSPolicy.java
+++ b/src/frontend/org/voltcore/network/ReverseDNSPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/TLSDecryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSDecryptionAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
+++ b/src/frontend/org/voltcore/network/TLSEncryptionAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/TLSException.java
+++ b/src/frontend/org/voltcore/network/TLSException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/TLSPicoNIOWriteStream.java
+++ b/src/frontend/org/voltcore/network/TLSPicoNIOWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/TLSPicoNetwork.java
+++ b/src/frontend/org/voltcore/network/TLSPicoNetwork.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/frontend/org/voltcore/network/TLSVoltPort.java
+++ b/src/frontend/org/voltcore/network/TLSVoltPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltNIOWriteStream.java
+++ b/src/frontend/org/voltcore/network/VoltNIOWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltNetwork.java
+++ b/src/frontend/org/voltcore/network/VoltNetwork.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following
@@ -43,7 +43,7 @@
  */
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltNetworkPool.java
+++ b/src/frontend/org/voltcore/network/VoltNetworkPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltPort.java
+++ b/src/frontend/org/voltcore/network/VoltPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltPortFactory.java
+++ b/src/frontend/org/voltcore/network/VoltPortFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltProtocolHandler.java
+++ b/src/frontend/org/voltcore/network/VoltProtocolHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/VoltTLSNIOWriteStream.java
+++ b/src/frontend/org/voltcore/network/VoltTLSNIOWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/network/WriteStream.java
+++ b/src/frontend/org/voltcore/network/WriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/Bits.java
+++ b/src/frontend/org/voltcore/utils/Bits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ByteBufferInputStream.java
+++ b/src/frontend/org/voltcore/utils/ByteBufferInputStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ByteBufferOutputStream.java
+++ b/src/frontend/org/voltcore/utils/ByteBufferOutputStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/COWMap.java
+++ b/src/frontend/org/voltcore/utils/COWMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/COWNavigableSet.java
+++ b/src/frontend/org/voltcore/utils/COWNavigableSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/COWSortedMap.java
+++ b/src/frontend/org/voltcore/utils/COWSortedMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/CompressionStrategy.java
+++ b/src/frontend/org/voltcore/utils/CompressionStrategy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/CompressionStrategySnappy.java
+++ b/src/frontend/org/voltcore/utils/CompressionStrategySnappy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/CoreUtils.java
+++ b/src/frontend/org/voltcore/utils/CoreUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/DBBPool.java.template
+++ b/src/frontend/org/voltcore/utils/DBBPool.java.template
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/DeferredSerialization.java
+++ b/src/frontend/org/voltcore/utils/DeferredSerialization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/DirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/DirectBufferCleaner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/EstTime.java
+++ b/src/frontend/org/voltcore/utils/EstTime.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/EstTimeUpdater.java
+++ b/src/frontend/org/voltcore/utils/EstTimeUpdater.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/FlexibleSemaphore.java
+++ b/src/frontend/org/voltcore/utils/FlexibleSemaphore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/InstanceId.java
+++ b/src/frontend/org/voltcore/utils/InstanceId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/LatencyWatchdog.java
+++ b/src/frontend/org/voltcore/utils/LatencyWatchdog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/OnDemandBinaryLogger.java
+++ b/src/frontend/org/voltcore/utils/OnDemandBinaryLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/Pair.java
+++ b/src/frontend/org/voltcore/utils/Pair.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/PortGenerator.java
+++ b/src/frontend/org/voltcore/utils/PortGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/Punycode.java
+++ b/src/frontend/org/voltcore/utils/Punycode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/RateLimitedLogger.java
+++ b/src/frontend/org/voltcore/utils/RateLimitedLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ReflectiveDirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/ReflectiveDirectBufferCleaner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ShutdownHooks.java
+++ b/src/frontend/org/voltcore/utils/ShutdownHooks.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/UnsafeDirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/UnsafeDirectBufferCleaner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/VersionChecker.java
+++ b/src/frontend/org/voltcore/utils/VersionChecker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/VoltUnsafe.java
+++ b/src/frontend/org/voltcore/utils/VoltUnsafe.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ssl/MessagingChannel.java
+++ b/src/frontend/org/voltcore/utils/ssl/MessagingChannel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ssl/SSLBufferDecrypter.java
+++ b/src/frontend/org/voltcore/utils/ssl/SSLBufferDecrypter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ssl/SSLBufferEncrypter.java
+++ b/src/frontend/org/voltcore/utils/ssl/SSLBufferEncrypter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ssl/SSLConfiguration.java
+++ b/src/frontend/org/voltcore/utils/ssl/SSLConfiguration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/utils/ssl/TLSMessagingChannel.java
+++ b/src/frontend/org/voltcore/utils/ssl/TLSMessagingChannel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/BabySitter.java
+++ b/src/frontend/org/voltcore/zk/BabySitter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/CoreZK.java
+++ b/src/frontend/org/voltcore/zk/CoreZK.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/LeaderElector.java
+++ b/src/frontend/org/voltcore/zk/LeaderElector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/LeaderNoticeHandler.java
+++ b/src/frontend/org/voltcore/zk/LeaderNoticeHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/MapCache.java
+++ b/src/frontend/org/voltcore/zk/MapCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/MapCacheReader.java
+++ b/src/frontend/org/voltcore/zk/MapCacheReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/MapCacheWriter.java
+++ b/src/frontend/org/voltcore/zk/MapCacheWriter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/ZKCountdownLatch.java
+++ b/src/frontend/org/voltcore/zk/ZKCountdownLatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/ZKUtil.java
+++ b/src/frontend/org/voltcore/zk/ZKUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltcore/zk/ZooKeeperLock.java
+++ b/src/frontend/org/voltcore/zk/ZooKeeperLock.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/AbstractTopology.java
+++ b/src/frontend/org/voltdb/AbstractTopology.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/AdHocAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/AdHocAcceptancePolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/AdmissionControlGroup.java
+++ b/src/frontend/org/voltdb/AdmissionControlGroup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/AuthSystem.java
+++ b/src/frontend/org/voltdb/AuthSystem.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/AuthenticationResult.java
+++ b/src/frontend/org/voltdb/AuthenticationResult.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/BackendTarget.java
+++ b/src/frontend/org/voltdb/BackendTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/Buckets.java
+++ b/src/frontend/org/voltdb/Buckets.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CLIConfig.java
+++ b/src/frontend/org/voltdb/CLIConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CSVSnapshotFilter.java
+++ b/src/frontend/org/voltdb/CSVSnapshotFilter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClientAppBase.java
+++ b/src/frontend/org/voltdb/ClientAppBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClientInterface.java
+++ b/src/frontend/org/voltdb/ClientInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClientInterfaceHandleManager.java
+++ b/src/frontend/org/voltdb/ClientInterfaceHandleManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClientInterfaceRepairCallback.java
+++ b/src/frontend/org/voltdb/ClientInterfaceRepairCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ClusterMonitor.java
+++ b/src/frontend/org/voltdb/ClusterMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CommandLogReinitiator.java
+++ b/src/frontend/org/voltdb/CommandLogReinitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CommandLogStats.java
+++ b/src/frontend/org/voltdb/CommandLogStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ConsumerDRGateway.java
+++ b/src/frontend/org/voltdb/ConsumerDRGateway.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CpuStats.java
+++ b/src/frontend/org/voltdb/CpuStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/CreateTransactionResult.java
+++ b/src/frontend/org/voltdb/CreateTransactionResult.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRConflictManager.java
+++ b/src/frontend/org/voltdb/DRConflictManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
+++ b/src/frontend/org/voltdb/DRConsumerDrIdTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRConsumerMpCoordinator.java
+++ b/src/frontend/org/voltdb/DRConsumerMpCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRIdempotencyResult.java
+++ b/src/frontend/org/voltdb/DRIdempotencyResult.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRLogSegmentId.java
+++ b/src/frontend/org/voltdb/DRLogSegmentId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRRoleStats.java
+++ b/src/frontend/org/voltdb/DRRoleStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DRSequenceId.java
+++ b/src/frontend/org/voltdb/DRSequenceId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DefaultCommandLogReinitiator.java
+++ b/src/frontend/org/voltdb/DefaultCommandLogReinitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DefaultProcedureManager.java
+++ b/src/frontend/org/voltdb/DefaultProcedureManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DeferredSnapshotSetup.java
+++ b/src/frontend/org/voltdb/DeferredSnapshotSetup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DependencyPair.java
+++ b/src/frontend/org/voltdb/DependencyPair.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DeprecatedProcedureAPIAccess.java
+++ b/src/frontend/org/voltdb/DeprecatedProcedureAPIAccess.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DevNullSnapshotTarget.java
+++ b/src/frontend/org/voltdb/DevNullSnapshotTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DiskResourceChecker.java
+++ b/src/frontend/org/voltdb/DiskResourceChecker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/DummyCommandLog.java
+++ b/src/frontend/org/voltdb/DummyCommandLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ElasticHashinator.java
+++ b/src/frontend/org/voltdb/ElasticHashinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/EnterpriseMaintenance.java
+++ b/src/frontend/org/voltdb/EnterpriseMaintenance.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/Expectation.java
+++ b/src/frontend/org/voltdb/Expectation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ExpectedProcedureException.java
+++ b/src/frontend/org/voltdb/ExpectedProcedureException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ExportStatsBase.java
+++ b/src/frontend/org/voltdb/ExportStatsBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
+++ b/src/frontend/org/voltdb/ExtensibleSnapshotDigestData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/FileCheckForTest.java
+++ b/src/frontend/org/voltdb/FileCheckForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/GcStats.java
+++ b/src/frontend/org/voltdb/GcStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/GetActionArgument.java
+++ b/src/frontend/org/voltdb/GetActionArgument.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/GlobalServiceElector.java
+++ b/src/frontend/org/voltdb/GlobalServiceElector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/HTTPClientInterface.java
+++ b/src/frontend/org/voltdb/HTTPClientInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/HealthMonitor.java
+++ b/src/frontend/org/voltdb/HealthMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/HsqlBackend.java
+++ b/src/frontend/org/voltdb/HsqlBackend.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/HybridCrc32.java
+++ b/src/frontend/org/voltdb/HybridCrc32.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/IOStats.java
+++ b/src/frontend/org/voltdb/IOStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
+++ b/src/frontend/org/voltdb/ImporterServerAdapterImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InProcessVoltDBServer.java
+++ b/src/frontend/org/voltdb/InProcessVoltDBServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/IndexStats.java
+++ b/src/frontend/org/voltdb/IndexStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InternalAdapterTaskAttributes.java
+++ b/src/frontend/org/voltdb/InternalAdapterTaskAttributes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InternalClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/InternalClientResponseAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InternalConnectionContext.java
+++ b/src/frontend/org/voltdb/InternalConnectionContext.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InternalConnectionHandler.java
+++ b/src/frontend/org/voltdb/InternalConnectionHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InternalConnectionStatsCollector.java
+++ b/src/frontend/org/voltdb/InternalConnectionStatsCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationClientHandler.java
+++ b/src/frontend/org/voltdb/InvocationClientHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationDefaultProcPermissionPolicy.java
+++ b/src/frontend/org/voltdb/InvocationDefaultProcPermissionPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationDispatcher.java
+++ b/src/frontend/org/voltdb/InvocationDispatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationPermissionPolicy.java
+++ b/src/frontend/org/voltdb/InvocationPermissionPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationSqlPermissionPolicy.java
+++ b/src/frontend/org/voltdb/InvocationSqlPermissionPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationSysprocPermissionPolicy.java
+++ b/src/frontend/org/voltdb/InvocationSysprocPermissionPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationUserDefinedProcedurePermissionPolicy.java
+++ b/src/frontend/org/voltdb/InvocationUserDefinedProcedurePermissionPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationValidationPolicy.java
+++ b/src/frontend/org/voltdb/InvocationValidationPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/InvocationValidator.java
+++ b/src/frontend/org/voltdb/InvocationValidator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/Iv2TransactionCreator.java
+++ b/src/frontend/org/voltdb/Iv2TransactionCreator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/JdbcDatabaseMetaDataGenerator.java
+++ b/src/frontend/org/voltdb/JdbcDatabaseMetaDataGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/LightweightNTClientResponseAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/LiveClientsStats.java
+++ b/src/frontend/org/voltdb/LiveClientsStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/LoadedProcedureSet.java
+++ b/src/frontend/org/voltdb/LoadedProcedureSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/LogEntry.java
+++ b/src/frontend/org/voltdb/LogEntry.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/LogEntryType.java
+++ b/src/frontend/org/voltdb/LogEntryType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/MailboxNodeContent.java
+++ b/src/frontend/org/voltdb/MailboxNodeContent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/MemoryStats.java
+++ b/src/frontend/org/voltdb/MemoryStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/NTProcedureService.java
+++ b/src/frontend/org/voltdb/NTProcedureService.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/NativeLibraryLoader.java
+++ b/src/frontend/org/voltdb/NativeLibraryLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/NodeStateTracker.java
+++ b/src/frontend/org/voltdb/NodeStateTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/NonVoltDBBackend.java
+++ b/src/frontend/org/voltdb/NonVoltDBBackend.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/OperationMode.java
+++ b/src/frontend/org/voltdb/OperationMode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/OpsAgent.java
+++ b/src/frontend/org/voltdb/OpsAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/OpsRegistrar.java
+++ b/src/frontend/org/voltdb/OpsRegistrar.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/OpsSelector.java
+++ b/src/frontend/org/voltdb/OpsSelector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ParameterDeserializationPolicy.java
+++ b/src/frontend/org/voltdb/ParameterDeserializationPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ParameterSet.java
+++ b/src/frontend/org/voltdb/ParameterSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PartitionCountStats.java
+++ b/src/frontend/org/voltdb/PartitionCountStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PartitionProjectionSnapshotFilter.java
+++ b/src/frontend/org/voltdb/PartitionProjectionSnapshotFilter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PermissionValidator.java
+++ b/src/frontend/org/voltdb/PermissionValidator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PlannerStatsCollector.java
+++ b/src/frontend/org/voltdb/PlannerStatsCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PostGISBackend.java
+++ b/src/frontend/org/voltdb/PostGISBackend.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PostSnapshotTask.java
+++ b/src/frontend/org/voltdb/PostSnapshotTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PostgreSQLBackend.java
+++ b/src/frontend/org/voltdb/PostgreSQLBackend.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/PrivateVoltTableFactory.java
+++ b/src/frontend/org/voltdb/PrivateVoltTableFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcStatsOption.java
+++ b/src/frontend/org/voltdb/ProcStatsOption.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcedureDetailResultTable.java
+++ b/src/frontend/org/voltdb/ProcedureDetailResultTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcedurePartitionData.java
+++ b/src/frontend/org/voltdb/ProcedurePartitionData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcedureRunner.java
+++ b/src/frontend/org/voltdb/ProcedureRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcedureRunnerNT.java
+++ b/src/frontend/org/voltdb/ProcedureRunnerNT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProcedureStatsCollector.java
+++ b/src/frontend/org/voltdb/ProcedureStatsCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ProducerDRGateway.java
+++ b/src/frontend/org/voltdb/ProducerDRGateway.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/Promotable.java
+++ b/src/frontend/org/voltdb/Promotable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/QueueDepthTracker.java
+++ b/src/frontend/org/voltdb/QueueDepthTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/RateLimitedClientNotifier.java
+++ b/src/frontend/org/voltdb/RateLimitedClientNotifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/ReplicaInvocationAcceptancePolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ReplicationRole.java
+++ b/src/frontend/org/voltdb/ReplicationRole.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/RestoreAgent.java
+++ b/src/frontend/org/voltdb/RestoreAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SQLStmt.java
+++ b/src/frontend/org/voltdb/SQLStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
+++ b/src/frontend/org/voltdb/SQLStmtAdHocHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/ServerThread.java
+++ b/src/frontend/org/voltdb/ServerThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
+++ b/src/frontend/org/voltdb/SimpleClientResponseAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SiteSnapshotConnection.java
+++ b/src/frontend/org/voltdb/SiteSnapshotConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SiteStatsSource.java
+++ b/src/frontend/org/voltdb/SiteStatsSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotCompletionInterest.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionInterest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
+++ b/src/frontend/org/voltdb/SnapshotCompletionMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotDaemon.java
+++ b/src/frontend/org/voltdb/SnapshotDaemon.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotDataFilter.java
+++ b/src/frontend/org/voltdb/SnapshotDataFilter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotDeleteAgent.java
+++ b/src/frontend/org/voltdb/SnapshotDeleteAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotFormat.java
+++ b/src/frontend/org/voltdb/SnapshotFormat.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotIOAgent.java
+++ b/src/frontend/org/voltdb/SnapshotIOAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotIOAgentImpl.java
+++ b/src/frontend/org/voltdb/SnapshotIOAgentImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotInitiationInfo.java
+++ b/src/frontend/org/voltdb/SnapshotInitiationInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotSaveAPI.java
+++ b/src/frontend/org/voltdb/SnapshotSaveAPI.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotScanAgent.java
+++ b/src/frontend/org/voltdb/SnapshotScanAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SnapshotTableTask.java
+++ b/src/frontend/org/voltdb/SnapshotTableTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StartAction.java
+++ b/src/frontend/org/voltdb/StartAction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StarvationTracker.java
+++ b/src/frontend/org/voltdb/StarvationTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatementStats.java
+++ b/src/frontend/org/voltdb/StatementStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsManager.java
+++ b/src/frontend/org/voltdb/StatsManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsProcInputTable.java
+++ b/src/frontend/org/voltdb/StatsProcInputTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsProcOutputTable.java
+++ b/src/frontend/org/voltdb/StatsProcOutputTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsProcProfTable.java
+++ b/src/frontend/org/voltdb/StatsProcProfTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StatsSource.java
+++ b/src/frontend/org/voltdb/StatsSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/StoredProcedureInvocation.java
+++ b/src/frontend/org/voltdb/StoredProcedureInvocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SystemCatalogAgent.java
+++ b/src/frontend/org/voltdb/SystemCatalogAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SystemInformationAgent.java
+++ b/src/frontend/org/voltdb/SystemInformationAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
+++ b/src/frontend/org/voltdb/SystemProcedureExecutionContext.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TTLManager.java
+++ b/src/frontend/org/voltdb/TTLManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableCompressor.java
+++ b/src/frontend/org/voltdb/TableCompressor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableHelper.java
+++ b/src/frontend/org/voltdb/TableHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableShorthand.java
+++ b/src/frontend/org/voltdb/TableShorthand.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableStats.java
+++ b/src/frontend/org/voltdb/TableStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableStreamType.java
+++ b/src/frontend/org/voltdb/TableStreamType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableStreamer.java
+++ b/src/frontend/org/voltdb/TableStreamer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TableType.java
+++ b/src/frontend/org/voltdb/TableType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TheHashinator.java
+++ b/src/frontend/org/voltdb/TheHashinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TraceAgent.java
+++ b/src/frontend/org/voltdb/TraceAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/TupleStreamStateInfo.java
+++ b/src/frontend/org/voltdb/TupleStreamStateInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UpdateCatalogAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/UpdateCatalogAcceptancePolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UpdateClassesAcceptancePolicy.java
+++ b/src/frontend/org/voltdb/UpdateClassesAcceptancePolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UserDefinedAggregateFunctionRunner.java
+++ b/src/frontend/org/voltdb/UserDefinedAggregateFunctionRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UserDefinedFunctionManager.java
+++ b/src/frontend/org/voltdb/UserDefinedFunctionManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UserDefinedFunctionRunner.java
+++ b/src/frontend/org/voltdb/UserDefinedFunctionRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/UserDefinedScalarFunctionRunner.java
+++ b/src/frontend/org/voltdb/UserDefinedScalarFunctionRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VLog.java
+++ b/src/frontend/org/voltdb/VLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltNTSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltNTSystemProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltNonTransactionalProcedure.java
+++ b/src/frontend/org/voltdb/VoltNonTransactionalProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltOverflowException.java
+++ b/src/frontend/org/voltdb/VoltOverflowException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltProcedure.java
+++ b/src/frontend/org/voltdb/VoltProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltSystemProcedure.java
+++ b/src/frontend/org/voltdb/VoltSystemProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltTableRow.java
+++ b/src/frontend/org/voltdb/VoltTableRow.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltType.java
+++ b/src/frontend/org/voltdb/VoltType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltTypeException.java
+++ b/src/frontend/org/voltdb/VoltTypeException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltUDAggregate.java
+++ b/src/frontend/org/voltdb/VoltUDAggregate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/WorkloadTrace.java
+++ b/src/frontend/org/voltdb/WorkloadTrace.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/catalog/package.html
+++ b/src/frontend/org/voltdb/catalog/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/AbstractProcedureArgumentCacher.java
+++ b/src/frontend/org/voltdb/client/AbstractProcedureArgumentCacher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/AllPartitionProcedureCallback.java
+++ b/src/frontend/org/voltdb/client/AllPartitionProcedureCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/AutoReconnectListener.java
+++ b/src/frontend/org/voltdb/client/AutoReconnectListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/BatchTimeoutOverrideType.java
+++ b/src/frontend/org/voltdb/client/BatchTimeoutOverrideType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/Client.java
+++ b/src/frontend/org/voltdb/client/Client.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientAffinityStats.java
+++ b/src/frontend/org/voltdb/client/ClientAffinityStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientAuthScheme.java
+++ b/src/frontend/org/voltdb/client/ClientAuthScheme.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientConfig.java
+++ b/src/frontend/org/voltdb/client/ClientConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientFactory.java
+++ b/src/frontend/org/voltdb/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientIOStats.java
+++ b/src/frontend/org/voltdb/client/ClientIOStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientImpl.java
+++ b/src/frontend/org/voltdb/client/ClientImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientResponse.java
+++ b/src/frontend/org/voltdb/client/ClientResponse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientResponseWithPartitionKey.java
+++ b/src/frontend/org/voltdb/client/ClientResponseWithPartitionKey.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientStats.java
+++ b/src/frontend/org/voltdb/client/ClientStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientStatsContext.java
+++ b/src/frontend/org/voltdb/client/ClientStatsContext.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientStatusListener.java
+++ b/src/frontend/org/voltdb/client/ClientStatusListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientStatusListenerExt.java
+++ b/src/frontend/org/voltdb/client/ClientStatusListenerExt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientStatusListenerWrapper.java
+++ b/src/frontend/org/voltdb/client/ClientStatusListenerWrapper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ClientUtils.java
+++ b/src/frontend/org/voltdb/client/ClientUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ConnectionUtil.java
+++ b/src/frontend/org/voltdb/client/ConnectionUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/DelegatePrincipal.java
+++ b/src/frontend/org/voltdb/client/DelegatePrincipal.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/Distributer.java
+++ b/src/frontend/org/voltdb/client/Distributer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/HashinatorLite.java
+++ b/src/frontend/org/voltdb/client/HashinatorLite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/NoConnectionsException.java
+++ b/src/frontend/org/voltdb/client/NoConnectionsException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/NullCallback.java
+++ b/src/frontend/org/voltdb/client/NullCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcCallException.java
+++ b/src/frontend/org/voltdb/client/ProcCallException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcedureArgumentCacher.java
+++ b/src/frontend/org/voltdb/client/ProcedureArgumentCacher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcedureCallback.java
+++ b/src/frontend/org/voltdb/client/ProcedureCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcedureInvocation.java
+++ b/src/frontend/org/voltdb/client/ProcedureInvocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcedureInvocationExtensions.java
+++ b/src/frontend/org/voltdb/client/ProcedureInvocationExtensions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ProcedureInvocationType.java
+++ b/src/frontend/org/voltdb/client/ProcedureInvocationType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/RateLimiter.java
+++ b/src/frontend/org/voltdb/client/RateLimiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/ReconnectStatusListener.java
+++ b/src/frontend/org/voltdb/client/ReconnectStatusListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/SyncCallback.java
+++ b/src/frontend/org/voltdb/client/SyncCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/TLSHandshaker.java
+++ b/src/frontend/org/voltdb/client/TLSHandshaker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderFailureCallBack.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderFailureCallBack.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderState.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderSuccessCallback.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/BulkLoaderSuccessCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/PerPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/VoltBulkLoader.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/VoltBulkLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/VoltBulkLoader/VoltBulkLoaderRow.java
+++ b/src/frontend/org/voltdb/client/VoltBulkLoader/VoltBulkLoaderRow.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/AppHelper.java
+++ b/src/frontend/org/voltdb/client/exampleutils/AppHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/ClientConnection.java
+++ b/src/frontend/org/voltdb/client/exampleutils/ClientConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/ClientConnectionPool.java
+++ b/src/frontend/org/voltdb/client/exampleutils/ClientConnectionPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/ExecutionFuture.java
+++ b/src/frontend/org/voltdb/client/exampleutils/ExecutionFuture.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/IRateLimiter.java
+++ b/src/frontend/org/voltdb/client/exampleutils/IRateLimiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/LatencyLimiter.java
+++ b/src/frontend/org/voltdb/client/exampleutils/LatencyLimiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/MathEx.java
+++ b/src/frontend/org/voltdb/client/exampleutils/MathEx.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/PerfCounter.java
+++ b/src/frontend/org/voltdb/client/exampleutils/PerfCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/PerfCounterMap.java
+++ b/src/frontend/org/voltdb/client/exampleutils/PerfCounterMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/exampleutils/RateLimiter.java
+++ b/src/frontend/org/voltdb/client/exampleutils/RateLimiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/client/package.html
+++ b/src/frontend/org/voltdb/client/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/common/Constants.java
+++ b/src/frontend/org/voltdb/common/Constants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/common/NodeState.java
+++ b/src/frontend/org/voltdb/common/NodeState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/common/Permission.java
+++ b/src/frontend/org/voltdb/common/Permission.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/AdHocCompilerCache.java
+++ b/src/frontend/org/voltdb/compiler/AdHocCompilerCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
+++ b/src/frontend/org/voltdb/compiler/AdHocPlannedStatement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/AdHocPlannedStmtBatch.java
+++ b/src/frontend/org/voltdb/compiler/AdHocPlannedStmtBatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/CatalogBuilder.java
+++ b/src/frontend/org/voltdb/compiler/CatalogBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
+++ b/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/ClassMatcher.java
+++ b/src/frontend/org/voltdb/compiler/ClassMatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/CodeBlockCompilerException.java
+++ b/src/frontend/org/voltdb/compiler/CodeBlockCompilerException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/DDLParserCallback.java
+++ b/src/frontend/org/voltdb/compiler/DDLParserCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/DatabaseEstimates.java
+++ b/src/frontend/org/voltdb/compiler/DatabaseEstimates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/DeploymentBuilder.java
+++ b/src/frontend/org/voltdb/compiler/DeploymentBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/DeterminismMode.java
+++ b/src/frontend/org/voltdb/compiler/DeterminismMode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/MatViewFallbackQueryXMLGenerator.java
+++ b/src/frontend/org/voltdb/compiler/MatViewFallbackQueryXMLGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
+++ b/src/frontend/org/voltdb/compiler/MaterializedViewProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/PlannerTool.java
+++ b/src/frontend/org/voltdb/compiler/PlannerTool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
+++ b/src/frontend/org/voltdb/compiler/ProcedureCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/ScalarValueHints.java
+++ b/src/frontend/org/voltdb/compiler/ScalarValueHints.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/SqlPlanner.java
+++ b/src/frontend/org/voltdb/compiler/SqlPlanner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/StatementCompiler.java
+++ b/src/frontend/org/voltdb/compiler/StatementCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompiler.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompilerFileReader.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompilerFileReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompilerJarFileReader.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompilerJarFileReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompilerReader.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompilerReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompilerStringReader.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompilerStringReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltCompilerUtils.java
+++ b/src/frontend/org/voltdb/compiler/VoltCompilerUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltDDLElementTracker.java
+++ b/src/frontend/org/voltdb/compiler/VoltDDLElementTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
+++ b/src/frontend/org/voltdb/compiler/VoltProjectBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/VoltXMLElementHelper.java
+++ b/src/frontend/org/voltdb/compiler/VoltXMLElementHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/package.html
+++ b/src/frontend/org/voltdb/compiler/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CatchAllVoltDBStatement.java
+++ b/src/frontend/org/voltdb/compiler/statements/CatchAllVoltDBStatement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateAggregateFunctionFromClass.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateAggregateFunctionFromClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateFunction.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateFunction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateFunctionFromMethod.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateFunctionFromMethod.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateProcedure.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateProcedureAsSQL.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateProcedureAsSQL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateProcedureAsScript.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateProcedureAsScript.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateProcedureFromClass.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateProcedureFromClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/CreateRole.java
+++ b/src/frontend/org/voltdb/compiler/statements/CreateRole.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DRTable.java
+++ b/src/frontend/org/voltdb/compiler/statements/DRTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DropAggregateFunction.java
+++ b/src/frontend/org/voltdb/compiler/statements/DropAggregateFunction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DropFunction.java
+++ b/src/frontend/org/voltdb/compiler/statements/DropFunction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DropProcedure.java
+++ b/src/frontend/org/voltdb/compiler/statements/DropProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DropRole.java
+++ b/src/frontend/org/voltdb/compiler/statements/DropRole.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/DropStream.java
+++ b/src/frontend/org/voltdb/compiler/statements/DropStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/PartitionStatement.java
+++ b/src/frontend/org/voltdb/compiler/statements/PartitionStatement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/ReplicateTable.java
+++ b/src/frontend/org/voltdb/compiler/statements/ReplicateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/SetGlobalParam.java
+++ b/src/frontend/org/voltdb/compiler/statements/SetGlobalParam.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compiler/statements/VoltDBStatementProcessor.java
+++ b/src/frontend/org/voltdb/compiler/statements/VoltDBStatementProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compilereport/IndexAnnotation.java
+++ b/src/frontend/org/voltdb/compilereport/IndexAnnotation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compilereport/ProcedureAnnotation.java
+++ b/src/frontend/org/voltdb/compilereport/ProcedureAnnotation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compilereport/ReportMaker.java
+++ b/src/frontend/org/voltdb/compilereport/ReportMaker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compilereport/TableAnnotation.java
+++ b/src/frontend/org/voltdb/compilereport/TableAnnotation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/compilereport/ViewExplainer.java
+++ b/src/frontend/org/voltdb/compilereport/ViewExplainer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dbmonitor/index.htm
+++ b/src/frontend/org/voltdb/dbmonitor/index.htm
@@ -1441,7 +1441,7 @@
         </div>
     </div>
     <div class="footer" id="mainFooter">
-        <p>Copyright (C) 2008-2019 VoltDB Inc. All rights reserved. </p>
+        <p>Copyright (C) 2008-2020 VoltDB Inc. All rights reserved. </p>
     </div>
     <!-- POPUP Saved Preferences -->
     <div id="myPreference" style="display: none">

--- a/src/frontend/org/voltdb/dr2/DRIDTrackerHelper.java
+++ b/src/frontend/org/voltdb/dr2/DRIDTrackerHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dr2/DRProtocol.java
+++ b/src/frontend/org/voltdb/dr2/DRProtocol.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/InitiatorStats.java
+++ b/src/frontend/org/voltdb/dtxn/InitiatorStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/LatencyHistogramStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyHistogramStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/LatencyStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/LatencyUncompressedHistogramStats.java
+++ b/src/frontend/org/voltdb/dtxn/LatencyUncompressedHistogramStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/OrderableTransaction.java
+++ b/src/frontend/org/voltdb/dtxn/OrderableTransaction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/SiteTracker.java
+++ b/src/frontend/org/voltdb/dtxn/SiteTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/TransactionCreator.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionCreator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/TransactionInitiator.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionInitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/TransactionState.java
+++ b/src/frontend/org/voltdb/dtxn/TransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/UndoAction.java
+++ b/src/frontend/org/voltdb/dtxn/UndoAction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/dtxn/package.html
+++ b/src/frontend/org/voltdb/dtxn/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
+++ b/src/frontend/org/voltdb/elastic/BalancePartitionsStatistics.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/elastic/ElasticService.java
+++ b/src/frontend/org/voltdb/elastic/ElasticService.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/ConstraintFailureException.java
+++ b/src/frontend/org/voltdb/exceptions/ConstraintFailureException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/DRTableNotFoundException.java
+++ b/src/frontend/org/voltdb/exceptions/DRTableNotFoundException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/EEException.java
+++ b/src/frontend/org/voltdb/exceptions/EEException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/InterruptException.java
+++ b/src/frontend/org/voltdb/exceptions/InterruptException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/MispartitionedException.java
+++ b/src/frontend/org/voltdb/exceptions/MispartitionedException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/PlanningErrorException.java
+++ b/src/frontend/org/voltdb/exceptions/PlanningErrorException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/ReplicatedTableException.java
+++ b/src/frontend/org/voltdb/exceptions/ReplicatedTableException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/SQLException.java
+++ b/src/frontend/org/voltdb/exceptions/SQLException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/SerializableException.java
+++ b/src/frontend/org/voltdb/exceptions/SerializableException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/SpecifiedException.java
+++ b/src/frontend/org/voltdb/exceptions/SpecifiedException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/TransactionRestartException.java
+++ b/src/frontend/org/voltdb/exceptions/TransactionRestartException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/TransactionTerminationException.java
+++ b/src/frontend/org/voltdb/exceptions/TransactionTerminationException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exceptions/ValidationError.java
+++ b/src/frontend/org/voltdb/exceptions/ValidationError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/AckingContainer.java
+++ b/src/frontend/org/voltdb/export/AckingContainer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/AdvertisedDataSource.java
+++ b/src/frontend/org/voltdb/export/AdvertisedDataSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportCoordinator.java
+++ b/src/frontend/org/voltdb/export/ExportCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportDataProcessor.java
+++ b/src/frontend/org/voltdb/export/ExportDataProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportSequenceNumberTracker.java
+++ b/src/frontend/org/voltdb/export/ExportSequenceNumberTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExportStats.java
+++ b/src/frontend/org/voltdb/export/ExportStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/ExporterVersion.java
+++ b/src/frontend/org/voltdb/export/ExporterVersion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/MigrateRowsDeleter.java
+++ b/src/frontend/org/voltdb/export/MigrateRowsDeleter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/StreamBlock.java
+++ b/src/frontend/org/voltdb/export/StreamBlock.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/StreamBlockQueue.java
+++ b/src/frontend/org/voltdb/export/StreamBlockQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/DiscardingExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/DiscardingExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ElasticSearchHttpExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/ElasticSearchHttpExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportClientBase.java
+++ b/src/frontend/org/voltdb/exportclient/ExportClientBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportClientException.java
+++ b/src/frontend/org/voltdb/exportclient/ExportClientException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportClientLogger.java
+++ b/src/frontend/org/voltdb/exportclient/ExportClientLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportDecoderBase.java
+++ b/src/frontend/org/voltdb/exportclient/ExportDecoderBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportEncoder.java
+++ b/src/frontend/org/voltdb/exportclient/ExportEncoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportRowSchema.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRowSchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportRowSchemaSerializer.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRowSchemaSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
+++ b/src/frontend/org/voltdb/exportclient/ExportToFileClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/HttpExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/HttpExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/JDBCExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/JDBCExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/MeasuringNoOpExporter.java
+++ b/src/frontend/org/voltdb/exportclient/MeasuringNoOpExporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/MeasuringNoOpExporterLegacy.java
+++ b/src/frontend/org/voltdb/exportclient/MeasuringNoOpExporterLegacy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/NoOpExporter.java
+++ b/src/frontend/org/voltdb/exportclient/NoOpExporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/RejectingExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/RejectingExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/SocketExporter.java
+++ b/src/frontend/org/voltdb/exportclient/SocketExporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/SocketExporterLegacy.java
+++ b/src/frontend/org/voltdb/exportclient/SocketExporterLegacy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/AvroDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/AvroDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/AvroEntityDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/AvroEntityDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/BatchDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/BatchDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/ByteBufferEntity.java
+++ b/src/frontend/org/voltdb/exportclient/decode/ByteBufferEntity.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/CSVEntityDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/CSVEntityDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/CSVStringDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/CSVStringDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/CSVWriterDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/CSVWriterDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/DecodeType.java
+++ b/src/frontend/org/voltdb/exportclient/decode/DecodeType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/ElasticSearchJsonEntityDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/ElasticSearchJsonEntityDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/EndpointExpander.java
+++ b/src/frontend/org/voltdb/exportclient/decode/EndpointExpander.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/EntityDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/EntityDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/FieldDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/FieldDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/JsonObjectDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/JsonObjectDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/JsonStringDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/JsonStringDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/JsonWriterDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/JsonWriterDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/NVPairsDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/NVPairsDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/RowDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/RowDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/StringArrayDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/StringArrayDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/decode/StringMapDecoder.java
+++ b/src/frontend/org/voltdb/exportclient/decode/StringMapDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/kafka/KafkaExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/kafka/KafkaExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/kafka/KafkaExportException.java
+++ b/src/frontend/org/voltdb/exportclient/kafka/KafkaExportException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportException.java
+++ b/src/frontend/org/voltdb/exportclient/loopback/LoopbackExportException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/AbstractExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractSubqueryExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/AbstractValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/AbstractValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/AggregateExpression.java
+++ b/src/frontend/org/voltdb/expressions/AggregateExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/ComparisonExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConjunctionExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ConstantValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ExpressionUtil.java
+++ b/src/frontend/org/voltdb/expressions/ExpressionUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/FunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/FunctionExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/HashRangeExpression.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/HashRangeExpressionBuilder.java
+++ b/src/frontend/org/voltdb/expressions/HashRangeExpressionBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/InComparisonExpression.java
+++ b/src/frontend/org/voltdb/expressions/InComparisonExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/OperatorExpression.java
+++ b/src/frontend/org/voltdb/expressions/OperatorExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ParameterValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/ScalarValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/TupleAddressExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleAddressExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/TupleValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/TupleValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/VectorValueExpression.java
+++ b/src/frontend/org/voltdb/expressions/VectorValueExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/WindowFunctionExpression.java
+++ b/src/frontend/org/voltdb/expressions/WindowFunctionExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/expressions/package.html
+++ b/src/frontend/org/voltdb/expressions/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/ImportBaseException.java
+++ b/src/frontend/org/voltdb/importclient/ImportBaseException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/BaseKafkaLoaderCLIArguments.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/BaseKafkaLoaderCLIArguments.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/DurableTracker.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/DurableTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/HostAndPort.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/HostAndPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/KafkaCommitPolicy.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/KafkaCommitPolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/KafkaConstants.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/KafkaConstants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/KafkaUtils.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/KafkaUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/PendingWorkTracker.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/PendingWorkTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/ProcedureInvocationCallback.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/ProcedureInvocationCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka/util/SimpleTracker.java
+++ b/src/frontend/org/voltdb/importclient/kafka/util/SimpleTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaConsumerRunner.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaConsumerRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaExternalConsumerRunner.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaExternalConsumerRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaInternalConsumerRunner.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaInternalConsumerRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaLoader.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaLoaderCLIArguments.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaLoaderCLIArguments.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaLoaderConfig.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaLoaderConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporterFactory.java
+++ b/src/frontend/org/voltdb/importclient/kafka10/KafkaStreamImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporter.java
+++ b/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterException.java
+++ b/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterFactory.java
+++ b/src/frontend/org/voltdb/importclient/kinesis/KinesisStreamImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/log4j/Log4jSocketHandlerImporter.java
+++ b/src/frontend/org/voltdb/importclient/log4j/Log4jSocketHandlerImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/log4j/Log4jSocketImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/log4j/Log4jSocketImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/log4j/Log4jSocketImporterFactory.java
+++ b/src/frontend/org/voltdb/importclient/log4j/Log4jSocketImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/PullSocketImporter.java
+++ b/src/frontend/org/voltdb/importclient/socket/PullSocketImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/PullSocketImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/socket/PullSocketImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/PullSocketImporterFactory.java
+++ b/src/frontend/org/voltdb/importclient/socket/PullSocketImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/ServerSocketImporter.java
+++ b/src/frontend/org/voltdb/importclient/socket/ServerSocketImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/ServerSocketImporterConfig.java
+++ b/src/frontend/org/voltdb/importclient/socket/ServerSocketImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importclient/socket/ServerSocketImporterFactory.java
+++ b/src/frontend/org/voltdb/importclient/socket/ServerSocketImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/AbstractImporter.java
+++ b/src/frontend/org/voltdb/importer/AbstractImporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/AbstractImporterFactory.java
+++ b/src/frontend/org/voltdb/importer/AbstractImporterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ChannelAssignment.java
+++ b/src/frontend/org/voltdb/importer/ChannelAssignment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ChannelChangeCallback.java
+++ b/src/frontend/org/voltdb/importer/ChannelChangeCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ChannelDistributer.java
+++ b/src/frontend/org/voltdb/importer/ChannelDistributer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ChannelSpec.java
+++ b/src/frontend/org/voltdb/importer/ChannelSpec.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/CommitTracker.java
+++ b/src/frontend/org/voltdb/importer/CommitTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/DistributerException.java
+++ b/src/frontend/org/voltdb/importer/DistributerException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImportContext.java
+++ b/src/frontend/org/voltdb/importer/ImportContext.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImportDataProcessor.java
+++ b/src/frontend/org/voltdb/importer/ImportDataProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImportManager.java
+++ b/src/frontend/org/voltdb/importer/ImportManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImportProcessor.java
+++ b/src/frontend/org/voltdb/importer/ImportProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterChannelAssignment.java
+++ b/src/frontend/org/voltdb/importer/ImporterChannelAssignment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterConfig.java
+++ b/src/frontend/org/voltdb/importer/ImporterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
+++ b/src/frontend/org/voltdb/importer/ImporterLifeCycleManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterLifecycle.java
+++ b/src/frontend/org/voltdb/importer/ImporterLifecycle.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterLogger.java
+++ b/src/frontend/org/voltdb/importer/ImporterLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
+++ b/src/frontend/org/voltdb/importer/ImporterServerAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
+++ b/src/frontend/org/voltdb/importer/ImporterStatsCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/Invocation.java
+++ b/src/frontend/org/voltdb/importer/Invocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/VersionedOperationMode.java
+++ b/src/frontend/org/voltdb/importer/VersionedOperationMode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/AbstractFormatterFactory.java
+++ b/src/frontend/org/voltdb/importer/formatter/AbstractFormatterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/FormatException.java
+++ b/src/frontend/org/voltdb/importer/formatter/FormatException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/Formatter.java
+++ b/src/frontend/org/voltdb/importer/formatter/Formatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/FormatterBuilder.java
+++ b/src/frontend/org/voltdb/importer/formatter/FormatterBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/builtin/VoltCSVFormatter.java
+++ b/src/frontend/org/voltdb/importer/formatter/builtin/VoltCSVFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/builtin/VoltCSVFormatterFactory.java
+++ b/src/frontend/org/voltdb/importer/formatter/builtin/VoltCSVFormatterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/formatter/builtin/VoltSuperCSVFormatter.java
+++ b/src/frontend/org/voltdb/importer/formatter/builtin/VoltSuperCSVFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/importer/package.html
+++ b/src/frontend/org/voltdb/importer/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/BaseInitiator.java
+++ b/src/frontend/org/voltdb/iv2/BaseInitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/BorrowTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/BorrowTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/BorrowedTask.java
+++ b/src/frontend/org/voltdb/iv2/BorrowedTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/BufferedReadLog.java
+++ b/src/frontend/org/voltdb/iv2/BufferedReadLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Cartographer.java
+++ b/src/frontend/org/voltdb/iv2/Cartographer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/CompleteTransactionTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/DeterminismHash.java
+++ b/src/frontend/org/voltdb/iv2/DeterminismHash.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/DummyTransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/DummyTransactionTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/DuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/DuplicateCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/ElasticJoinProducer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/EveryPartTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/EveryPartTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/EveryPartitionTask.java
+++ b/src/frontend/org/voltdb/iv2/EveryPartitionTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/FragmentTaskBase.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTaskBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Initiator.java
+++ b/src/frontend/org/voltdb/iv2/Initiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/InitiatorLeaderMonitor.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorLeaderMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/InitiatorMessageHandler.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMessageHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Iv2Trace.java
+++ b/src/frontend/org/voltdb/iv2/Iv2Trace.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/JoinProducerBase.java
+++ b/src/frontend/org/voltdb/iv2/JoinProducerBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/KSafetyStats.java
+++ b/src/frontend/org/voltdb/iv2/KSafetyStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/LeaderAppointer.java
+++ b/src/frontend/org/voltdb/iv2/LeaderAppointer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/LeaderCache.java
+++ b/src/frontend/org/voltdb/iv2/LeaderCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/LeaderCacheReader.java
+++ b/src/frontend/org/voltdb/iv2/LeaderCacheReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/LeaderCacheWriter.java
+++ b/src/frontend/org/voltdb/iv2/LeaderCacheWriter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MPIEndOfLogTask.java
+++ b/src/frontend/org/voltdb/iv2/MPIEndOfLogTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MPIEndOfLogTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MPIEndOfLogTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MigratePartitionLeaderInfo.java
+++ b/src/frontend/org/voltdb/iv2/MigratePartitionLeaderInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/MpProcedureTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
+++ b/src/frontend/org/voltdb/iv2/MpRestartSequenceGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpRoSitePool.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSitePool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpTerm.java
+++ b/src/frontend/org/voltdb/iv2/MpTerm.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/MpTransactionTaskQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/ParticipantTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/ParticipantTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/ProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/ProcedureTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/RepairAlgo.java
+++ b/src/frontend/org/voltdb/iv2/RepairAlgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/ReplaySequencer.java
+++ b/src/frontend/org/voltdb/iv2/ReplaySequencer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Scheduler.java
+++ b/src/frontend/org/voltdb/iv2/Scheduler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SiteTasker.java
+++ b/src/frontend/org/voltdb/iv2/SiteTasker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
+++ b/src/frontend/org/voltdb/iv2/SiteTaskerQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SnapshotTask.java
+++ b/src/frontend/org/voltdb/iv2/SnapshotTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
+++ b/src/frontend/org/voltdb/iv2/SpDurabilityListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpInitiator.java
+++ b/src/frontend/org/voltdb/iv2/SpInitiator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpProcedureTask.java
+++ b/src/frontend/org/voltdb/iv2/SpProcedureTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/SpScheduler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpTerm.java
+++ b/src/frontend/org/voltdb/iv2/SpTerm.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SpTransactionState.java
+++ b/src/frontend/org/voltdb/iv2/SpTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SysprocBorrowedTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocBorrowedTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/Term.java
+++ b/src/frontend/org/voltdb/iv2/Term.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/TickProducer.java
+++ b/src/frontend/org/voltdb/iv2/TickProducer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/TransactionCommitInterest.java
+++ b/src/frontend/org/voltdb/iv2/TransactionCommitInterest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTaskQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/TxnEgo.java
+++ b/src/frontend/org/voltdb/iv2/TxnEgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/iv2/UniqueIdGenerator.java
+++ b/src/frontend/org/voltdb/iv2/UniqueIdGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/Driver.java
+++ b/src/frontend/org/voltdb/jdbc/Driver.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/IVoltDBConnection.java
+++ b/src/frontend/org/voltdb/jdbc/IVoltDBConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4CallableStatement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4CallableStatement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ClientConnectionPool.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ClientConnectionPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Connection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4DatabaseMetaData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ExecutionFuture.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ExecutionFuture.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4NClob.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4NClob.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ParameterMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ParameterMetaData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4PreparedStatement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4PreparedStatement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ResultSet.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ResultSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4ResultSetMetaData.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4ResultSetMetaData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
+++ b/src/frontend/org/voltdb/jdbc/JDBC4Statement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/Resources.java
+++ b/src/frontend/org/voltdb/jdbc/Resources.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jdbc/SQLError.java
+++ b/src/frontend/org/voltdb/jdbc/SQLError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/EELoggers.java
+++ b/src/frontend/org/voltdb/jni/EELoggers.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/Sha1Wrapper.java
+++ b/src/frontend/org/voltdb/jni/Sha1Wrapper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/jni/package.html
+++ b/src/frontend/org/voltdb/jni/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/largequery/BlockId.java
+++ b/src/frontend/org/voltdb/largequery/BlockId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/largequery/LargeBlockManager.java
+++ b/src/frontend/org/voltdb/largequery/LargeBlockManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/largequery/LargeBlockResponse.java
+++ b/src/frontend/org/voltdb/largequery/LargeBlockResponse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/largequery/LargeBlockTask.java
+++ b/src/frontend/org/voltdb/largequery/LargeBlockTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/licensetool/LicenseApi.java
+++ b/src/frontend/org/voltdb/licensetool/LicenseApi.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/licensetool/LicenseException.java
+++ b/src/frontend/org/voltdb/licensetool/LicenseException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/BorrowTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/BorrowTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/CoalescedHeartbeatMessage.java
+++ b/src/frontend/org/voltdb/messaging/CoalescedHeartbeatMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Dr2MultipartTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/DummyTransactionResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/DummyTransactionResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/DummyTransactionTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/DumpMessage.java
+++ b/src/frontend/org/voltdb/messaging/DumpMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/DumpPlanThenExitMessage.java
+++ b/src/frontend/org/voltdb/messaging/DumpPlanThenExitMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/FastDeserializer.java
+++ b/src/frontend/org/voltdb/messaging/FastDeserializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/FastSerializable.java
+++ b/src/frontend/org/voltdb/messaging/FastSerializable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/FastSerializer.java
+++ b/src/frontend/org/voltdb/messaging/FastSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/FragmentTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/HashMismatchMessage.java
+++ b/src/frontend/org/voltdb/messaging/HashMismatchMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/InitiateResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/InitiateTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/InitiateTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Iv2EndOfLogMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2EndOfLogMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2InitiateTaskMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Iv2LogFaultMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2LogFaultMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Iv2RepairLogRequestMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2RepairLogRequestMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/Iv2RepairLogResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/Iv2RepairLogResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/LocalMailbox.java
+++ b/src/frontend/org/voltdb/messaging/LocalMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/MPBacklogFlushMessage.java
+++ b/src/frontend/org/voltdb/messaging/MPBacklogFlushMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/MigratePartitionLeaderMessage.java
+++ b/src/frontend/org/voltdb/messaging/MigratePartitionLeaderMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/MpReplayAckMessage.java
+++ b/src/frontend/org/voltdb/messaging/MpReplayAckMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/MpReplayMessage.java
+++ b/src/frontend/org/voltdb/messaging/MpReplayMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/MultiPartitionParticipantMessage.java
+++ b/src/frontend/org/voltdb/messaging/MultiPartitionParticipantMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/RejoinMessage.java
+++ b/src/frontend/org/voltdb/messaging/RejoinMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/RepairLogTruncationMessage.java
+++ b/src/frontend/org/voltdb/messaging/RepairLogTruncationMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/SnapshotCheckRequestMessage.java
+++ b/src/frontend/org/voltdb/messaging/SnapshotCheckRequestMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/SnapshotCheckResponseMessage.java
+++ b/src/frontend/org/voltdb/messaging/SnapshotCheckResponseMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
+++ b/src/frontend/org/voltdb/messaging/VoltDbMessageFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/messaging/package.html
+++ b/src/frontend/org/voltdb/messaging/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/modular/ModularException.java
+++ b/src/frontend/org/voltdb/modular/ModularException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/modular/ModuleManager.java
+++ b/src/frontend/org/voltdb/modular/ModuleManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/package.html
+++ b/src/frontend/org/voltdb/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/HSQLLexer.java
+++ b/src/frontend/org/voltdb/parser/HSQLLexer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/JDBCParser.java
+++ b/src/frontend/org/voltdb/parser/JDBCParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLLexer.java
+++ b/src/frontend/org/voltdb/parser/SQLLexer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLPatternFactory.java
+++ b/src/frontend/org/voltdb/parser/SQLPatternFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLPatternPart.java
+++ b/src/frontend/org/voltdb/parser/SQLPatternPart.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLPatternPartElement.java
+++ b/src/frontend/org/voltdb/parser/SQLPatternPartElement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/parser/SQLPatternPartString.java
+++ b/src/frontend/org/voltdb/parser/SQLPatternPartString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/AbstractCostModel.java
+++ b/src/frontend/org/voltdb/planner/AbstractCostModel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
+++ b/src/frontend/org/voltdb/planner/AbstractParsedStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/AccessPath.java
+++ b/src/frontend/org/voltdb/planner/AccessPath.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ActivePlanRepository.java
+++ b/src/frontend/org/voltdb/planner/ActivePlanRepository.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/AdHocPlanSet.java
+++ b/src/frontend/org/voltdb/planner/AdHocPlanSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/BoundPlan.java
+++ b/src/frontend/org/voltdb/planner/BoundPlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/CommonTableLeafNode.java
+++ b/src/frontend/org/voltdb/planner/CommonTableLeafNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/CompiledPlan.java
+++ b/src/frontend/org/voltdb/planner/CompiledPlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/CorePlan.java
+++ b/src/frontend/org/voltdb/planner/CorePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ExpressionOrColumn.java
+++ b/src/frontend/org/voltdb/planner/ExpressionOrColumn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/FilterMatcher.java
+++ b/src/frontend/org/voltdb/planner/FilterMatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/IndexUseType.java
+++ b/src/frontend/org/voltdb/planner/IndexUseType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/InsertSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/InsertSubPlanAssembler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/MVQueryRewriter.java
+++ b/src/frontend/org/voltdb/planner/MVQueryRewriter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/MaterializedViewFixInfo.java
+++ b/src/frontend/org/voltdb/planner/MaterializedViewFixInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParameterizationInfo.java
+++ b/src/frontend/org/voltdb/planner/ParameterizationInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedColInfo.java
+++ b/src/frontend/org/voltdb/planner/ParsedColInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedDeleteStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedDeleteStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedInsertStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedMigrateStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedMigrateStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSelectStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedSwapStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedSwapStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUnionStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
+++ b/src/frontend/org/voltdb/planner/ParsedUpdateStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/PlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/PlanAssembler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/PlanSelector.java
+++ b/src/frontend/org/voltdb/planner/PlanSelector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/PlanStatistics.java
+++ b/src/frontend/org/voltdb/planner/PlanStatistics.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/QueryPlanner.java
+++ b/src/frontend/org/voltdb/planner/QueryPlanner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ScanDeterminizer.java
+++ b/src/frontend/org/voltdb/planner/ScanDeterminizer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/ScanPlanNodeWhichCanHaveInlineInsert.java
+++ b/src/frontend/org/voltdb/planner/ScanPlanNodeWhichCanHaveInlineInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SelectSubPlanAssembler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/StatementPartitioning.java
+++ b/src/frontend/org/voltdb/planner/StatementPartitioning.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/StatsField.java
+++ b/src/frontend/org/voltdb/planner/StatsField.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/StmtEphemeralTableScan.java
+++ b/src/frontend/org/voltdb/planner/StmtEphemeralTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/SubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/SubPlanAssembler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/TrivialCostModel.java
+++ b/src/frontend/org/voltdb/planner/TrivialCostModel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/WindowFunctionScore.java
+++ b/src/frontend/org/voltdb/planner/WindowFunctionScore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/WindowFunctionScoreboard.java
+++ b/src/frontend/org/voltdb/planner/WindowFunctionScoreboard.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
+++ b/src/frontend/org/voltdb/planner/WriterSubPlanAssembler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/InlineAggregation.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/InlineAggregation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/InlineOrderByIntoMergeReceive.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/InlineOrderByIntoMergeReceive.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/MakeInsertNodesInlineIfPossible.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/MakeInsertNodesInlineIfPossible.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimization.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/MicroOptimizationRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/OffsetQueryUsingCountingIndex.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/PushdownLimits.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/PushdownLimits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/RemoveUnnecessaryProjectNodes.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/RemoveUnnecessaryProjectNodes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
+++ b/src/frontend/org/voltdb/planner/microoptimizations/ReplaceWithIndexLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/package-info.java
+++ b/src/frontend/org/voltdb/planner/package-info.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/package.html
+++ b/src/frontend/org/voltdb/planner/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/BranchNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/JoinNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScanShared.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtCommonTableScanShared.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtSubqueryScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/StmtTargetTableScan.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/StmtTargetTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/SubqueryLeafNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
+++ b/src/frontend/org/voltdb/planner/parseinfo/TableLeafNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/AbstractSqlBatchDecorator.java
+++ b/src/frontend/org/voltdb/plannerv2/AbstractSqlBatchDecorator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/AbstractSqlTaskDecorator.java
+++ b/src/frontend/org/voltdb/plannerv2/AbstractSqlTaskDecorator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/ColumnTypes.java
+++ b/src/frontend/org/voltdb/plannerv2/ColumnTypes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/NonDdlBatch.java
+++ b/src/frontend/org/voltdb/plannerv2/NonDdlBatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
+++ b/src/frontend/org/voltdb/plannerv2/NonDdlBatchPlanner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/ParameterizationVisitor.java
+++ b/src/frontend/org/voltdb/plannerv2/ParameterizationVisitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/ParameterizedSqlTask.java
+++ b/src/frontend/org/voltdb/plannerv2/ParameterizedSqlTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/SqlBatch.java
+++ b/src/frontend/org/voltdb/plannerv2/SqlBatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/SqlBatchImpl.java
+++ b/src/frontend/org/voltdb/plannerv2/SqlBatchImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/SqlTask.java
+++ b/src/frontend/org/voltdb/plannerv2/SqlTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/SqlTaskImpl.java
+++ b/src/frontend/org/voltdb/plannerv2/SqlTaskImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltFastSqlParser.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltFastSqlParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltFrameworkConfig.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltFrameworkConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltPlanner.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltPlanner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltRelDataTypeSystem.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltRelDataTypeSystem.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltRelOptCost.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltRelOptCost.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltSchemaPlus.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSchemaPlus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltSqlConformance.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSqlConformance.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltSqlToRelConverterConfig.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSqlToRelConverterConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltSqlValidator.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltSqlValidator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/VoltTable.java
+++ b/src/frontend/org/voltdb/plannerv2/VoltTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/converter/ExpressionTypeConverter.java
+++ b/src/frontend/org/voltdb/plannerv2/converter/ExpressionTypeConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/converter/RelConverter.java
+++ b/src/frontend/org/voltdb/plannerv2/converter/RelConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/converter/RexConverter.java
+++ b/src/frontend/org/voltdb/plannerv2/converter/RexConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/converter/RexConverterHelper.java
+++ b/src/frontend/org/voltdb/plannerv2/converter/RexConverterHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/AcceptAllSelect.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/AcceptAllSelect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/AcceptDDLsAsWeCan.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/AcceptDDLsAsWeCan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/BanLargeQuery.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/BanLargeQuery.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/CalciteCompatibilityCheck.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/CalciteCompatibilityCheck.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/CalcitePlanningException.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/CalcitePlanningException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/guards/PlannerFallbackException.java
+++ b/src/frontend/org/voltdb/plannerv2/guards/PlannerFallbackException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMdParallelism.java
+++ b/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMdParallelism.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMdRowCount.java
+++ b/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMdRowCount.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMetadataProvider.java
+++ b/src/frontend/org/voltdb/plannerv2/metadata/VoltRelMetadataProvider.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/AbstractVoltTableScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/AbstractVoltTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/VoltLRelBuilder.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/VoltLRelBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/VoltLRelFactories.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/VoltLRelFactories.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/VoltPRelBuilder.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/VoltPRelBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/VoltPRelFactories.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/VoltPRelFactories.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalAggregate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalCalc.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalCalc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalExchange.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalExchange.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalIntersect.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalIntersect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalLimit.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalMinus.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalMinus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalRel.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalRel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalSort.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalSort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalTableScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalUnion.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalUnion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/logical/VoltLogicalValues.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalAggregate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalCalc.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalCalc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalExchange.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalExchange.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalHashAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalHashAggregate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalIntersect.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalIntersect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalLimit.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMergeExchange.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMergeExchange.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMergeJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMergeJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMinus.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalMinus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalNestLoopIndexJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalNestLoopIndexJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalNestLoopJoin.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalNestLoopJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalRel.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalRel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSerialAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSerialAggregate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSort.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableIndexScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableIndexScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableSequentialScan.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalTableSequentialScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalUnion.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalUnion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalValues.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/util/PlanCostUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/util/PlanCostUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rel/util/PlanNodeUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/util/PlanNodeUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalAggregateScanMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalAggregateScanMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalCalcAggregateMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalCalcAggregateMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalCalcScanMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalCalcScanMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalExchangeMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalExchangeMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitJoinMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitJoinMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitScanMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitScanMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitSerialAggregateMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitSerialAggregateMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitSortMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/inlining/VoltPhysicalLimitSortMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/MPJoinQueryFallBackRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/MPJoinQueryFallBackRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/MPQueryFallBackRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/MPQueryFallBackRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/MPSetOpsQueryFallBackRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/MPSetOpsQueryFallBackRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/RelDistributionUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/RelDistributionUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateCalcMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateCalcMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLAggregateRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLCalcJoinMergeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLCalcJoinMergeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLCalcRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLCalcRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLJoinCommuteRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLJoinCommuteRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLJoinRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLJoinRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLSetOpsRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLSetOpsRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLSortRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLSortRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLTableScanRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLTableScanRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/logical/VoltLValuesRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPAggregateRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPAggregateRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPCalcRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPCalcRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPCalcScanToIndexRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPCalcScanToIndexRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPExchangeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPExchangeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPExchangeTransposeRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPExchangeTransposeRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinCommuteRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinCommuteRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinPushThroughJoinRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinPushThroughJoinRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPJoinRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPLimitRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPLimitRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPNestLoopIndexToMergeJoinRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPNestLoopIndexToMergeJoinRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPNestLoopToIndexJoinRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPNestLoopToIndexJoinRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSeqScanRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSeqScanRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSetOpsRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSetOpsRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortConvertRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortConvertRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortIndexScanRemoveRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortIndexScanRemoveRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortScanToIndexRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPSortScanToIndexRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPValuesRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/sqlfunctions/VoltSqlFunctions.java
+++ b/src/frontend/org/voltdb/plannerv2/sqlfunctions/VoltSqlFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/AbstractPlanNodeVisitor.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/AbstractPlanNodeVisitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/Cacheable.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/Cacheable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/CalciteUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/CalciteUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/CreateIndexUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/CreateIndexUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/CreateTableUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/CreateTableUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/DropTableUtils.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/DropTableUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/ExpressionTranslator.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/ExpressionTranslator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/IndexUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/IndexUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/PostBuildVisitor.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/PostBuildVisitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/RelTraitShuttle.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/RelTraitShuttle.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/VoltRelUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/VoltRelUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannerv2/utils/VoltRexUtil.java
+++ b/src/frontend/org/voltdb/plannerv2/utils/VoltRexUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractJoinPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractOperationPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractReceivePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AbstractScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/AggregatePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/CommonTablePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/CommonTablePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/DeletePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/DeletePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/HashAggregatePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexCountPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/IndexSortablePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/IndexSortablePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/IndexUseForOrderBy.java
+++ b/src/frontend/org/voltdb/plannodes/IndexUseForOrderBy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/InsertPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/LimitPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MaterializedScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/MergeJoinPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MergeJoinPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MergeReceivePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/MigratePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/MigratePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopIndexPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/NestLoopPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/NodeSchema.java
+++ b/src/frontend/org/voltdb/plannodes/NodeSchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/OrderByPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/PartialAggregatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/PartialAggregatePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/PlanNodeList.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeList.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
+++ b/src/frontend/org/voltdb/plannodes/PlanNodeTree.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ProjectionPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/ReceivePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/ReceivePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/SchemaColumn.java
+++ b/src/frontend/org/voltdb/plannodes/SchemaColumn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/SendPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SendPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SeqScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/SwapTablesPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/SwapTablesPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TableCountPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/TupleScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UnionPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/UpdatePlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/UpdatePlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/WindowFunctionPlanNode.java
+++ b/src/frontend/org/voltdb/plannodes/WindowFunctionPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/plannodes/package-info.java
+++ b/src/frontend/org/voltdb/plannodes/package-info.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/probe/HostCriteria.java
+++ b/src/frontend/org/voltdb/probe/HostCriteria.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/probe/MeshProber.java
+++ b/src/frontend/org/voltdb/probe/MeshProber.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/processtools/ShellTools.java
+++ b/src/frontend/org/voltdb/processtools/ShellTools.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/JoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/JoinCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/RejoinDataAckMessage.java
+++ b/src/frontend/org/voltdb/rejoin/RejoinDataAckMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/RejoinDataMessage.java
+++ b/src/frontend/org/voltdb/rejoin/RejoinDataMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/RejoinTaskBuffer.java
+++ b/src/frontend/org/voltdb/rejoin/RejoinTaskBuffer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotAckSender.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotAckSender.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotBase.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataReceiver.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataReceiver.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotMessageType.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotMessageType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotSink.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/TaskLog.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
+++ b/src/frontend/org/voltdb/rejoin/TaskLogImpl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/security/AuthenticationRequest.java
+++ b/src/frontend/org/voltdb/security/AuthenticationRequest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/ClusterSettings.java
+++ b/src/frontend/org/voltdb/settings/ClusterSettings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/ClusterSettingsRef.java
+++ b/src/frontend/org/voltdb/settings/ClusterSettingsRef.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/DbSettings.java
+++ b/src/frontend/org/voltdb/settings/DbSettings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/Settings.java
+++ b/src/frontend/org/voltdb/settings/Settings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/settings/SettingsException.java
+++ b/src/frontend/org/voltdb/settings/SettingsException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/DummySnmpTrapSender.java
+++ b/src/frontend/org/voltdb/snmp/DummySnmpTrapSender.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/FaultCode.java
+++ b/src/frontend/org/voltdb/snmp/FaultCode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/FaultFacility.java
+++ b/src/frontend/org/voltdb/snmp/FaultFacility.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/FaultLevel.java
+++ b/src/frontend/org/voltdb/snmp/FaultLevel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/SnmpTrapSender.java
+++ b/src/frontend/org/voltdb/snmp/SnmpTrapSender.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/snmp/ThresholdType.java
+++ b/src/frontend/org/voltdb/snmp/ThresholdType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHocBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocLarge.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocNTExplain.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHocSpForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RO_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RO_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RO_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RO_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RW_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/AdHoc_RW_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc_RW_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/BalancePartitionsRequest.java
+++ b/src/frontend/org/voltdb/sysprocs/BalancePartitionsRequest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/CancelShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/CancelShutdown.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
+++ b/src/frontend/org/voltdb/sysprocs/CheckUpgradePlanNT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/ExecuteTask_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Explain.java
+++ b/src/frontend/org/voltdb/sysprocs/Explain.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainJSON.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExplainProc.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExplainView.java
+++ b/src/frontend/org/voltdb/sysprocs/ExplainView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ExportControl.java
+++ b/src/frontend/org/voltdb/sysprocs/ExportControl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/GC.java
+++ b/src/frontend/org/voltdb/sysprocs/GC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/GetHashinatorConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/GetHashinatorConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadMultipartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/LoadSinglepartitionTable.java
+++ b/src/frontend/org/voltdb/sysprocs/LoadSinglepartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/LowImpactDeleteNT.java
+++ b/src/frontend/org/voltdb/sysprocs/LowImpactDeleteNT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigratePartitionLeader.java
+++ b/src/frontend/org/voltdb/sysprocs/MigratePartitionLeader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_SP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsAcked_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsBase.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsDeleterNT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsNT.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsNT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/MigrateRowsSP.java
+++ b/src/frontend/org/voltdb/sysprocs/MigrateRowsSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteBase.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
+++ b/src/frontend/org/voltdb/sysprocs/NibbleDeleteSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Pause.java
+++ b/src/frontend/org/voltdb/sysprocs/Pause.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/PingPartitions.java
+++ b/src/frontend/org/voltdb/sysprocs/PingPartitions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/PrepareShutdown.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ProfCtl.java
+++ b/src/frontend/org/voltdb/sysprocs/ProfCtl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Promote.java
+++ b/src/frontend/org/voltdb/sysprocs/Promote.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/QueryStats.java
+++ b/src/frontend/org/voltdb/sysprocs/QueryStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Quiesce.java
+++ b/src/frontend/org/voltdb/sysprocs/Quiesce.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Resume.java
+++ b/src/frontend/org/voltdb/sysprocs/Resume.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotDelete.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestoreResultSet.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestoreResultSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotScan.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotStatus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/Statistics.java
+++ b/src/frontend/org/voltdb/sysprocs/Statistics.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SwapTables.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTables.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
+++ b/src/frontend/org/voltdb/sysprocs/SwapTablesCore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SystemCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateLogging.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLogging.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
+++ b/src/frontend/org/voltdb/sysprocs/ValidatePartitioning.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/VerifyCatalogAndWriteJar.java
+++ b/src/frontend/org/voltdb/sysprocs/VerifyCatalogAndWriteJar.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/CSVSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/CSVSnapshotWritePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ClusterSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ClusterSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/DuplicateRowHandler.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/DuplicateRowHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/HashinatorSnapshotData.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/HashinatorSnapshotData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotRequestConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotWritePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/PartitionedTableSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/ReplicatedTableSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SavedTableConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPathType.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPathType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPredicates.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotPredicates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotRequestConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotRequestConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/TableSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/ConstraintType.java
+++ b/src/frontend/org/voltdb/types/ConstraintType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/ExpressionType.java
+++ b/src/frontend/org/voltdb/types/ExpressionType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/GeographyValue.java
+++ b/src/frontend/org/voltdb/types/GeographyValue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/IndexLookupType.java
+++ b/src/frontend/org/voltdb/types/IndexLookupType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/IndexType.java
+++ b/src/frontend/org/voltdb/types/IndexType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/JoinType.java
+++ b/src/frontend/org/voltdb/types/JoinType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/PartitionMethodType.java
+++ b/src/frontend/org/voltdb/types/PartitionMethodType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/PlanMatcher.java
+++ b/src/frontend/org/voltdb/types/PlanMatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/PlanNodeType.java
+++ b/src/frontend/org/voltdb/types/PlanNodeType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/PlannerType.java
+++ b/src/frontend/org/voltdb/types/PlannerType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/QuantifierType.java
+++ b/src/frontend/org/voltdb/types/QuantifierType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/QueryType.java
+++ b/src/frontend/org/voltdb/types/QueryType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/ResultType.java
+++ b/src/frontend/org/voltdb/types/ResultType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/SortDirectionType.java
+++ b/src/frontend/org/voltdb/types/SortDirectionType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/TimestampType.java
+++ b/src/frontend/org/voltdb/types/TimestampType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/VoltDecimalHelper.java
+++ b/src/frontend/org/voltdb/types/VoltDecimalHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/types/package.html
+++ b/src/frontend/org/voltdb/types/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/AllocationStrategy.java
+++ b/src/frontend/org/voltdb/utils/AllocationStrategy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/ApiRequestServlet.java
+++ b/src/frontend/org/voltdb/utils/ApiRequestServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/ApiRequestServletV2.java
+++ b/src/frontend/org/voltdb/utils/ApiRequestServletV2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BandwidthMonitor.java
+++ b/src/frontend/org/voltdb/utils/BandwidthMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/Base64.java
+++ b/src/frontend/org/voltdb/utils/Base64.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/frontend/org/voltdb/utils/BinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/BinaryDeque.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BinaryDequeDeferredSerializer.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeDeferredSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BinaryDequeReader.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BinaryDequeSerializer.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BuildDirectoryUtils.java
+++ b/src/frontend/org/voltdb/utils/BuildDirectoryUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/BulkLoaderErrorHandler.java
+++ b/src/frontend/org/voltdb/utils/BulkLoaderErrorHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CLibrary.java
+++ b/src/frontend/org/voltdb/utils/CLibrary.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVBulkDataLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVBulkDataLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVDataLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVDataLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVFileReader.java
+++ b/src/frontend/org/voltdb/utils/CSVFileReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVTableSaveFile.java
+++ b/src/frontend/org/voltdb/utils/CSVTableSaveFile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CSVTupleDataLoader.java
+++ b/src/frontend/org/voltdb/utils/CSVTupleDataLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CachedByteBufferAllocator.java
+++ b/src/frontend/org/voltdb/utils/CachedByteBufferAllocator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CallableNoThrow.java
+++ b/src/frontend/org/voltdb/utils/CallableNoThrow.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CatalogPasswordScrambler.java
+++ b/src/frontend/org/voltdb/utils/CatalogPasswordScrambler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CatalogRequestServlet.java
+++ b/src/frontend/org/voltdb/utils/CatalogRequestServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
+++ b/src/frontend/org/voltdb/utils/CatalogSchemaTools.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CatalogSizing.java
+++ b/src/frontend/org/voltdb/utils/CatalogSizing.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/ClientResponseToJsonApiV2.java
+++ b/src/frontend/org/voltdb/utils/ClientResponseToJsonApiV2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/Collector.java
+++ b/src/frontend/org/voltdb/utils/Collector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CommandLine.java
+++ b/src/frontend/org/voltdb/utils/CommandLine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/CompressionService.java
+++ b/src/frontend/org/voltdb/utils/CompressionService.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/DBMonitorServlet.java
+++ b/src/frontend/org/voltdb/utils/DBMonitorServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/DeploymentRequestServlet.java
+++ b/src/frontend/org/voltdb/utils/DeploymentRequestServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/Digester.java
+++ b/src/frontend/org/voltdb/utils/Digester.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/Encoder.java
+++ b/src/frontend/org/voltdb/utils/Encoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/FailedLoginCounter.java
+++ b/src/frontend/org/voltdb/utils/FailedLoginCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/FakeStatsProducer.java
+++ b/src/frontend/org/voltdb/utils/FakeStatsProducer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/FixedDBBPool.java
+++ b/src/frontend/org/voltdb/utils/FixedDBBPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/HDFSUtils.java
+++ b/src/frontend/org/voltdb/utils/HDFSUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/HTMLChartHelper.java
+++ b/src/frontend/org/voltdb/utils/HTMLChartHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/HTTPAdminListener.java
+++ b/src/frontend/org/voltdb/utils/HTTPAdminListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/IOThreadPool.java
+++ b/src/frontend/org/voltdb/utils/IOThreadPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/InMemoryJarfile.java
+++ b/src/frontend/org/voltdb/utils/InMemoryJarfile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/JDBCLoader.java
+++ b/src/frontend/org/voltdb/utils/JDBCLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/JDBCStatementReader.java
+++ b/src/frontend/org/voltdb/utils/JDBCStatementReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/JavaBuiltInFunctions.java
+++ b/src/frontend/org/voltdb/utils/JavaBuiltInFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/LatencyLogger.java
+++ b/src/frontend/org/voltdb/utils/LatencyLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/LineReaderAdapter.java
+++ b/src/frontend/org/voltdb/utils/LineReaderAdapter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/LogKeys.java
+++ b/src/frontend/org/voltdb/utils/LogKeys.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/LogoutServlet.java
+++ b/src/frontend/org/voltdb/utils/LogoutServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/MinimumRatioMaintainer.java
+++ b/src/frontend/org/voltdb/utils/MinimumRatioMaintainer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/NotImplementedException.java
+++ b/src/frontend/org/voltdb/utils/NotImplementedException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PBDRegularSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDRegularSegment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PBDSegment.java
+++ b/src/frontend/org/voltdb/utils/PBDSegment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PBDSegmentReader.java
+++ b/src/frontend/org/voltdb/utils/PBDSegmentReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PBDUtils.java
+++ b/src/frontend/org/voltdb/utils/PBDUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PairSequencer.java
+++ b/src/frontend/org/voltdb/utils/PairSequencer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
+++ b/src/frontend/org/voltdb/utils/PbdQuarantinedSegment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PbdSegmentName.java
+++ b/src/frontend/org/voltdb/utils/PbdSegmentName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PermutationGenerator.java
+++ b/src/frontend/org/voltdb/utils/PermutationGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PlatformProperties.java
+++ b/src/frontend/org/voltdb/utils/PlatformProperties.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PolygonFactory.java
+++ b/src/frontend/org/voltdb/utils/PolygonFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/PosixAdvise.java
+++ b/src/frontend/org/voltdb/utils/PosixAdvise.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/ProClass.java
+++ b/src/frontend/org/voltdb/utils/ProClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/RowWithMetaData.java
+++ b/src/frontend/org/voltdb/utils/RowWithMetaData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommandLineReader.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandLineReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommandOutputFormatter.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandOutputFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterCSV.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterCSV.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterDefault.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterDefault.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterTabDelimited.java
+++ b/src/frontend/org/voltdb/utils/SQLCommandOutputFormatterTabDelimited.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLCompleter.java
+++ b/src/frontend/org/voltdb/utils/SQLCompleter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SQLConsoleReader.java
+++ b/src/frontend/org/voltdb/utils/SQLConsoleReader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SerializationHelper.java
+++ b/src/frontend/org/voltdb/utils/SerializationHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SnapshotConverter.java
+++ b/src/frontend/org/voltdb/utils/SnapshotConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SnapshotVerifier.java
+++ b/src/frontend/org/voltdb/utils/SnapshotVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SplitStmtResults.java
+++ b/src/frontend/org/voltdb/utils/SplitStmtResults.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/StringInputStream.java
+++ b/src/frontend/org/voltdb/utils/StringInputStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SusceptibleRunnable.java
+++ b/src/frontend/org/voltdb/utils/SusceptibleRunnable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/SystemStatsCollector.java
+++ b/src/frontend/org/voltdb/utils/SystemStatsCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/TopologyZKUtils.java
+++ b/src/frontend/org/voltdb/utils/TopologyZKUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/TraceFileWriter.java
+++ b/src/frontend/org/voltdb/utils/TraceFileWriter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/UserProfileServlet.java
+++ b/src/frontend/org/voltdb/utils/UserProfileServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltBaseServlet.java
+++ b/src/frontend/org/voltdb/utils/VoltBaseServlet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltFile.java
+++ b/src/frontend/org/voltdb/utils/VoltFile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltSampler.java
+++ b/src/frontend/org/voltdb/utils/VoltSampler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/src/frontend/org/voltdb/utils/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTableUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltTrace.java
+++ b/src/frontend/org/voltdb/utils/VoltTrace.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltTypeUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTypeUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/VoltUncaughtExceptionHandler.java
+++ b/src/frontend/org/voltdb/utils/VoltUncaughtExceptionHandler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/generate_logkeys.py
+++ b/src/frontend/org/voltdb/utils/generate_logkeys.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -26,7 +26,7 @@ import os
 
 gpl_header = \
 """/* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/utils/package.html
+++ b/src/frontend/org/voltdb/utils/package.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltScannableTable.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltScannableTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltTableData.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltTableData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltTableEnumerator.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltTableEnumerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltTableSchema.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltTableSchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltTableSchemaFactory.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltTableSchemaFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/org/voltdb/volttableutil/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/volttableutil/VoltTableUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/frontend/overview-public.html
+++ b/src/frontend/overview-public.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/frontend/overview.html
+++ b/src/frontend/overview.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 This file is part of VoltDB.
-Copyright (C) 2008-2019 VoltDB Inc.
+Copyright (C) 2008-2020 VoltDB Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionStartsWith.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/ExpressionStartsWith.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLDDLInfo.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLDDLInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLFileParser.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLFileParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/HSQLInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/StartsWith.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/StartsWith.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/hsqldb19b3/org/hsqldb_voltpatches/VoltXMLElement.java
+++ b/src/hsqldb19b3/org/hsqldb_voltpatches/VoltXMLElement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tests/bench/iotest/IOBench.java
+++ b/tests/bench/iotest/IOBench.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/snapshot-performance/analyze.py
+++ b/tests/bench/snapshot-performance/analyze.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/Task.h
+++ b/tests/bench/throughput/Task.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/Workload.h
+++ b/tests/bench/throughput/Workload.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/javasetup.h
+++ b/tests/bench/throughput/javasetup.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/registration.h
+++ b/tests/bench/throughput/registration.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/run.py
+++ b/tests/bench/throughput/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/tasks/CFib.h
+++ b/tests/bench/throughput/tasks/CFib.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/tasks/JavaFib.h
+++ b/tests/bench/throughput/tasks/JavaFib.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/tasks/JavaFib.java
+++ b/tests/bench/throughput/tasks/JavaFib.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/tasks/RBTreeAccess.h
+++ b/tests/bench/throughput/tasks/RBTreeAccess.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/throughput.cpp
+++ b/tests/bench/throughput/throughput.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/bench/throughput/timer.h
+++ b/tests/bench/throughput/timer.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/ee/catalog/ExportTupleStreamTest.cpp
+++ b/tests/ee/catalog/ExportTupleStreamTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/catalog/ExportTupleStreamTest.hpp
+++ b/tests/ee/catalog/ExportTupleStreamTest.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/catalog/catalog_test.cpp
+++ b/tests/ee/catalog/catalog_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/LargeTempTableBlockIdTest.cpp
+++ b/tests/ee/common/LargeTempTableBlockIdTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/PerFragmentStatsTest.cpp
+++ b/tests/ee/common/PerFragmentStatsTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/PerFragmentStatsTest.hpp
+++ b/tests/ee/common/PerFragmentStatsTest.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/PoolCheckingTest.cpp
+++ b/tests/ee/common/PoolCheckingTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/ThreadLocalPoolTest.cpp
+++ b/tests/ee/common/ThreadLocalPoolTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/bytearray_test.cpp
+++ b/tests/ee/common/bytearray_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/debuglog_test.cpp
+++ b/tests/ee/common/debuglog_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/elastic_hashinator_test.cpp
+++ b/tests/ee/common/elastic_hashinator_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/common/function_thread.cpp
+++ b/tests/ee/common/function_thread.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/function_thread.h
+++ b/tests/ee/common/function_thread.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/nvalue_test.cpp
+++ b/tests/ee/common/nvalue_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/common/pool_test.cpp
+++ b/tests/ee/common/pool_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/serializeio_test.cpp
+++ b/tests/ee/common/serializeio_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/tabletuple_test.cpp
+++ b/tests/ee/common/tabletuple_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/common/tupleschema_test.cpp
+++ b/tests/ee/common/tupleschema_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/common/undolog_test.cpp
+++ b/tests/ee/common/undolog_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/common/uniqueid_test.cpp
+++ b/tests/ee/common/uniqueid_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/common/valuearray_test.cpp
+++ b/tests/ee/common/valuearray_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/execution/ExecutorVectorTest.cpp
+++ b/tests/ee/execution/ExecutorVectorTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/execution/FragmentManagerTest.cpp
+++ b/tests/ee/execution/FragmentManagerTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/execution/add_drop_table.cpp
+++ b/tests/ee/execution/add_drop_table.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/execution/engine_test.cpp
+++ b/tests/ee/execution/engine_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/executors/CommonTableExpressionTest.cpp
+++ b/tests/ee/executors/CommonTableExpressionTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/executors/MergeReceiveExecutorTest.cpp
+++ b/tests/ee/executors/MergeReceiveExecutorTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/executors/OptimizedProjectorTest.cpp
+++ b/tests/ee/executors/OptimizedProjectorTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/expressions/expression_test.cpp
+++ b/tests/ee/expressions/expression_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/harness.cpp
+++ b/tests/ee/harness.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/harness.h
+++ b/tests/ee/harness.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/harness_test/harness_tester.cpp
+++ b/tests/ee/harness_test/harness_tester.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/indexes/CompactingHashIndexTest.cpp
+++ b/tests/ee/indexes/CompactingHashIndexTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/indexes/CompactingTreeMultiIndexTest.cpp
+++ b/tests/ee/indexes/CompactingTreeMultiIndexTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/indexes/CoveringCellIndexTest.cpp
+++ b/tests/ee/indexes/CoveringCellIndexTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/indexes/index_key_test.cpp
+++ b/tests/ee/indexes/index_key_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/indexes/index_scripted_test.cpp
+++ b/tests/ee/indexes/index_scripted_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/indexes/index_scripted_test.py
+++ b/tests/ee/indexes/index_scripted_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/indexes/polygons.hpp
+++ b/tests/ee/indexes/polygons.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/logging/logging_test.cpp
+++ b/tests/ee/logging/logging_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/memleaktests/definite_losses.cpp
+++ b/tests/ee/memleaktests/definite_losses.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/memleaktests/indirect_losses.cpp
+++ b/tests/ee/memleaktests/indirect_losses.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/memleaktests/no_losses.cpp
+++ b/tests/ee/memleaktests/no_losses.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/memleaktests/possible_losses.cpp
+++ b/tests/ee/memleaktests/possible_losses.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/memleaktests/rw_deleted.cpp
+++ b/tests/ee/memleaktests/rw_deleted.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/memleaktests/still_reachable_losses.cpp
+++ b/tests/ee/memleaktests/still_reachable_losses.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/plannodes/PlanNodeFragmentTest.cpp
+++ b/tests/ee/plannodes/PlanNodeFragmentTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/plannodes/PlanNodeUtilTest.cpp
+++ b/tests/ee/plannodes/PlanNodeUtilTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/plannodes/WindowFunctionPlanNodeTest.cpp
+++ b/tests/ee/plannodes/WindowFunctionPlanNodeTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/CopyOnWriteTest.cpp
+++ b/tests/ee/storage/CopyOnWriteTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/DRBinaryLog_test.cpp
+++ b/tests/ee/storage/DRBinaryLog_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/DRTupleStream_test.cpp
+++ b/tests/ee/storage/DRTupleStream_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/ExportTupleStream_test.cpp
+++ b/tests/ee/storage/ExportTupleStream_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/LargeTempTableBlockTest.cpp
+++ b/tests/ee/storage/LargeTempTableBlockTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/LargeTempTableSortTest.cpp
+++ b/tests/ee/storage/LargeTempTableSortTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/LargeTempTableTest.cpp
+++ b/tests/ee/storage/LargeTempTableTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/PersistentTableMemStatsTest.cpp
+++ b/tests/ee/storage/PersistentTableMemStatsTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/StreamedTable_test.cpp
+++ b/tests/ee/storage/StreamedTable_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/TempTableLimitsTest.cpp
+++ b/tests/ee/storage/TempTableLimitsTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/constraint_test.cpp
+++ b/tests/ee/storage/constraint_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/storage/filter_test.cpp
+++ b/tests/ee/storage/filter_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/serialize_test.cpp
+++ b/tests/ee/storage/serialize_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/storage/table_and_indexes_test.cpp
+++ b/tests/ee/storage/table_and_indexes_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/table_test.cpp
+++ b/tests/ee/storage/table_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/storage/tabletuple_export_test.cpp
+++ b/tests/ee/storage/tabletuple_export_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/storage/tabletuplefilter_test.cpp
+++ b/tests/ee/storage/tabletuplefilter_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/structures/CompactingHashTest.cpp
+++ b/tests/ee/structures/CompactingHashTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/structures/CompactingMapBenchmark.cpp
+++ b/tests/ee/structures/CompactingMapBenchmark.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/structures/CompactingMapIndexCountTest.cpp
+++ b/tests/ee/structures/CompactingMapIndexCountTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/structures/CompactingMapTest.cpp
+++ b/tests/ee/structures/CompactingMapTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/structures/CompactingPoolTest.cpp
+++ b/tests/ee/structures/CompactingPoolTest.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/LargeTempTableTopend.hpp
+++ b/tests/ee/test_utils/LargeTempTableTopend.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/LoadTableFrom.hpp
+++ b/tests/ee/test_utils/LoadTableFrom.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/test_utils/ScopedTupleSchema.hpp
+++ b/tests/ee/test_utils/ScopedTupleSchema.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/Tools.hpp
+++ b/tests/ee/test_utils/Tools.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/test_utils/TupleComparingTest.hpp
+++ b/tests/ee/test_utils/TupleComparingTest.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/UniqueEngine.hpp
+++ b/tests/ee/test_utils/UniqueEngine.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/UniqueTable.hpp
+++ b/tests/ee/test_utils/UniqueTable.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/ee/test_utils/plan_testing_baseclass.h
+++ b/tests/ee/test_utils/plan_testing_baseclass.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/test_utils/plan_testing_config.h
+++ b/tests/ee/test_utils/plan_testing_config.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/ee/test_utils/testing_topend.h
+++ b/tests/ee/test_utils/testing_topend.h
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltcore/agreement/FakeMesh.java
+++ b/tests/frontend/org/voltcore/agreement/FakeMesh.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/MiniMailbox.java
+++ b/tests/frontend/org/voltcore/agreement/MiniMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/MiniNode.java
+++ b/tests/frontend/org/voltcore/agreement/MiniNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/MiniSite.java
+++ b/tests/frontend/org/voltcore/agreement/MiniSite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/TestAgreementSeeker.java
+++ b/tests/frontend/org/voltcore/agreement/TestAgreementSeeker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/TestFuzzMeshArbiter.java
+++ b/tests/frontend/org/voltcore/agreement/TestFuzzMeshArbiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/TestMeshArbiter.java
+++ b/tests/frontend/org/voltcore/agreement/TestMeshArbiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/maker/SiteFailureMessageMaker.java
+++ b/tests/frontend/org/voltcore/agreement/maker/SiteFailureMessageMaker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/agreement/matcher/SiteFailureMatchers.java
+++ b/tests/frontend/org/voltcore/agreement/matcher/SiteFailureMatchers.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/messaging/MockMailbox.java
+++ b/tests/frontend/org/voltcore/messaging/MockMailbox.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
+++ b/tests/frontend/org/voltcore/messaging/TestHostMessenger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/messaging/TestMessaging.java
+++ b/tests/frontend/org/voltcore/messaging/TestMessaging.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/messaging/TestSiteFailureMessage.java
+++ b/tests/frontend/org/voltcore/messaging/TestSiteFailureMessage.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/MockConnection.java
+++ b/tests/frontend/org/voltcore/network/MockConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/MockWriteStream.java
+++ b/tests/frontend/org/voltcore/network/MockWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/TestNIOReadStream.java
+++ b/tests/frontend/org/voltcore/network/TestNIOReadStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltcore/network/TestNIOWriteStream.java
+++ b/tests/frontend/org/voltcore/network/TestNIOWriteStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltcore/network/TestPicoNetwork.java
+++ b/tests/frontend/org/voltcore/network/TestPicoNetwork.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/TestReverseDNSCache.java
+++ b/tests/frontend/org/voltcore/network/TestReverseDNSCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/TestVoltNetwork.java
+++ b/tests/frontend/org/voltcore/network/TestVoltNetwork.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/network/TestVoltPort.java
+++ b/tests/frontend/org/voltcore/network/TestVoltPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/JSR166TestCase.java
+++ b/tests/frontend/org/voltcore/utils/JSR166TestCase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestByteBufferStreams.java
+++ b/tests/frontend/org/voltcore/utils/TestByteBufferStreams.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestCOWMap.java
+++ b/tests/frontend/org/voltcore/utils/TestCOWMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestCOWNavigableSet.java
+++ b/tests/frontend/org/voltcore/utils/TestCOWNavigableSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestCOWSortedMap.java
+++ b/tests/frontend/org/voltcore/utils/TestCOWSortedMap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestDBBPool.java
+++ b/tests/frontend/org/voltcore/utils/TestDBBPool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestMurmur3.java
+++ b/tests/frontend/org/voltcore/utils/TestMurmur3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/utils/TestRateLimitedLogger.java
+++ b/tests/frontend/org/voltcore/utils/TestRateLimitedLogger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
+++ b/tests/frontend/org/voltcore/zk/StateMachineSnipits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/TestBabySitter.java
+++ b/tests/frontend/org/voltcore/zk/TestBabySitter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/TestMapCache.java
+++ b/tests/frontend/org/voltcore/zk/TestMapCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/TestStateMachine.java
+++ b/tests/frontend/org/voltcore/zk/TestStateMachine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/TestZK.java
+++ b/tests/frontend/org/voltcore/zk/TestZK.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltcore/zk/ZKTestBase.java
+++ b/tests/frontend/org/voltcore/zk/ZKTestBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/AdHocQueryTester.java
+++ b/tests/frontend/org/voltdb/AdHocQueryTester.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/AdhocDDLTestBase.java
+++ b/tests/frontend/org/voltdb/AdhocDDLTestBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/AllTpccSQL.java
+++ b/tests/frontend/org/voltdb/AllTpccSQL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/CrashVoltDBTest.java
+++ b/tests/frontend/org/voltdb/CrashVoltDBTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/EmptyProcedure.java
+++ b/tests/frontend/org/voltdb/EmptyProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/EmptyProjectBuilder.java
+++ b/tests/frontend/org/voltdb/EmptyProjectBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/FlakyTestRule.java
+++ b/tests/frontend/org/voltdb/FlakyTestRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
+++ b/tests/frontend/org/voltdb/FlakyTestStandardRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/GenerateCPPTestFiles.java
+++ b/tests/frontend/org/voltdb/GenerateCPPTestFiles.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/IndexOrderPlayground.java
+++ b/tests/frontend/org/voltdb/IndexOrderPlayground.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/IndexOverflowDebugTool.java
+++ b/tests/frontend/org/voltdb/IndexOverflowDebugTool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/LatencyManualTest.java
+++ b/tests/frontend/org/voltdb/LatencyManualTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/MockStatsSource.java
+++ b/tests/frontend/org/voltdb/MockStatsSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/MultivariateEmptyProcedure.java
+++ b/tests/frontend/org/voltdb/MultivariateEmptyProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/ProcedureCallMicrobench.java
+++ b/tests/frontend/org/voltdb/ProcedureCallMicrobench.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/RejoinTestBase.java
+++ b/tests/frontend/org/voltdb/RejoinTestBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/ReplicatedProcedure.java
+++ b/tests/frontend/org/voltdb/ReplicatedProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TCPThroughput.java
+++ b/tests/frontend/org/voltdb/TCPThroughput.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TPCCServer.java
+++ b/tests/frontend/org/voltdb/TPCCServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/TPCDataPrinter.java
+++ b/tests/frontend/org/voltdb/TPCDataPrinter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAbstractTopology.java
+++ b/tests/frontend/org/voltdb/TestAbstractTopology.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdHocQueries.java
+++ b/tests/frontend/org/voltdb/TestAdHocQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocAlterTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocAlterTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCompilerErrorMessages.java
+++ b/tests/frontend/org/voltdb/TestAdhocCompilerErrorMessages.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCompilerException.java
+++ b/tests/frontend/org/voltdb/TestAdhocCompilerException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropIndex.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropIndex.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropJavaProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropJavaProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropRole.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropRole.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateDropView.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateDropView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateStatementProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocCreateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocCreateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocDropCreateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocDropCreateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocDropTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocDropTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocExportTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocExportTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocLimitOffset.java
+++ b/tests/frontend/org/voltdb/TestAdhocLimitOffset.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
+++ b/tests/frontend/org/voltdb/TestAdhocMigrateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocProcedureRoles.java
+++ b/tests/frontend/org/voltdb/TestAdhocProcedureRoles.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
+++ b/tests/frontend/org/voltdb/TestAdhocWithOnlyComment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestAdmissionControlGroup.java
+++ b/tests/frontend/org/voltdb/TestAdmissionControlGroup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestBuildString.java
+++ b/tests/frontend/org/voltdb/TestBuildString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestCSVFormatterSuite.java
+++ b/tests/frontend/org/voltdb/TestCSVFormatterSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestCSVFormatterSuiteBase.java
+++ b/tests/frontend/org/voltdb/TestCSVFormatterSuiteBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestClientInterface.java
+++ b/tests/frontend/org/voltdb/TestClientInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestClientInterfaceHandleManager.java
+++ b/tests/frontend/org/voltdb/TestClientInterfaceHandleManager.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
+++ b/tests/frontend/org/voltdb/TestDRConsumerDrIdTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestDefaultDeployment.java
+++ b/tests/frontend/org/voltdb/TestDefaultDeployment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestDeleteInExportRecoverWithView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExpectations.java
+++ b/tests/frontend/org/voltdb/TestExpectations.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
+++ b/tests/frontend/org/voltdb/TestExportConstraintsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
+++ b/tests/frontend/org/voltdb/TestExportLiveDDLSuiteLegacy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportOverflow.java
+++ b/tests/frontend/org/voltdb/TestExportOverflow.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRecoverWithView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportRejoinWithView.java
+++ b/tests/frontend/org/voltdb/TestExportRejoinWithView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportSPIMigration.java
+++ b/tests/frontend/org/voltdb/TestExportSPIMigration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
+++ b/tests/frontend/org/voltdb/TestExportSuiteReplicatedSocketExportRecover.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestExportView.java
+++ b/tests/frontend/org/voltdb/TestExportView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestHSQLBackend.java
+++ b/tests/frontend/org/voltdb/TestHSQLBackend.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestHttpTraceDisabled.java
+++ b/tests/frontend/org/voltdb/TestHttpTraceDisabled.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestImportStatistics.java
+++ b/tests/frontend/org/voltdb/TestImportStatistics.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestImportSuite.java
+++ b/tests/frontend/org/voltdb/TestImportSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestInvocationAcceptancePolicy.java
+++ b/tests/frontend/org/voltdb/TestInvocationAcceptancePolicy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestJSONInterface.java
+++ b/tests/frontend/org/voltdb/TestJSONInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestJSONInterfaceSession.java
+++ b/tests/frontend/org/voltdb/TestJSONInterfaceSession.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestJSONOverHttps.java
+++ b/tests/frontend/org/voltdb/TestJSONOverHttps.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestJavaAssertionsAreOn.java
+++ b/tests/frontend/org/voltdb/TestJavaAssertionsAreOn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestJdbcDatabaseMetaDataGenerator.java
+++ b/tests/frontend/org/voltdb/TestJdbcDatabaseMetaDataGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestLikeQueries.java
+++ b/tests/frontend/org/voltdb/TestLikeQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestLiveDDLAfterAutoUpgrade.java
+++ b/tests/frontend/org/voltdb/TestLiveDDLAfterAutoUpgrade.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestLiveDDLSchemaSwitch.java
+++ b/tests/frontend/org/voltdb/TestLiveDDLSchemaSwitch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestMemoryResourceMonitor.java
+++ b/tests/frontend/org/voltdb/TestMemoryResourceMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestMidRejoinDeath.java
+++ b/tests/frontend/org/voltdb/TestMidRejoinDeath.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
+++ b/tests/frontend/org/voltdb/TestMixedPauseModeCluster.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestMixedVersionClusters.java
+++ b/tests/frontend/org/voltdb/TestMixedVersionClusters.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestNTProcs.java
+++ b/tests/frontend/org/voltdb/TestNTProcs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestNativeLibraryLoader.java
+++ b/tests/frontend/org/voltdb/TestNativeLibraryLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestParameterConverter.java
+++ b/tests/frontend/org/voltdb/TestParameterConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestParameterSet.java
+++ b/tests/frontend/org/voltdb/TestParameterSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
+++ b/tests/frontend/org/voltdb/TestPrepareShutdownWithExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRateLimitedClientNotifier.java
+++ b/tests/frontend/org/voltdb/TestRateLimitedClientNotifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRejoinFuzz.java
+++ b/tests/frontend/org/voltdb/TestRejoinFuzz.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRejoinFuzz2.java
+++ b/tests/frontend/org/voltdb/TestRejoinFuzz2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRejoinWithCatalogUpdates.java
+++ b/tests/frontend/org/voltdb/TestRejoinWithCatalogUpdates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestReplicatedTableSnapshotRestore.java
+++ b/tests/frontend/org/voltdb/TestReplicatedTableSnapshotRestore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestRoutingEdgeCases.java
+++ b/tests/frontend/org/voltdb/TestRoutingEdgeCases.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSSL.java
+++ b/tests/frontend/org/voltdb/TestSSL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSimpleCJK.java
+++ b/tests/frontend/org/voltdb/TestSimpleCJK.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotDaemon.java
+++ b/tests/frontend/org/voltdb/TestSnapshotDaemon.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotDaemonLeaderElection.java
+++ b/tests/frontend/org/voltdb/TestSnapshotDaemonLeaderElection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotDirectory.java
+++ b/tests/frontend/org/voltdb/TestSnapshotDirectory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotIOAgent.java
+++ b/tests/frontend/org/voltdb/TestSnapshotIOAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
+++ b/tests/frontend/org/voltdb/TestSnapshotInitiationInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotWithViews.java
+++ b/tests/frontend/org/voltdb/TestSnapshotWithViews.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestSnapshotsWithFailures.java
+++ b/tests/frontend/org/voltdb/TestSnapshotsWithFailures.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStartAction.java
+++ b/tests/frontend/org/voltdb/TestStartAction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStatsAgent.java
+++ b/tests/frontend/org/voltdb/TestStatsAgent.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStatsProcInputTable.java
+++ b/tests/frontend/org/voltdb/TestStatsProcInputTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStatsProcOutputTable.java
+++ b/tests/frontend/org/voltdb/TestStatsProcOutputTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStatsProcProfTable.java
+++ b/tests/frontend/org/voltdb/TestStatsProcProfTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStoredProcedureInvocation.java
+++ b/tests/frontend/org/voltdb/TestStoredProcedureInvocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestStreamView.java
+++ b/tests/frontend/org/voltdb/TestStreamView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestTableHelper.java
+++ b/tests/frontend/org/voltdb/TestTableHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestTheHashinator.java
+++ b/tests/frontend/org/voltdb/TestTheHashinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestTwoSitePlans.java
+++ b/tests/frontend/org/voltdb/TestTwoSitePlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
+++ b/tests/frontend/org/voltdb/TestUpdateInExportRecoverWithView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVarBinaryPartition.java
+++ b/tests/frontend/org/voltdb/TestVarBinaryPartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVoltDB.java
+++ b/tests/frontend/org/voltdb/TestVoltDB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVoltProcedure.java
+++ b/tests/frontend/org/voltdb/TestVoltProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/TestVoltTable.java
+++ b/tests/frontend/org/voltdb/TestVoltTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVoltTableUtil.java
+++ b/tests/frontend/org/voltdb/TestVoltTableUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVoltType.java
+++ b/tests/frontend/org/voltdb/TestVoltType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/TestVoltZK.java
+++ b/tests/frontend/org/voltdb/TestVoltZK.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/VoltJUnitFormatter.java
+++ b/tests/frontend/org/voltdb/VoltJUnitFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/VoltTableTestHelpers.java
+++ b/tests/frontend/org/voltdb/VoltTableTestHelpers.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/VoltTestRunner.java
+++ b/tests/frontend/org/voltdb/VoltTestRunner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/benchmark/tpcc/Constants.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/Constants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/TPCCProjectBuilder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/TPCCProjectBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ByteBuilder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ByteBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/FragmentUpdateTestProcedure.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/FragmentUpdateTestProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/InsertNewOrder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/InsertNewOrder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/InsertOrderLineBatched.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/InsertOrderLineBatched.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/LoadWarehouse.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/LoadWarehouse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/LoadWarehouseReplicated.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/LoadWarehouseReplicated.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ResetWarehouse.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ResetWarehouse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/SelectAll.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/SelectAll.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/UpdateNewOrder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/UpdateNewOrder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/delivery.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/delivery.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/neworder.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/neworder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ostatByCustomerId.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ostatByCustomerId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ostatByCustomerName.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/ostatByCustomerName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerId.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerIdC.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerIdC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerIdW.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerIdW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerName.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerNameC.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerNameC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerNameW.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/paymentByCustomerNameW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/benchmark/tpcc/procedures/slev.java
+++ b/tests/frontend/org/voltdb/benchmark/tpcc/procedures/slev.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/canonicalddl/TestCanonicalDDLThroughSQLcmd.java
+++ b/tests/frontend/org/voltdb/canonicalddl/TestCanonicalDDLThroughSQLcmd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/InsertNewOrder.java
+++ b/tests/frontend/org/voltdb/catalog/InsertNewOrder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/catalog/ProcedureA.java
+++ b/tests/frontend/org/voltdb/catalog/ProcedureA.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/ProcedureB.java
+++ b/tests/frontend/org/voltdb/catalog/ProcedureB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/catalog/ProcedureC.java
+++ b/tests/frontend/org/voltdb/catalog/ProcedureC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogDiffs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/TestCatalogSerialization.java
+++ b/tests/frontend/org/voltdb/catalog/TestCatalogSerialization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
+++ b/tests/frontend/org/voltdb/catalog/TestDRCatalogDiffs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/TestLiveProcedurePartitioningChanges.java
+++ b/tests/frontend/org/voltdb/catalog/TestLiveProcedurePartitioningChanges.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/TestLiveTableSchemaMigration.java
+++ b/tests/frontend/org/voltdb/catalog/TestLiveTableSchemaMigration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
+++ b/tests/frontend/org/voltdb/catalog/TestResourcesInUpdateClasses.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/ArbitraryDurationProc.java
+++ b/tests/frontend/org/voltdb/client/ArbitraryDurationProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/BulkClient.java
+++ b/tests/frontend/org/voltdb/client/BulkClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/ClientConfigForTest.java
+++ b/tests/frontend/org/voltdb/client/ClientConfigForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/MockVoltClient.java
+++ b/tests/frontend/org/voltdb/client/MockVoltClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/client/MultiPartitionProcedureSample.java
+++ b/tests/frontend/org/voltdb/client/MultiPartitionProcedureSample.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/PartitionFailureTestProc.java
+++ b/tests/frontend/org/voltdb/client/PartitionFailureTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/PartitionIntegerTestProc.java
+++ b/tests/frontend/org/voltdb/client/PartitionIntegerTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/PartitionStringTestProc.java
+++ b/tests/frontend/org/voltdb/client/PartitionStringTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/PartitionedTestProcNonZeroPartitioningParam.java
+++ b/tests/frontend/org/voltdb/client/PartitionedTestProcNonZeroPartitioningParam.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestAllPartitionProcedureCalls.java
+++ b/tests/frontend/org/voltdb/client/TestAllPartitionProcedureCalls.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestClientClose.java
+++ b/tests/frontend/org/voltdb/client/TestClientClose.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestClientFeatures.java
+++ b/tests/frontend/org/voltdb/client/TestClientFeatures.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestConnectionUtilDelayedExecutionThread.java
+++ b/tests/frontend/org/voltdb/client/TestConnectionUtilDelayedExecutionThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestDistributer.java
+++ b/tests/frontend/org/voltdb/client/TestDistributer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestHashinatorLite.java
+++ b/tests/frontend/org/voltdb/client/TestHashinatorLite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/client/TestProcedureInvocation.java
+++ b/tests/frontend/org/voltdb/client/TestProcedureInvocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/common/TestPermission.java
+++ b/tests/frontend/org/voltdb/common/TestPermission.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/CatalogUpgradeTools.java
+++ b/tests/frontend/org/voltdb/compiler/CatalogUpgradeTools.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestCatalogVersionUpgrade.java
+++ b/tests/frontend/org/voltdb/compiler/TestCatalogVersionUpgrade.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
+++ b/tests/frontend/org/voltdb/compiler/TestClassMatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestDDLCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestLiveDDLCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestLiveDDLCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestPartitionDDL.java
+++ b/tests/frontend/org/voltdb/compiler/TestPartitionDDL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestProcCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestTwoPartitionProcs.java
+++ b/tests/frontend/org/voltdb/compiler/TestTwoPartitionProcs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompiler.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerAlterDropTable.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerAlterDropTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerAnnotationsAndWarnings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltCompilerErrorMsgs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/TestVoltXMLElement.java
+++ b/tests/frontend/org/voltdb/compiler/TestVoltXMLElement.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/dummy_test_underscore.java
+++ b/tests/frontend/org/voltdb/compiler/dummy_test_underscore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/functions/AbstractUDFClass.java
+++ b/tests/frontend/org/voltdb/compiler/functions/AbstractUDFClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/functions/InvalidUDFLibrary.java
+++ b/tests/frontend/org/voltdb/compiler/functions/InvalidUDFLibrary.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/AddBook.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/AddBook.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/AddBookBoxed.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/AddBookBoxed.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/CrazyBlahProc.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/CrazyBlahProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/DelayProc.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/DelayProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/EmptyProcedure.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/EmptyProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/FloatParamToGetNiceComplaint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/FloatParamToGetNiceComplaint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloat.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloat.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatInHaving.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatWithSetops.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/InsertAggregatesOfFloatWithSetops.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedAddBook.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedAddBook.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedEmptyProcedure.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedEmptyProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedEmptyStaticInitializerProcedure.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedEmptyStaticInitializerProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamBigint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamBigint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamInteger.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamInteger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamSmallint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamSmallint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamString.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamTinyint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/NotAnnotatedPartitionParamTinyint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/PartitionParamBigint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/PartitionParamBigint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/PartitionParamInteger.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/PartitionParamInteger.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/PartitionParamSmallint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/PartitionParamSmallint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/PartitionParamString.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/PartitionParamString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/PartitionParamTinyint.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/PartitionParamTinyint.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/SelectStarHelloWorld.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/SelectStarHelloWorld.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compiler/procedures/TPCCTestProc.java
+++ b/tests/frontend/org/voltdb/compiler/procedures/TPCCTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compilereport/TestDDLSource.java
+++ b/tests/frontend/org/voltdb/compilereport/TestDDLSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
+++ b/tests/frontend/org/voltdb/compilereport/TestReportMaker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/Deterministic_RO_MP.java
+++ b/tests/frontend/org/voltdb/dtxn/Deterministic_RO_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/Deterministic_RO_SP.java
+++ b/tests/frontend/org/voltdb/dtxn/Deterministic_RO_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/NonDeterministicSPProc.java
+++ b/tests/frontend/org/voltdb/dtxn/NonDeterministicSPProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/NonDeterministic_RO_MP.java
+++ b/tests/frontend/org/voltdb/dtxn/NonDeterministic_RO_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/NonDeterministic_RO_SP.java
+++ b/tests/frontend/org/voltdb/dtxn/NonDeterministic_RO_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/TestHashMismatches.java
+++ b/tests/frontend/org/voltdb/dtxn/TestHashMismatches.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/dtxn/TestSiteTracker.java
+++ b/tests/frontend/org/voltdb/dtxn/TestSiteTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/eng1016/Runner.java
+++ b/tests/frontend/org/voltdb/eng1016/Runner.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
+++ b/tests/frontend/org/voltdb/export/ExportLocalClusterBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportMatchers.java
+++ b/tests/frontend/org/voltdb/export/ExportMatchers.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportTestClient.java
+++ b/tests/frontend/org/voltdb/export/ExportTestClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportTestExpectedData.java
+++ b/tests/frontend/org/voltdb/export/ExportTestExpectedData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportTestVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportTestVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportToFileTestVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportToFileTestVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportToFileVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportToFileVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
+++ b/tests/frontend/org/voltdb/export/ExportToSocketTestVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/JDBCDriverForTest.java
+++ b/tests/frontend/org/voltdb/export/JDBCDriverForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/SocketExportTestServer.java
+++ b/tests/frontend/org/voltdb/export/SocketExportTestServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportAlterStreamEndToEnd.java
+++ b/tests/frontend/org/voltdb/export/TestExportAlterStreamEndToEnd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportBase.java
+++ b/tests/frontend/org/voltdb/export/TestExportBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportClientBasic.java
+++ b/tests/frontend/org/voltdb/export/TestExportClientBasic.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportCoordinator.java
+++ b/tests/frontend/org/voltdb/export/TestExportCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportDanglingSources.java
+++ b/tests/frontend/org/voltdb/export/TestExportDanglingSources.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportDataSource.java
+++ b/tests/frontend/org/voltdb/export/TestExportDataSource.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
+++ b/tests/frontend/org/voltdb/export/TestExportEndToEnd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportFeatureOption.java
+++ b/tests/frontend/org/voltdb/export/TestExportFeatureOption.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportGap.java
+++ b/tests/frontend/org/voltdb/export/TestExportGap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportInsertIntoSelectSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportInsertIntoSelectSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportLoopbackClient.java
+++ b/tests/frontend/org/voltdb/export/TestExportLoopbackClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportRejoin.java
+++ b/tests/frontend/org/voltdb/export/TestExportRejoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportRollback.java
+++ b/tests/frontend/org/voltdb/export/TestExportRollback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
+++ b/tests/frontend/org/voltdb/export/TestExportSequenceNumberTracker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportSnapshot.java
+++ b/tests/frontend/org/voltdb/export/TestExportSnapshot.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportStatsSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportStatsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportSuite.java
+++ b/tests/frontend/org/voltdb/export/TestExportSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportV2Suite.java
+++ b/tests/frontend/org/voltdb/export/TestExportV2Suite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestExportV2SuitePro.java
+++ b/tests/frontend/org/voltdb/export/TestExportV2SuitePro.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestMultiStreamPolling.java
+++ b/tests/frontend/org/voltdb/export/TestMultiStreamPolling.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestPersistentExport.java
+++ b/tests/frontend/org/voltdb/export/TestPersistentExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/ExportClientTestBase.java
+++ b/tests/frontend/org/voltdb/exportclient/ExportClientTestBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/NoOpTestExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/NoOpTestExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestElasticSearchHttpExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestElasticSearchHttpExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestExportDecoderBase.java
+++ b/tests/frontend/org/voltdb/exportclient/TestExportDecoderBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestExportDecoderBaseLegacy.java
+++ b/tests/frontend/org/voltdb/exportclient/TestExportDecoderBaseLegacy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestExportToFileClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestHttpExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestHttpExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/TestJDBCExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/TestJDBCExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/VoltDBFickleCluster.java
+++ b/tests/frontend/org/voltdb/exportclient/VoltDBFickleCluster.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/BaseForDecoderTests.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/BaseForDecoderTests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/TestEndpointExpander.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/TestEndpointExpander.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/TestEntityDecoders.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/TestEntityDecoders.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/TestJsonObjectDecoer.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/TestJsonObjectDecoer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/TestJsonStringDecoder.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/TestJsonStringDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/decode/TestStringArrayDecoder.java
+++ b/tests/frontend/org/voltdb/exportclient/decode/TestStringArrayDecoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/exportclient/kafka/TestKafkaExportClient.java
+++ b/tests/frontend/org/voltdb/exportclient/kafka/TestKafkaExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/expressions/TestExpressionUtil.java
+++ b/tests/frontend/org/voltdb/expressions/TestExpressionUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/fullddlfeatures/TestDDLFeatures.java
+++ b/tests/frontend/org/voltdb/fullddlfeatures/TestDDLFeatures.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/importer/TestChannelDistributer.java
+++ b/tests/frontend/org/voltdb/importer/TestChannelDistributer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/importer/TestVoltCSVFormatter.java
+++ b/tests/frontend/org/voltdb/importer/TestVoltCSVFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/importer/kafka10/TestKafka10Configuration.java
+++ b/tests/frontend/org/voltdb/importer/kafka10/TestKafka10Configuration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/RandomMsgGenerator.java
+++ b/tests/frontend/org/voltdb/iv2/RandomMsgGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestCartographer.java
+++ b/tests/frontend/org/voltdb/iv2/TestCartographer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
+++ b/tests/frontend/org/voltdb/iv2/TestDurabilityListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderAppointer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
+++ b/tests/frontend/org/voltdb/iv2/TestLeaderCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestMaxMpResponseSize.java
+++ b/tests/frontend/org/voltdb/iv2/TestMaxMpResponseSize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestMpRestartSequenceGenerator.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpRestartSequenceGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestMpTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpTransactionTaskQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestRepairLog.java
+++ b/tests/frontend/org/voltdb/iv2/TestRepairLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestReplaySequencer.java
+++ b/tests/frontend/org/voltdb/iv2/TestReplaySequencer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestScoreboard.java
+++ b/tests/frontend/org/voltdb/iv2/TestScoreboard.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestSpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpPromoteAlgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerDedupe.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
+++ b/tests/frontend/org/voltdb/iv2/TestSpSchedulerSpHandle.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
+++ b/tests/frontend/org/voltdb/iv2/TestTransactionTaskQueue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestTxnEgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestTxnEgo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/iv2/TestUniqueIdGenerator.java
+++ b/tests/frontend/org/voltdb/iv2/TestUniqueIdGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/JDBCTestCommons.java
+++ b/tests/frontend/org/voltdb/jdbc/JDBCTestCommons.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCAutoReconnectOnLoss.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCAutoReconnectOnLoss.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCConnectionFail.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCConnectionFail.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCDriver.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCMultiConnection.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCMultiConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCMultiNodeConnection.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCMultiNodeConnection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCResultSet.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCResultSet.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCSecurityEnabled.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCSecurityEnabled.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jdbc/TestJDBCStreamQueries.java
+++ b/tests/frontend/org/voltdb/jdbc/TestJDBCStreamQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
+++ b/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/largequery/TestLargeBlockManagerSuite.java
+++ b/tests/frontend/org/voltdb/largequery/TestLargeBlockManagerSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/messaging/EchoServer.java
+++ b/tests/frontend/org/voltdb/messaging/EchoServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/messaging/FastSerializableTestUtil.java
+++ b/tests/frontend/org/voltdb/messaging/FastSerializableTestUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/messaging/MockFastSerializable.java
+++ b/tests/frontend/org/voltdb/messaging/MockFastSerializable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/messaging/TestFastSerializer.java
+++ b/tests/frontend/org/voltdb/messaging/TestFastSerializer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
+++ b/tests/frontend/org/voltdb/messaging/TestVoltMessageSerialization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/np/Test2PTransactionExport.java
+++ b/tests/frontend/org/voltdb/np/Test2PTransactionExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/parser/TestSQLParser.java
+++ b/tests/frontend/org/voltdb/parser/TestSQLParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestAideDeCamp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/PlannerTestCase.java
+++ b/tests/frontend/org/voltdb/planner/PlannerTestCase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/ScanPerfTest.java
+++ b/tests/frontend/org/voltdb/planner/ScanPerfTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TPCCDebugTest.java
+++ b/tests/frontend/org/voltdb/planner/TPCCDebugTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestAdHocPlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestColumnTrimmingPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestColumnTrimmingPlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestConstants.java
+++ b/tests/frontend/org/voltdb/planner/TestConstants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestDeterminism.java
+++ b/tests/frontend/org/voltdb/planner/TestDeterminism.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
+++ b/tests/frontend/org/voltdb/planner/TestGetTablesAndIndexes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestIndexCoveringPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestIndexCoveringPlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestIndexReverseScan.java
+++ b/tests/frontend/org/voltdb/planner/TestIndexReverseScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestIndexSelection.java
+++ b/tests/frontend/org/voltdb/planner/TestIndexSelection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestJoinOrder.java
+++ b/tests/frontend/org/voltdb/planner/TestJoinOrder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestLargeModeRatio.java
+++ b/tests/frontend/org/voltdb/planner/TestLargeModeRatio.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestMVOptimization.java
+++ b/tests/frontend/org/voltdb/planner/TestMVOptimization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestMultipleOuterJoinPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestMultipleOuterJoinPlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestParsedStatements.java
+++ b/tests/frontend/org/voltdb/planner/TestParsedStatements.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlannerTool.java
+++ b/tests/frontend/org/voltdb/planner/TestPlannerTool.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansApproxCountDistinct.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansApproxCountDistinct.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansCommonTableExpression.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansCommonTableExpression.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/TestPlansCount.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansCount.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansDML.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansDML.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansDistinct.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansDistinct.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansENG10022.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansENG10022.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansGroupBy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansIn.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansIn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInExistsSubQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansInsertIntoSelect.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansInsertIntoSelect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/TestPlansJoin.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansLimit.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansMatView.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansMatView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansOrderBy.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansScalarSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansScalarSubQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansSubQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansTPCC.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansTPCC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPlansWhereBoolean.java
+++ b/tests/frontend/org/voltdb/planner/TestPlansWhereBoolean.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestPushDownAggregates.java
+++ b/tests/frontend/org/voltdb/planner/TestPushDownAggregates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestReplaceWithIndexLimit.java
+++ b/tests/frontend/org/voltdb/planner/TestReplaceWithIndexLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestSelfJoins.java
+++ b/tests/frontend/org/voltdb/planner/TestSelfJoins.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestUnion.java
+++ b/tests/frontend/org/voltdb/planner/TestUnion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestValidatePlan.java
+++ b/tests/frontend/org/voltdb/planner/TestValidatePlan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/TestVerbotenPlans.java
+++ b/tests/frontend/org/voltdb/planner/TestVerbotenPlans.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
+++ b/tests/frontend/org/voltdb/planner/TestWindowedFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/debugTPCCdelivery.java
+++ b/tests/frontend/org/voltdb/planner/debugTPCCdelivery.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/debugTPCCostat.java
+++ b/tests/frontend/org/voltdb/planner/debugTPCCostat.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/debugTPCCpayment.java
+++ b/tests/frontend/org/voltdb/planner/debugTPCCpayment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/debugTPCCslev.java
+++ b/tests/frontend/org/voltdb/planner/debugTPCCslev.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/debugUpdateProc.java
+++ b/tests/frontend/org/voltdb/planner/debugUpdateProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/eegentests/EEPlanGenerator.java
+++ b/tests/frontend/org/voltdb/planner/eegentests/EEPlanGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/eegentests/GenerateEETests.java
+++ b/tests/frontend/org/voltdb/planner/eegentests/GenerateEETests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/planner/plannerTester.java
+++ b/tests/frontend/org/voltdb/planner/plannerTester.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/testLoadPlanNodeFromJSON.java
+++ b/tests/frontend/org/voltdb/planner/testLoadPlanNodeFromJSON.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/planner/testPlannerTester.java
+++ b/tests/frontend/org/voltdb/planner/testPlannerTester.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/CalcitePlannerTestCase.java
+++ b/tests/frontend/org/voltdb/plannerv2/CalcitePlannerTestCase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/MPChecker.java
+++ b/tests/frontend/org/voltdb/plannerv2/MPChecker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/PlanChecker.java
+++ b/tests/frontend/org/voltdb/plannerv2/PlanChecker.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/Plannerv2TestCase.java
+++ b/tests/frontend/org/voltdb/plannerv2/Plannerv2TestCase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestAdHoc.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestAdHoc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestInlineRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestLogicalSetOpsRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestLogicalSetOpsRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestMPQueryFallbackRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestOuterJoinSimplificationRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestOuterJoinSimplificationRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestParser.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalConversion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexSelection.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalIndexSelection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalInline.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalInline.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalJoin.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalMPQueries.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalMPQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalMergeJoin.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalMergeJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalSetOpsRules.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalSetOpsRules.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPlanConversion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestQueryParameterization.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestQueryParameterization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestRelConversion.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestRelConversion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannerv2/TestValidation.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestValidation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/MockPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannodes/TestNestLoopPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/TestNestLoopPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
+++ b/tests/frontend/org/voltdb/plannodes/TestScanPlanNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/CatalogChangeSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/CatalogChangeSingleProcessServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/EEProcess.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/InternalPortGeneratorForTest.java
+++ b/tests/frontend/org/voltdb/regressionsuites/InternalPortGeneratorForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/JUnit4LocalClusterTest.java
+++ b/tests/frontend/org/voltdb/regressionsuites/JUnit4LocalClusterTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalSingleProcessServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
+++ b/tests/frontend/org/voltdb/regressionsuites/MultiConfigSuiteBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/OutputWatcher.java
+++ b/tests/frontend/org/voltdb/regressionsuites/OutputWatcher.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/PipeToFile.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PipeToFile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/PortConnector.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PortConnector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/PortGeneratorForTest.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PortGeneratorForTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/PortListener.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PortListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/RegressionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/SaveRestoreBase.java
+++ b/tests/frontend/org/voltdb/regressionsuites/SaveRestoreBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/SaveRestoreTestProjectBuilder.java
+++ b/tests/frontend/org/voltdb/regressionsuites/SaveRestoreTestProjectBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/StatisticsTestSuiteBase.java
+++ b/tests/frontend/org/voltdb/regressionsuites/StatisticsTestSuiteBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdHocLargeFallback.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdHocLargeFallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdHocLargeSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdHocLargeSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdHocPlannerCache.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAddDropUDF.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAddDropUDF.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdminMode.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdminMode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdminModeFromCommandLine.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdminModeFromCommandLine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestAdminPort.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestAdminPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestApproxCountDistinctSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestApproxCountDistinctSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestBigBatchAndFallbackBufferResults.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestBooleanLiteralsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestBooleanLiteralsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestByteBufferAsParameter.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestByteBufferAsParameter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCRUDSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCRUDSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCalciteJoinsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCalciteJoinsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateAutoUpgradeSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateAutoUpgradeSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCatalogUpdateSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCatchExceptionsInProcedure.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCatchExceptionsInProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestClientPortChannel.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestClientPortChannel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestClientPortListener.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestClientPortListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCommonTableExpressionsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/TestCompactingViewsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestCompactingViewsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestComparisonOperatorsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestComparisonOperatorsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestConcurrentUpdateCatalog.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestConcurrentUpdateCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestDecimalDefaults.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestDecimalDefaults.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestDecimalRoundingSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestEELibraryLoaderSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestEELibraryLoaderSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestEmptySchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestExistsNotFactoringSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExistsNotFactoringSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestExplainCommandSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExplainCommandSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportCRUDSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportCRUDSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportRowLengthLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestExportWithMisconfiguredExportClient.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestExportWithMisconfiguredExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFailuresSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFailuresSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedRaceConditionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedRaceConditionsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFixedSQLSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForJSON.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForJSON.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsForVoltDBSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite2.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestFunctionsSuite2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyPointValue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeographyValueQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGeospatialIndexes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGiantDeleteSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGiantDeleteSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexMaterializedViewSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupByComplexSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestGroupBySuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestHexLiteralsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestHexLiteralsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestHttpPort.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestHttpPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexColumnLessThanSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexColumnLessThanSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexCountSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexCountSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexLimitSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexLimitSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexMemoryOwnershipSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexMemoryOwnershipSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOffsetSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexOverflowSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexOverflowSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexReverseScanSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexReverseScanSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexScanCountSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexScanCountSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestIndexesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestIndexesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterAllOutOfProcess.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInitStartLocalClusterInProcess.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInsertIntoSelectSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestInternalPort.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestInternalPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestJoinsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestLargeBlockManagerStartUpSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLargeBlockManagerStartUpSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLimitOffsetSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestLoadingSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMPBasecaseSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMPBasecaseSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMPMultiRoundTripSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMPMultiRoundTripSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMVOptimizationSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMVOptimizationSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaliciousClientSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaliciousClientSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewNonemptyTablesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewNonemptyTablesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaterializedViewSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMaxSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestMultiPartitionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestMultiPartitionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestOrderBySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestOrderBySuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPartialIndexesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestPartitionDetection.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPartitionDetection.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestPasswordMaskSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPasswordMaskSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestPrepareShutdown.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestPrepareShutdown.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestProcedureAPISuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestQueryTimeout.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestRestoreEmptyDatabaseSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRestoreEmptyDatabaseSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestRestoreSchema.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRestoreSchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRestoreSysprocSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestRollbackSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestRollbackSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSPBasecaseSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSPBasecaseSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesNewSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLFeaturesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSQLTypesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSQLTypesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveSnapshotAtDefaultLocation.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveSnapshotAtDefaultLocation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSecurityNoAdminUser.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSecurityNoAdminUser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSecuritySuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSecuritySuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestShutdown.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestShutdown.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestShutdownSave.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestShutdownSave.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestShutdownSaveNoCommandLog.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestShutdownSaveNoCommandLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotSaveTruncation.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotSaveTruncation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSnapshotStatus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlAggregateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlAggregateSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlDeleteSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlInsertSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlInsertSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlLikeRegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlLikeRegressionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlLogicOperatorsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlLogicOperatorsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlStartsWithRegressionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlStartsWithRegressionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlUpdateSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSqlUpsertSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSqlUpsertSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestStartWithClassesOnly.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStartWithClassesOnly.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestStartWithSchema.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStartWithSchema.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestStopNode.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStopNode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOff.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOff.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOn.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestStopNode2NK1PartitionDetectionOn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSubQueriesSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSystemCatalogSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestSystemProcedureSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSystemProcedureSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestTPCCSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestTPCCSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestTableCountSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestTableCountSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestTempTableMemoryKnob.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestTempTableMemoryKnob.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestTypeConversionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestTypeConversionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUndoSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUndoSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUnionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUnionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateClasses.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpdateDeployment.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUpgradeWithCatalogJar.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUpgradeWithCatalogJar.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUserDefinedAggregates.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUserDefinedAggregates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestUserDefinedFunctions.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestUserDefinedFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestViewsInPartialSnapshotRestore.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestViewsInPartialSnapshotRestore.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestVoltTableUtil.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestVoltTableUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuiteMinMaxSum.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionSuiteMinMaxSum.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionsWithIndexes.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestWindowFunctionsWithIndexes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/TestZooKeeperPort.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestZooKeeperPort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/ValgrindXMLParser.java
+++ b/tests/frontend/org/voltdb/regressionsuites/ValgrindXMLParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
+++ b/tests/frontend/org/voltdb/regressionsuites/VoltServerConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestProcedureDetails.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestProcedureDetails.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestProcedureStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestProcedureStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsCommandLogStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsCommandLogStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteCpuStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteCpuStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDatabaseElementStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuitePlannerStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuitePlannerStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteRebalanceStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteRebalanceStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteSnapshotStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteSnapshotStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/IncrementProc.java
+++ b/tests/frontend/org/voltdb/rejoin/IncrementProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/IncrementProcSP.java
+++ b/tests/frontend/org/voltdb/rejoin/IncrementProcSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/LiveRejoinFailureTests.java
+++ b/tests/frontend/org/voltdb/rejoin/LiveRejoinFailureTests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/LiveRejoinOverflowTests.java
+++ b/tests/frontend/org/voltdb/rejoin/LiveRejoinOverflowTests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinator.java
+++ b/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinatorLive.java
+++ b/tests/frontend/org/voltdb/rejoin/TestIv2RejoinCoordinatorLive.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinEndToEnd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinFuzz.java
+++ b/tests/frontend/org/voltdb/rejoin/TestPauselessRejoinFuzz.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestRejoinTaskBuffer.java
+++ b/tests/frontend/org/voltdb/rejoin/TestRejoinTaskBuffer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotDataTarget.java
+++ b/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotDataTarget.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotRequestConfig.java
+++ b/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotRequestConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/rejoin/TestTaskLog.java
+++ b/tests/frontend/org/voltdb/rejoin/TestTaskLog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sqlgenerator/SimpleServer.java
+++ b/tests/frontend/org/voltdb/sqlgenerator/SimpleServer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/TestLowImpactDelete.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestLowImpactDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/TestMockUpdateApplicationCatalog.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestMockUpdateApplicationCatalog.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/TestNibbleDelete.java
+++ b/tests/frontend/org/voltdb/sysprocs/TestNibbleDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestClusterSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestClusterSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestPartitionedTableSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestPartitionedTableSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestReplicatedTableSaveFileState.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestSavedTableConverter.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestSavedTableConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/sysprocs/saverestore/TestTableSaveFile.java
+++ b/tests/frontend/org/voltdb/sysprocs/saverestore/TestTableSaveFile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
+++ b/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/BigFatBlobAndStringMD5.java
+++ b/tests/frontend/org/voltdb/types/BigFatBlobAndStringMD5.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/FakeCustomerLookup.java
+++ b/tests/frontend/org/voltdb/types/FakeCustomerLookup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/TestBlobType.java
+++ b/tests/frontend/org/voltdb/types/TestBlobType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/TestDateParsing.java
+++ b/tests/frontend/org/voltdb/types/TestDateParsing.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/types/TestExpressionType.java
+++ b/tests/frontend/org/voltdb/types/TestExpressionType.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/TestGeographyPointValueNormalization.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyPointValueNormalization.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/types/TestGeographyValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyValue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/TestVoltDecimalHelper.java
+++ b/tests/frontend/org/voltdb/types/TestVoltDecimalHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/types/VarbinaryStringLookup.java
+++ b/tests/frontend/org/voltdb/types/VarbinaryStringLookup.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/HTTPAdminListenerStarter.java
+++ b/tests/frontend/org/voltdb/utils/HTTPAdminListenerStarter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/HTTPDBenchmark.java
+++ b/tests/frontend/org/voltdb/utils/HTTPDBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/OverprintingStatusListener.java
+++ b/tests/frontend/org/voltdb/utils/OverprintingStatusListener.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCLibrary.java
+++ b/tests/frontend/org/voltdb/utils/TestCLibrary.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCSVLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestCSVLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCSVLoaderSecurityEnabled.java
+++ b/tests/frontend/org/voltdb/utils/TestCSVLoaderSecurityEnabled.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestCatalogUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCollector.java
+++ b/tests/frontend/org/voltdb/utils/TestCollector.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCommandLine.java
+++ b/tests/frontend/org/voltdb/utils/TestCommandLine.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestCompressionService.java
+++ b/tests/frontend/org/voltdb/utils/TestCompressionService.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestEncoder.java
+++ b/tests/frontend/org/voltdb/utils/TestEncoder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestFailedLoginCounter.java
+++ b/tests/frontend/org/voltdb/utils/TestFailedLoginCounter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestInMemoryJarfile.java
+++ b/tests/frontend/org/voltdb/utils/TestInMemoryJarfile.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestJDBCLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestJDBCLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestMinimumRatioMaintainer.java
+++ b/tests/frontend/org/voltdb/utils/TestMinimumRatioMaintainer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestMiscUtils.java
+++ b/tests/frontend/org/voltdb/utils/TestMiscUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
+++ b/tests/frontend/org/voltdb/utils/TestPBDMultipleReaders.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPairSequencer.java
+++ b/tests/frontend/org/voltdb/utils/TestPairSequencer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
+++ b/tests/frontend/org/voltdb/utils/TestPbdSegmentName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDequeCorruption.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestPolygonFactory.java
+++ b/tests/frontend/org/voltdb/utils/TestPolygonFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/utils/TestSQLLexer.java
+++ b/tests/frontend/org/voltdb/utils/TestSQLLexer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestSnapshotConverter.java
+++ b/tests/frontend/org/voltdb/utils/TestSnapshotConverter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
+++ b/tests/frontend/org/voltdb/utils/TestSplitSQLStatements.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestSqlCmdErrorHandling.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCmdErrorHandling.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCmdInterface.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestSqlCommandParserInteractive.java
+++ b/tests/frontend/org/voltdb/utils/TestSqlCommandParserInteractive.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestValgrindParser.java
+++ b/tests/frontend/org/voltdb/utils/TestValgrindParser.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/frontend/org/voltdb/utils/TestVoltBulkLoader.java
+++ b/tests/frontend/org/voltdb/utils/TestVoltBulkLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -48,7 +48,7 @@ import org.voltdb.types.TimestampType;
 import junit.framework.TestCase;
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestVoltTrace.java
+++ b/tests/frontend/org/voltdb/utils/TestVoltTrace.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/frontend/org/voltdb/utils/TestVoltTypeUtil.java
+++ b/tests/frontend/org/voltdb/utils/TestVoltTypeUtil.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/build.gradle
+++ b/tests/geb/vmc/build.gradle
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/AdminPage.groovy
+++ b/tests/geb/vmc/src/pages/AdminPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/AnalysisPage.groovy
+++ b/tests/geb/vmc/src/pages/AnalysisPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/Cluster.groovy
+++ b/tests/geb/vmc/src/pages/Cluster.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/DbMonitorPage.groovy
+++ b/tests/geb/vmc/src/pages/DbMonitorPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/Directories.groovy
+++ b/tests/geb/vmc/src/pages/Directories.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/DrPage.groovy
+++ b/tests/geb/vmc/src/pages/DrPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/Footer.groovy
+++ b/tests/geb/vmc/src/pages/Footer.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/Header.groovy
+++ b/tests/geb/vmc/src/pages/Header.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/ImporterPage.groovy
+++ b/tests/geb/vmc/src/pages/ImporterPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/LoginLogoutPage.groovy
+++ b/tests/geb/vmc/src/pages/LoginLogoutPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/NetworkInterfaces.groovy
+++ b/tests/geb/vmc/src/pages/NetworkInterfaces.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/Overview.groovy
+++ b/tests/geb/vmc/src/pages/Overview.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPage.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPageDdlSourceTab.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPageDdlSourceTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPageOverviewTab.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPageOverviewTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPageProceduresAndSqlTab.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPageProceduresAndSqlTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPageSchemaTab.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPageSchemaTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SchemaPageSizeWorksheetTab.groovy
+++ b/tests/geb/vmc/src/pages/SchemaPageSizeWorksheetTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/SqlQueryPage.groovy
+++ b/tests/geb/vmc/src/pages/SqlQueryPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/VoltDBManagementCenterPage.groovy
+++ b/tests/geb/vmc/src/pages/VoltDBManagementCenterPage.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/downloadconfigbtn.groovy
+++ b/tests/geb/vmc/src/pages/downloadconfigbtn.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/schemaTab.groovy
+++ b/tests/geb/vmc/src/pages/schemaTab.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/pages/voltDBclusterserver.groovy
+++ b/tests/geb/vmc/src/pages/voltDBclusterserver.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/resources/GebConfig.groovy
+++ b/tests/geb/vmc/src/resources/GebConfig.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminAdvancedTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminAdvancedTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminDrTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminDrTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminExportEditTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminExportEditTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminExportTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminExportTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminImportEditTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminImportEditTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminImportTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminImportTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminSecurityUserTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminSecurityUserTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminSnmpTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminSnmpTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AdminTest.groovy
+++ b/tests/geb/vmc/src/tests/AdminTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/AnalysisPageTest.groovy
+++ b/tests/geb/vmc/src/tests/AnalysisPageTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/DbMonitorCLPTest.groovy
+++ b/tests/geb/vmc/src/tests/DbMonitorCLPTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/DbMonitorPaginationTest.groovy
+++ b/tests/geb/vmc/src/tests/DbMonitorPaginationTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/DbMonitorTest.groovy
+++ b/tests/geb/vmc/src/tests/DbMonitorTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -511,7 +511,7 @@ class DbMonitorTest extends TestBase {
         waitFor(30) {
             footer.banner.isDisplayed()
             footer.text.isDisplayed()
-            footer.text.text().toLowerCase().contains("Copyright (C) 2008-2019 VoltDB Inc. All rights reserved.".toLowerCase())
+            footer.text.text().toLowerCase().contains("Copyright (C) 2008-2020 VoltDB Inc. All rights reserved.".toLowerCase())
         }
     }
 

--- a/tests/geb/vmc/src/tests/DbMonitorUatTest.groovy
+++ b/tests/geb/vmc/src/tests/DbMonitorUatTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/DrPageTest.groovy
+++ b/tests/geb/vmc/src/tests/DrPageTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/FullDdlSqlBasicTest.groovy
+++ b/tests/geb/vmc/src/tests/FullDdlSqlBasicTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/ImporterTest.groovy
+++ b/tests/geb/vmc/src/tests/ImporterTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/LoginLogoutTest.groovy
+++ b/tests/geb/vmc/src/tests/LoginLogoutTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/NavigatePagesBasicTest.groovy
+++ b/tests/geb/vmc/src/tests/NavigatePagesBasicTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SchemaPageDatabaseTest.groovy
+++ b/tests/geb/vmc/src/tests/SchemaPageDatabaseTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SchemaPageTest.groovy
+++ b/tests/geb/vmc/src/tests/SchemaPageTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -384,7 +384,7 @@ class SchemaPageTest extends TestBase {
         waitFor(waitTime) {
             footer.banner.isDisplayed()
             footer.text.isDisplayed()
-            footer.text.text().toLowerCase().contains("Copyright (C) 2008-2019 VoltDB Inc. All rights reserved.".toLowerCase())
+            footer.text.text().toLowerCase().contains("Copyright (C) 2008-2020 VoltDB Inc. All rights reserved.".toLowerCase())
         }
     }
 

--- a/tests/geb/vmc/src/tests/SqlQueriesAdminTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesAdminTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesBasicTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesBasicTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesExportTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesExportTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesTabTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTabTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesTableAndViewTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTableAndViewTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesTestBase.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTestBase.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/SqlQueriesTextBoxTest.groovy
+++ b/tests/geb/vmc/src/tests/SqlQueriesTextBoxTest.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/geb/vmc/src/tests/TestBase.groovy
+++ b/tests/geb/vmc/src/tests/TestBase.groovy
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
+++ b/tests/hsqldb/org/hsqldb_voltpatches/TestHSQLDB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/hsqldb/org/hsqldb_voltpatches/TestJDBC.java
+++ b/tests/hsqldb/org/hsqldb_voltpatches/TestJDBC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/scripts/Testvoltdbclient.py
+++ b/tests/scripts/Testvoltdbclient.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/exp_test.py
+++ b/tests/scripts/exp_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.6
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/mesh_test.cpp
+++ b/tests/scripts/mesh_test.cpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/scripts/profctl.py
+++ b/tests/scripts/profctl.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/python_client_bench.py
+++ b/tests/scripts/python_client_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/runcppunit.py
+++ b/tests/scripts/runcppunit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/runcppunit_test.py
+++ b/tests/scripts/runcppunit_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/sqltests.py
+++ b/tests/scripts/sqltests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/valleak.py
+++ b/tests/scripts/valleak.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/scripts/valleak_test.py
+++ b/tests/scripts/valleak_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/functions/sqlcmdtest/IntFunction.java
+++ b/tests/sqlcmd/functions/sqlcmdtest/IntFunction.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/BadSwap.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/BadSwap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/BoxedInsertEmployee.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/BoxedInsertEmployee.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/Breakable0.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/Breakable0.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/Breakable1.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/Breakable1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/Breakable2.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/Breakable2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/InsertEmployee.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/InsertEmployee.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/ReferencedGetsSabotaged.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/ReferencedGetsSabotaged.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/Trivial.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/Trivial.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/procedures/sqlcmdtest/UsesUDF.java
+++ b/tests/sqlcmd/procedures/sqlcmdtest/UsesUDF.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/sqlcmdtest.py
+++ b/tests/sqlcmd/sqlcmdtest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcmd/test_voltsql.sh
+++ b/tests/sqlcmd/test_voltsql.sh
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/sqlcoverage/SQLCoverageReport.py
+++ b/tests/sqlcoverage/SQLCoverageReport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/SQLGenerator.py
+++ b/tests/sqlcoverage/SQLGenerator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/default-advanced-config.py
+++ b/tests/sqlcoverage/config/default-advanced-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/default-advanced-mv-subq-config.py
+++ b/tests/sqlcoverage/config/default-advanced-mv-subq-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/default-basic-config.py
+++ b/tests/sqlcoverage/config/default-basic-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/default-regression-config.py
+++ b/tests/sqlcoverage/config/default-regression-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/extended-config.py
+++ b/tests/sqlcoverage/config/extended-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/extended-subq-joins-config.py
+++ b/tests/sqlcoverage/config/extended-subq-joins-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/matview-config.py
+++ b/tests/sqlcoverage/config/matview-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/matview-int-config.py
+++ b/tests/sqlcoverage/config/matview-int-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/old-all-config.py
+++ b/tests/sqlcoverage/config/old-all-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/old-config.py
+++ b/tests/sqlcoverage/config/old-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/old-geo-config.py
+++ b/tests/sqlcoverage/config/old-geo-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/old-joined-matview-config.py
+++ b/tests/sqlcoverage/config/old-joined-matview-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-analytic-config.py
+++ b/tests/sqlcoverage/config/postgis-analytic-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-analytic-geo-config.py
+++ b/tests/sqlcoverage/config/postgis-analytic-geo-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-analytic-int-config.py
+++ b/tests/sqlcoverage/config/postgis-analytic-int-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-analytic-timestamp-config.py
+++ b/tests/sqlcoverage/config/postgis-analytic-timestamp-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-cte-config.py
+++ b/tests/sqlcoverage/config/postgis-cte-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-geo-config.py
+++ b/tests/sqlcoverage/config/postgis-geo-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/postgis-upsert-jmv-config.py
+++ b/tests/sqlcoverage/config/postgis-upsert-jmv-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/regression-config.py
+++ b/tests/sqlcoverage/config/regression-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/config/sql-grammar-gen-config.py
+++ b/tests/sqlcoverage/config/sql-grammar-gen-config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/NotANormalizer.py
+++ b/tests/sqlcoverage/normalizer/NotANormalizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/SortNulls.py
+++ b/tests/sqlcoverage/normalizer/SortNulls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/StandardNormalizer.py
+++ b/tests/sqlcoverage/normalizer/StandardNormalizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/normalizer.py
+++ b/tests/sqlcoverage/normalizer/normalizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/not-a-normalizer.py
+++ b/tests/sqlcoverage/normalizer/not-a-normalizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/normalizer/nulls-lowest-normalizer.py
+++ b/tests/sqlcoverage/normalizer/nulls-lowest-normalizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/decimal-schema.py
+++ b/tests/sqlcoverage/schema/decimal-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/geo-point-schema.py
+++ b/tests/sqlcoverage/schema/geo-point-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/geo-polygon-schema.py
+++ b/tests/sqlcoverage/schema/geo-polygon-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/index-count1-schema.py
+++ b/tests/sqlcoverage/schema/index-count1-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/index-join-schema.py
+++ b/tests/sqlcoverage/schema/index-join-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/index-scan-schema.py
+++ b/tests/sqlcoverage/schema/index-scan-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/index-varbinary-schema.py
+++ b/tests/sqlcoverage/schema/index-varbinary-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/insert-into-select-schema.py
+++ b/tests/sqlcoverage/schema/insert-into-select-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/int-schema.py
+++ b/tests/sqlcoverage/schema/int-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/joined-matview-int-schema.py
+++ b/tests/sqlcoverage/schema/joined-matview-int-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/joined-matview-schema.py
+++ b/tests/sqlcoverage/schema/joined-matview-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/joined-matview-string-schema.py
+++ b/tests/sqlcoverage/schema/joined-matview-string-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/joined-matview-timestamp-schema.py
+++ b/tests/sqlcoverage/schema/joined-matview-timestamp-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-advanced-join-schema.py
+++ b/tests/sqlcoverage/schema/matview-advanced-join-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-advanced-ncs-join-schema.py
+++ b/tests/sqlcoverage/schema/matview-advanced-ncs-join-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-advanced-ncs-nonjoin-schema.py
+++ b/tests/sqlcoverage/schema/matview-advanced-ncs-nonjoin-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-advanced-nonjoin-schema.py
+++ b/tests/sqlcoverage/schema/matview-advanced-nonjoin-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-basic-schema.py
+++ b/tests/sqlcoverage/schema/matview-basic-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/matview-query-opt-schema.py
+++ b/tests/sqlcoverage/schema/matview-query-opt-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/optimizer-matview-schema.py
+++ b/tests/sqlcoverage/schema/optimizer-matview-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/partial-covering-schema.py
+++ b/tests/sqlcoverage/schema/partial-covering-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/pushdown-schema.py
+++ b/tests/sqlcoverage/schema/pushdown-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/schema.py
+++ b/tests/sqlcoverage/schema/schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/sql-grammar-gen-schema.py
+++ b/tests/sqlcoverage/schema/sql-grammar-gen-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/strings-schema.py
+++ b/tests/sqlcoverage/schema/strings-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/timestamp-schema.py
+++ b/tests/sqlcoverage/schema/timestamp-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/schema/union-schema.py
+++ b/tests/sqlcoverage/schema/union-schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlcoverage/sql_coverage_test.py
+++ b/tests/sqlcoverage/sql_coverage_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/mp-checker
+++ b/tests/sqlgrammar/mp-checker
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/sqlgrammar/plan-checker
+++ b/tests/sqlgrammar/plan-checker
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/sqlgrammar/procedures/sqlgrammartest/GetOrInsertBase.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/GetOrInsertBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1ins.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1ins.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1insMax.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1insMax.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1insMin.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1insMin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1max.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1max.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1min.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1min.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1sel.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPP1sel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1ins.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1ins.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1insMax.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1insMax.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1insMin.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1insMin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1max.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1max.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1min.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1min.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1sel.java
+++ b/tests/sqlgrammar/procedures/sqlgrammartest/JSPR1sel.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/sqlgrammar/sql_grammar_generator.py
+++ b/tests/sqlgrammar/sql_grammar_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/scripts/generate.py
+++ b/tests/test_apps/adhocbenchmark/scripts/generate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/Benchmark.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/Benchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/BenchmarkConfiguration.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/BenchmarkConfiguration.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/ConfigurationException.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/ConfigurationException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/JoinTest.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/JoinTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/ProjectionTest.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/ProjectionTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/QueryTestBase.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/QueryTestBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocbenchmark/src/adhocbenchmark/QueryTestHelper.java
+++ b/tests/test_apps/adhocbenchmark/src/adhocbenchmark/QueryTestHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocddl/src/adhocddl/AdHocDDLBenchmark.java
+++ b/tests/test_apps/adhocddl/src/adhocddl/AdHocDDLBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocddl/src/adhocddl/DDLGenerator.java
+++ b/tests/test_apps/adhocddl/src/adhocddl/DDLGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/adhocsmash/src/adhocsmash/AdhocSmash.java
+++ b/tests/test_apps/adhocsmash/src/adhocsmash/AdhocSmash.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/aggbench/src/aggregationbenchmark/AggregationBenchmark.java
+++ b/tests/test_apps/aggbench/src/aggregationbenchmark/AggregationBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/aggregates/src/aggregates/Loader.java
+++ b/tests/test_apps/aggregates/src/aggregates/Loader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/approx-count-distinct/client/approxcountdistinct/Benchmark.java
+++ b/tests/test_apps/approx-count-distinct/client/approxcountdistinct/Benchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/approx-count-distinct/procedures/approxcountdistinct/DoCount.java
+++ b/tests/test_apps/approx-count-distinct/procedures/approxcountdistinct/DoCount.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/csvbenchmark/csvbenchmark.py
+++ b/tests/test_apps/csvbenchmark/csvbenchmark.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/csvbenchmark/src/csvbenchmark/procedures/DoNothingProcedure.java
+++ b/tests/test_apps/csvbenchmark/src/csvbenchmark/procedures/DoNothingProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ctindex/client/ctindex/Client.java
+++ b/tests/test_apps/ctindex/client/ctindex/Client.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ctindex/procedures/ctindex/CountStarRange.java
+++ b/tests/test_apps/ctindex/procedures/ctindex/CountStarRange.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ctindex/procedures/ctindex/CountStarSmaller.java
+++ b/tests/test_apps/ctindex/procedures/ctindex/CountStarSmaller.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ctindex/procedures/ctindex/Insert.java
+++ b/tests/test_apps/ctindex/procedures/ctindex/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/ClientDelete.java
+++ b/tests/test_apps/dedupe/src/com/ClientDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/ClientMover.java
+++ b/tests/test_apps/dedupe/src/com/ClientMover.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/ClientMoverEL.java
+++ b/tests/test_apps/dedupe/src/com/ClientMoverEL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/ClientRandom.java
+++ b/tests/test_apps/dedupe/src/com/ClientRandom.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/ArchiveVisits.java
+++ b/tests/test_apps/dedupe/src/com/procedures/ArchiveVisits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/ArchiveVisitsEL.java
+++ b/tests/test_apps/dedupe/src/com/procedures/ArchiveVisitsEL.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/CheckUserId.java
+++ b/tests/test_apps/dedupe/src/com/procedures/CheckUserId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/DeleteVisits.java
+++ b/tests/test_apps/dedupe/src/com/procedures/DeleteVisits.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/RecordHit.java
+++ b/tests/test_apps/dedupe/src/com/procedures/RecordHit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/dedupe/src/com/procedures/RecordHitMulti.java
+++ b/tests/test_apps/dedupe/src/com/procedures/RecordHitMulti.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/deletes/src/com/DeletesClient.java
+++ b/tests/test_apps/deletes/src/com/DeletesClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/deletes/src/com/deletes/CountBatchSize.java
+++ b/tests/test_apps/deletes/src/com/deletes/CountBatchSize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/deletes/src/com/deletes/DeleteDeceased.java
+++ b/tests/test_apps/deletes/src/com/deletes/DeleteDeceased.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/deletes/src/com/deletes/DeleteOldBatches.java
+++ b/tests/test_apps/deletes/src/com/deletes/DeleteOldBatches.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/deletes/src/com/deletes/Insert.java
+++ b/tests/test_apps/deletes/src/com/deletes/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng1969/src/eng1969/AsyncBenchmark.java
+++ b/tests/test_apps/eng1969/src/eng1969/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng1969/src/eng1969/procedures/CreateKey.java
+++ b/tests/test_apps/eng1969/src/eng1969/procedures/CreateKey.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng1969/src/eng1969/procedures/UpdateKey.java
+++ b/tests/test_apps/eng1969/src/eng1969/procedures/UpdateKey.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng585/src/com/eng585/Boom.java
+++ b/tests/test_apps/eng585/src/com/eng585/Boom.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng585/src/com/eng585/InsertS.java
+++ b/tests/test_apps/eng585/src/com/eng585/InsertS.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng585/src/com/eng585/InsertT.java
+++ b/tests/test_apps/eng585/src/com/eng585/InsertT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng585/src/com/eng585/LoadS.java
+++ b/tests/test_apps/eng585/src/com/eng585/LoadS.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng585/src/com/eng585/LoadT.java
+++ b/tests/test_apps/eng585/src/com/eng585/LoadT.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng866/src/com/Eng866Client.java
+++ b/tests/test_apps/eng866/src/com/Eng866Client.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng866/src/com/eng866/Delete.java
+++ b/tests/test_apps/eng866/src/com/eng866/Delete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng866/src/com/eng866/Insert.java
+++ b/tests/test_apps/eng866/src/com/eng866/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/eng866/src/com/eng866/Select.java
+++ b/tests/test_apps/eng866/src/com/eng866/Select.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/client/exportbenchmark/ExportBenchmark.java
+++ b/tests/test_apps/exportbenchmark/client/exportbenchmark/ExportBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport1.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport10.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport10.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport11.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport11.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport12.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport12.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport13.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport13.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport14.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport14.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport15.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport15.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport16.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport16.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport17.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport17.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport18.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport18.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport19.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport19.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport2.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport20.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport20.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport21.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport21.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport22.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport22.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport23.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport23.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport24.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport24.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport25.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport25.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport26.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport26.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport27.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport27.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport28.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport28.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport29.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport29.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport3.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport30.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport30.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport31.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport31.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport32.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport32.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport33.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport33.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport34.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport34.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport35.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport35.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport36.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport36.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport37.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport37.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport38.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport38.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport39.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport39.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport4.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport40.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport40.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport41.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport41.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport42.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport42.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport43.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport43.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport44.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport44.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport45.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport45.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport46.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport46.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport47.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport47.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport48.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport48.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport49.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport49.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport5.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport5.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport50.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport50.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport6.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport6.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport7.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport7.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport8.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport8.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport9.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/InsertExport9.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/procedures/exportbenchmark/SampleRecord.java
+++ b/tests/test_apps/exportbenchmark/procedures/exportbenchmark/SampleRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/server/exportbenchmark/NoOpExporter.java
+++ b/tests/test_apps/exportbenchmark/server/exportbenchmark/NoOpExporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/exportbenchmark/server/exportbenchmark/SocketExporter.java
+++ b/tests/test_apps/exportbenchmark/server/exportbenchmark/SocketExporter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/customexport/CustomOnServerExportClient.java
+++ b/tests/test_apps/genqa/src/customexport/CustomOnServerExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/customexport/OverflowingServerExportClient.java
+++ b/tests/test_apps/genqa/src/customexport/OverflowingServerExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/AsyncBenchmark.java
+++ b/tests/test_apps/genqa/src/genqa/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
+++ b/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/ExportRabbitMQVerifier.java
+++ b/tests/test_apps/genqa/src/genqa/ExportRabbitMQVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/JDBCBenchmark.java
+++ b/tests/test_apps/genqa/src/genqa/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/JDBCGetData.java
+++ b/tests/test_apps/genqa/src/genqa/JDBCGetData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/JDBCVoltVerifier.java
+++ b/tests/test_apps/genqa/src/genqa/JDBCVoltVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/KafkaClientVerifier.java
+++ b/tests/test_apps/genqa/src/genqa/KafkaClientVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/ReadVoltRows.java
+++ b/tests/test_apps/genqa/src/genqa/ReadVoltRows.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/RoughCSVTokenizer.java
+++ b/tests/test_apps/genqa/src/genqa/RoughCSVTokenizer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/RowCompare.java
+++ b/tests/test_apps/genqa/src/genqa/RowCompare.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/RowVerifier.java
+++ b/tests/test_apps/genqa/src/genqa/RowVerifier.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/SyncBenchmark.java
+++ b/tests/test_apps/genqa/src/genqa/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/ValidationErr.java
+++ b/tests/test_apps/genqa/src/genqa/ValidationErr.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/VerifierUtils.java
+++ b/tests/test_apps/genqa/src/genqa/VerifierUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/InsertExportDoneDetails.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/InsertExportDoneDetails.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleExportGeoSinglePartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleExportGeoSinglePartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleExportGroupSinglePartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleExportGroupSinglePartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleExportMultiPartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleExportMultiPartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleExportSinglePartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleExportSinglePartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleMultiPartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleMultiPartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleMultiPartitionWithDeletionExport.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleMultiPartitionWithDeletionExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleSinglePartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleSinglePartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/JiggleSinglePartitionWithDeletionExport.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/JiggleSinglePartitionWithDeletionExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/MigratePartitionedExport.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/MigratePartitionedExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/MigrateReplicatedExport.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/MigrateReplicatedExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/SampleGeoRecord.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/SampleGeoRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/SampleRecord.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/SampleRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/TableExport.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/TableExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/WaitMultiPartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/WaitMultiPartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa/procedures/WaitSinglePartition.java
+++ b/tests/test_apps/genqa/src/genqa/procedures/WaitSinglePartition.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/genqa/src/genqa2/procedures/SampleRecord.java
+++ b/tests/test_apps/genqa/src/genqa2/procedures/SampleRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/client/benchmark/Benchmark.java
+++ b/tests/test_apps/insertdelete/client/benchmark/Benchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/client/benchmark/BenchmarkCallback.java
+++ b/tests/test_apps/insertdelete/client/benchmark/BenchmarkCallback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/client/benchmark/BenchmarkStats.java
+++ b/tests/test_apps/insertdelete/client/benchmark/BenchmarkStats.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/client/benchmark/NonEmptyBenchmark.java
+++ b/tests/test_apps/insertdelete/client/benchmark/NonEmptyBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/client/benchmark/SeedTables.java
+++ b/tests/test_apps/insertdelete/client/benchmark/SeedTables.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/procedures/InsertDelete.java
+++ b/tests/test_apps/insertdelete/procedures/InsertDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/insertdelete/procedures/InsertDeleteWithString.java
+++ b/tests/test_apps/insertdelete/procedures/InsertDeleteWithString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/InsertExport.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/InsertExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/KafkaImportBenchmark.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/KafkaImportBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/MatchChecks.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/Producer.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/Producer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/SampleRecord.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/SampleRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/client/kafkaimporter/TableChangeMonitor.java
+++ b/tests/test_apps/kafkaimporter/client/kafkaimporter/TableChangeMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/custom_formatter/formatter/ExampleFormatter.java
+++ b/tests/test_apps/kafkaimporter/custom_formatter/formatter/ExampleFormatter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/custom_formatter/formatter/ExampleFormatterFactory.java
+++ b/tests/test_apps/kafkaimporter/custom_formatter/formatter/ExampleFormatterFactory.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertExport.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertExport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertExport2.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertExport2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertFinal.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertFinal.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImport.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImport2.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImport2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount1.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount2.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount3.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount4.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/InsertImportWithCount4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/MatchRows.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/MatchRows.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/db/procedures/SampleRecord.java
+++ b/tests/test_apps/kafkaimporter/db/procedures/SampleRecord.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/pounder.groovy
+++ b/tests/test_apps/kafkaimporter/pounder.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/pounder10.groovy
+++ b/tests/test_apps/kafkaimporter/pounder10.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kafkaimporter/pounder8.groovy
+++ b/tests/test_apps/kafkaimporter/pounder8.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/chartbuilder.groovy
+++ b/tests/test_apps/kvbenchmark/chartbuilder.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/HTTPBenchmark.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/HTTPBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/HTTPUtils.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/HTTPUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/PayloadProcessor.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/PayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/SyncBenchmark.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/procedures/Get.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/procedures/Get.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/procedures/Initialize.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/procedures/Put.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/procedures/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/kvbenchmark/src/kvbench/procedures/Remove.java
+++ b/tests/test_apps/kvbenchmark/src/kvbench/procedures/Remove.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/AsyncBenchmark.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/CheckReplicaConsistency.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/CheckReplicaConsistency.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/Initialize.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/MPUpdatePtn.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/MPUpdatePtn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/MPUpdateRep.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/MPUpdateRep.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCRCFromPtn.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCRCFromPtn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCRCFromRep.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCRCFromRep.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCountFromPtn.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCountFromPtn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCountFromRep.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getCountFromRep.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getNextFromPtn.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getNextFromPtn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getRowFromPtn.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getRowFromPtn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getRowFromRep.java
+++ b/tests/test_apps/live-rejoin-consistency/src/liverejoinconsistency/procedures/getRowFromRep.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/FetchLogRowsProcedure.java
+++ b/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/FetchLogRowsProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/LogAnalyzer.java
+++ b/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/LogAnalyzer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/LogTestClient.java
+++ b/tests/test_apps/log4jsocketimporter/src/log4jsocketimporter/LogTestClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/BenchmarkPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/BenchmarkPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/FourMinMaxPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/FourMinMaxPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/JoinedTableViewPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/JoinedTableViewPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MaterializedViewBenchmark.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MaterializedViewBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MinMaxPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MinMaxPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinBestOptPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinBestOptPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinOptPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinOptPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/MultiGroupsMinPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/NoJoinedTableViewPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/NoJoinedTableViewPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/Optimized4MinMaxPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/Optimized4MinMaxPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/OptimizedMinMaxPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/OptimizedMinMaxPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/WithViewPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/WithViewPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/matviewbenchmark/src/matviewbenchmark/WithoutViewPhase.java
+++ b/tests/test_apps/matviewbenchmark/src/matviewbenchmark/WithoutViewPhase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/measure-overhead/src/measureoverhead/MOBenchmark.java
+++ b/tests/test_apps/measure-overhead/src/measureoverhead/MOBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_ROMP.java
+++ b/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_ROMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_ROSP.java
+++ b/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_ROSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_RWMP.java
+++ b/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_RWMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_RWSP.java
+++ b/tests/test_apps/measure-overhead/src/measureoverhead/procedures/MO_RWSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/client/np/NPBenchmark.java
+++ b/tests/test_apps/nptxn-perf-benchmark/client/np/NPBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/procs/np/Authorize.java
+++ b/tests/test_apps/nptxn-perf-benchmark/procs/np/Authorize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/procs/np/Redeem.java
+++ b/tests/test_apps/nptxn-perf-benchmark/procs/np/Redeem.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/procs/np/Select.java
+++ b/tests/test_apps/nptxn-perf-benchmark/procs/np/Select.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/procs/np/Transfer.java
+++ b/tests/test_apps/nptxn-perf-benchmark/procs/np/Transfer.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/nptxn-perf-benchmark/run.sh
+++ b/tests/test_apps/nptxn-perf-benchmark/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/OneShotBenchmark.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/OneShotBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/PayloadProcessor.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/PayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Get.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Get.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/GetMP.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/GetMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Initialize.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/OptimisticPutsMP.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/OptimisticPutsMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Put.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/PutsMP.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/PutsMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Remove.java
+++ b/tests/test_apps/oneshotkv/src/oneshotkv/procedures/Remove.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/osm-import/client/osmimport/OSMImport.java
+++ b/tests/test_apps/osm-import/client/osmimport/OSMImport.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/osm-import/client/osmimport/VoltDBOsmSink.java
+++ b/tests/test_apps/osm-import/client/osmimport/VoltDBOsmSink.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/osm-import/client/osmimport/WayPolygonGeometryBuilder.java
+++ b/tests/test_apps/osm-import/client/osmimport/WayPolygonGeometryBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/overhead/src/overhead/AsyncBenchmark.java
+++ b/tests/test_apps/overhead/src/overhead/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/overhead/src/overhead/procedures/BinaryPayload.java
+++ b/tests/test_apps/overhead/src/overhead/procedures/BinaryPayload.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/overhead/src/overhead/procedures/BinaryPayloadRW.java
+++ b/tests/test_apps/overhead/src/overhead/procedures/BinaryPayloadRW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/overhead/src/overhead/procedures/NoArgs.java
+++ b/tests/test_apps/overhead/src/overhead/procedures/NoArgs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/overhead/src/overhead/procedures/NoArgsRW.java
+++ b/tests/test_apps/overhead/src/overhead/procedures/NoArgsRW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/polygonBenchmark/client/polygonBenchmark/AsyncBenchmark.java
+++ b/tests/test_apps/polygonBenchmark/client/polygonBenchmark/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsObject.java
+++ b/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsObject.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsString.java
+++ b/tests/test_apps/polygonBenchmark/procedures/polygonBenchmark/InsertPolygonAsString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/scans/src/scans/ScanBenchmark.java
+++ b/tests/test_apps/scans/src/scans/ScanBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/scans/src/scans/procedures/MinIndexScan.java
+++ b/tests/test_apps/scans/src/scans/procedures/MinIndexScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/scans/src/scans/procedures/MinSeqScan.java
+++ b/tests/test_apps/scans/src/scans/procedures/MinSeqScan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/schemachange/src/schemachange/SchemaChangeClient.java
+++ b/tests/test_apps/schemachange/src/schemachange/SchemaChangeClient.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/schemachange/src/schemachange/SchemaChangeUtility.java
+++ b/tests/test_apps/schemachange/src/schemachange/SchemaChangeUtility.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/schemachange/src/schemachange/TableLoader.java
+++ b/tests/test_apps/schemachange/src/schemachange/TableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/schemachange/src/schemachange/VerifySchemaChangedA.java
+++ b/tests/test_apps/schemachange/src/schemachange/VerifySchemaChangedA.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/schemachange/src/schemachange/VerifySchemaChangedB.java
+++ b/tests/test_apps/schemachange/src/schemachange/VerifySchemaChangedB.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/socketimporter/client/socketimporter/AsyncBenchmark.java
+++ b/tests/test_apps/socketimporter/client/socketimporter/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/socketimporter/client/socketimporter/DataUtils.java
+++ b/tests/test_apps/socketimporter/client/socketimporter/DataUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/socketimporter/client/socketimporter/UtilQueries.java
+++ b/tests/test_apps/socketimporter/client/socketimporter/UtilQueries.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/tpcc/client/com/Clock.java
+++ b/tests/test_apps/tpcc/client/com/Clock.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/client/com/Constants.java
+++ b/tests/test_apps/tpcc/client/com/Constants.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/client/com/MyLoader.java
+++ b/tests/test_apps/tpcc/client/com/MyLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/client/com/MyTPCC.java
+++ b/tests/test_apps/tpcc/client/com/MyTPCC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/tpcc/client/com/RandomGenerator.java
+++ b/tests/test_apps/tpcc/client/com/RandomGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/client/com/ScaleParameters.java
+++ b/tests/test_apps/tpcc/client/com/ScaleParameters.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/client/com/TPCCSimulation.java
+++ b/tests/test_apps/tpcc/client/com/TPCCSimulation.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/ByteBuilder.java
+++ b/tests/test_apps/tpcc/src/com/procedures/ByteBuilder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/LoadStatus.java
+++ b/tests/test_apps/tpcc/src/com/procedures/LoadStatus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/tpcc/src/com/procedures/LoadWarehouse.java
+++ b/tests/test_apps/tpcc/src/com/procedures/LoadWarehouse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/LoadWarehouseReplicated.java
+++ b/tests/test_apps/tpcc/src/com/procedures/LoadWarehouseReplicated.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/tpcc/src/com/procedures/ResetWarehouse.java
+++ b/tests/test_apps/tpcc/src/com/procedures/ResetWarehouse.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/delivery.java
+++ b/tests/test_apps/tpcc/src/com/procedures/delivery.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/neworder.java
+++ b/tests/test_apps/tpcc/src/com/procedures/neworder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/ostatByCustomerId.java
+++ b/tests/test_apps/tpcc/src/com/procedures/ostatByCustomerId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/ostatByCustomerName.java
+++ b/tests/test_apps/tpcc/src/com/procedures/ostatByCustomerName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerId.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerIdC.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerIdC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerIdW.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerIdW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerName.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerName.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerNameC.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerNameC.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerNameW.java
+++ b/tests/test_apps/tpcc/src/com/procedures/paymentByCustomerNameW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/tpcc/src/com/procedures/slev.java
+++ b/tests/test_apps/tpcc/src/com/procedures/slev.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/AsyncBenchmark.java
+++ b/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/TxnIdPayloadProcessor.java
+++ b/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/TxnIdPayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/Initialize.java
+++ b/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/doTxn.java
+++ b/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/doTxn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/updateReplicated.java
+++ b/tests/test_apps/txnid-selfcheck/src/txnIdSelfCheck/procedures/updateReplicated.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/bigjar/procedures/Insert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/bigjar/procedures/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/bigjar/procedures/SelectLEtbd.java
+++ b/tests/test_apps/txnid-selfcheck2/src/bigjar/procedures/SelectLEtbd.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/donothing/procedures/DoNothingProcedure.java
+++ b/tests/test_apps/txnid-selfcheck2/src/donothing/procedures/DoNothingProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/AdHocMayhemThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/AdHocMayhemThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/Benchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/BenchmarkThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/BenchmarkThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/BigTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/BigTableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/CappedTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/CappedTableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ClientThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ClientThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/DdlThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/DdlThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/InvokeDroppedProcedureThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/InvokeDroppedProcedureThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/LoadTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/LoadTableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ReadThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/ReadThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TTLLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TTLLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TaskLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TaskLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TruncateTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TruncateTableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2PayloadProcessor.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2PayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2RateLimiter.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2RateLimiter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2Utils.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2Utils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/UpdateClassesThread.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/UpdateClassesThread.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/WLoadTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/WLoadTableLoader.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/BIGPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/BIGPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/BIGRTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/BIGRTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPPCountPartitionRows.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPPCountPartitionRows.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPRTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CAPRTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/CopyLoadPartitionedSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteLoadPartitionedSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableSPW.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/DeleteOnlyLoadTableSPW.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/GenHashMismatchOnBigP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/GenHashMismatchOnBigP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportBaseProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportInsertP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportInsertP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportInsertR.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ImportInsertR.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDRTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/NIBDRTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonBaseProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PoisonSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PopulateDimension.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/PopulateDimension.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMPInProcAdHoc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadMPInProcAdHoc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSPInProcAdHoc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReadSPInProcAdHoc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReplicatedUpdateBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ReplicatedUpdateBaseProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SQLStmtAdHocHelperHelper.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SQLStmtAdHocHelperHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SetupAdHocTables.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SetupAdHocTables.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize_Import.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize_Import.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize_Replica.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/Summarize_Replica.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SwapTablesBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/SwapTablesBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TASKPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TASKPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TASKRTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TASKRTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPScanAggTableMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPScanAggTableMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPScanAggTableSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPScanAggTableSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPSwapTablesMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPTruncateTableMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRUPTruncateTableMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURScanAggTable.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURScanAggTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURSwapTables.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURTruncateTable.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TRURTruncateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TTLMIGRATEPTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TTLMIGRATEPTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TTLMIGRATERTableInsert.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/TTLMIGRATERTableInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBaseProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBothMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateBothMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdatePartitionedMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdatePartitionedMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdatePartitionedSP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdatePartitionedSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateReplicatedMP.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateReplicatedMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateReplicatedMPInProcAdHoc.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/UpdateReplicatedMPInProcAdHoc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ValidateLoadBase.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/ValidateLoadBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/exceptionUDF.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/exceptionUDF.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/udfs.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/procedures/udfs.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/uacbench/client/uac/UpdateClassesBenchmark.java
+++ b/tests/test_apps/uacbench/client/uac/UpdateClassesBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/tests/test_apps/uacbench/uacbench.py
+++ b/tests/test_apps/uacbench/uacbench.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFBenchmark.java
+++ b/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFBenchmarkConfig.java
+++ b/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFBenchmarkConfig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFLib.java
+++ b/tests/test_apps/udfbenchmark/client/udfbenchmark/UDFLib.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/udfbenchmark/run.sh
+++ b/tests/test_apps/udfbenchmark/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/AsyncBenchmark.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/HTTPBenchmark.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/HTTPBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/HTTPUtils.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/HTTPUtils.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/JDBCBenchmark.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/PayloadProcessor.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/PayloadProcessor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/SyncBenchmark.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Get.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Get.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/GetMp.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/GetMp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Initialize.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Put.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/PutMp.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/PutMp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Remove.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures/Remove.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures_withexport/Put.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures_withexport/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voltkvqa/src/voltkvqa/procedures_withexport/PutMp.java
+++ b/tests/test_apps/voltkvqa/src/voltkvqa/procedures_withexport/PutMp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-adhoc/AdHocBenchmark.java
+++ b/tests/test_apps/voter-adhoc/AdHocBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/AsyncBenchmark.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/HTTPBenchmark.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/HTTPBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/JDBCBenchmark.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/PhoneCallGenerator.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/PhoneCallGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/SyncBenchmark.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/procedures/ContestantWinningStates.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/procedures/ContestantWinningStates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/procedures/GetStateHeatmap.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/procedures/GetStateHeatmap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/procedures/Initialize.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/procedures/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/procedures/Results.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/procedures/Results.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-selfcheck/src/voter/procedures/Vote.java
+++ b/tests/test_apps/voter-selfcheck/src/voter/procedures/Vote.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/AsyncBenchmark.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/AsyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/JDBCBenchmark.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/JDBCBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/PhoneCallGenerator.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/PhoneCallGenerator.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/SimpleBenchmark.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/SimpleBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/SyncBenchmark.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/SyncBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/client/voter/TracingBenchmark.java
+++ b/tests/test_apps/voter-tracing-benchmark/client/voter/TracingBenchmark.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/ContestantWinningStates.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/ContestantWinningStates.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/DistinctCount.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/DistinctCount.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/GetStateHeatmap.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/GetStateHeatmap.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/Initialize.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/Initialize.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/Results.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/Results.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/procedures/voter/Vote.java
+++ b/tests/test_apps/voter-tracing-benchmark/procedures/voter/Vote.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/voter-tracing-benchmark/tracingBenchmarkPlot.py
+++ b/tests/test_apps/voter-tracing-benchmark/tracingBenchmarkPlot.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb-zipfian/src/com/procedures/Put.java
+++ b/tests/test_apps/ycsb-zipfian/src/com/procedures/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb-zipfian/src/com/procedures/Scan.java
+++ b/tests/test_apps/ycsb-zipfian/src/com/procedures/Scan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb-zipfian/src/com/yahoo/ycsb/db/ConnectionHelper.java
+++ b/tests/test_apps/ycsb-zipfian/src/com/yahoo/ycsb/db/ConnectionHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb-zipfian/src/com/yahoo/ycsb/db/VoltClient4.java
+++ b/tests/test_apps/ycsb-zipfian/src/com/yahoo/ycsb/db/VoltClient4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb/src/com/procedures/Put.java
+++ b/tests/test_apps/ycsb/src/com/procedures/Put.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb/src/com/procedures/Scan.java
+++ b/tests/test_apps/ycsb/src/com/procedures/Scan.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb/src/com/yahoo/ycsb/db/ConnectionHelper.java
+++ b/tests/test_apps/ycsb/src/com/yahoo/ycsb/db/ConnectionHelper.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/test_apps/ycsb/src/com/yahoo/ycsb/db/VoltClient4.java
+++ b/tests/test_apps/ycsb/src/com/yahoo/ycsb/db/VoltClient4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/BasicTestUDFSuite.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/BasicTestUDFSuite.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Uavg.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Uavg.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Ucount.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Ucount.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/UcountNull.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/UcountNull.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Umax.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Umax.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Umedian.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Umedian.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/UmedianEndUnsupportedReturn.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/UmedianEndUnsupportedReturn.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Umin.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Umin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Umode.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Umode.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/UmodeAssembleUnsupportedParameter.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/UmodeAssembleUnsupportedParameter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Uprimesum.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Uprimesum.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/UprimesumCombineWrongParameter.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/UprimesumCombineWrongParameter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/UserDefinedTestFunctions.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/UserDefinedTestFunctions.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testfuncs/org/voltdb_testfuncs/Usum.java
+++ b/tests/testfuncs/org/voltdb_testfuncs/Usum.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMPWRITE.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLMPWRITE.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSP.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSPWRITE.java
+++ b/tests/testprocs/org/voltdb_testprocs/adhoc/executeSQLSPWRITE.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/catalog/resourceuse/SwitchResourceProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/catalog/resourceuse/SwitchResourceProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/catalog/resourceuse/UseResourceProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/catalog/resourceuse/UseResourceProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingBase.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingCaseInsensitive.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingCaseInsensitive.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingExactMatch.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/GetGreetingExactMatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/LoadGreetings.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/LoadGreetings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/package-info.java
+++ b/tests/testprocs/org/voltdb_testprocs/fakeusecase/greetings/package-info.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/NoMeaningClass.java
+++ b/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/NoMeaningClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testCreateProcFromClassProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testCreateProcFromClassProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testImportProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testImportProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testJavaProcTooManyParams.java
+++ b/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testJavaProcTooManyParams.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testSinglePartitionedTruncateProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/fullddlfeatures/testSinglePartitionedTruncateProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/BufferArrayProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/BufferArrayProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/CurrentTimestampProcedure.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/CurrentTimestampProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/LastBatchLie.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/LastBatchLie.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/VariableBatchSizeMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/VariableBatchSizeMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/VariableBatchSizeSP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/VariableBatchSizeSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/aggregates/Insert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/aggregates/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/ByteBufferAsParam.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/ByteBufferAsParam.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1_MP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1_MP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1_SP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadP1_SP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadR1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/LoadR1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixReadsAndWrites.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixReadsAndWrites.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixReplicatedReadsAndWrites.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixReplicatedReadsAndWrites.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixedReads.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundMixedReads.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundP1Count.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundP1Count.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundR1Count.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/MultiRoundR1Count.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/eng7181.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/basecase/eng7181.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPCatchRethrowOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPCatchRethrowOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPInsertOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPInsertOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPInsertOnReplicatedTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/MPInsertOnReplicatedTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPBigBatchAdvancedOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPBigBatchAdvancedOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPBigBatchOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPBigBatchOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPCatchRethrowOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPCatchRethrowOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPInsertOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPInsertOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPMultipleTryCatchOnPartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/catchexceptions/SPMultipleTryCatchOnPartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/delete/DeleteOrderByLimit.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/delete/DeleteOrderByLimit.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/delete/DeleteOrderByLimitOffset.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/delete/DeleteOrderByLimitOffset.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/explainprocs/JavaProcedure.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/explainprocs/JavaProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertAllowNulls.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertAllowNulls.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertFromTableSelectMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertFromTableSelectMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertFromTableSelectSP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertFromTableSelectSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertNoNulls.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportInsertNoNulls.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportRollbackInsertNoNulls.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/ExportRollbackInsertNoNulls.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/InsertAddedStream.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/InsertAddedStream.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertLoopback.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertLoopback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertNoNulls.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertNoNulls.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertNoNullsRepl.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/TableInsertNoNullsRepl.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/Update_Export.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/exportprocs/Update_Export.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadDecimalToVarcharCompare.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadDecimalToVarcharCompare.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadFloatToVarcharCompare.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadFloatToVarcharCompare.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadParamTypesForTimestamp.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadParamTypesForTimestamp.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadVarcharCompare.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BadVarcharCompare.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BatchTooBig.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/BatchTooBig.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CleanupFail.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CleanupFail.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrashJVM.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrashJVM.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrashVoltDBProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrashVoltDBProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrushExpectations.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/CrushExpectations.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRONonSeqProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRONonSeqProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicROSeqProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicROSeqProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRWProc1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRWProc1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRWProc2.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DeterministicRWProc2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DivideByZero.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/DivideByZero.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FetchTooMuch.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/FetchTooMuch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertBigString.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertBigString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertLotsOfData.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertLotsOfData.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertReplicatedAfterDupPartitionedInsert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/InsertReplicatedAfterDupPartitionedInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/NondeterministicROProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/NondeterministicROProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/NondeterministicRWProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/NondeterministicRWProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate2.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate3.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate4.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate5.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate5.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate6.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPNoncandidate6.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate2.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate3.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate4.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate4.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate5.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate5.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate6.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate6.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate7.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcSPcandidate7.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcToTestTypeConversion.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ProcToTestTypeConversion.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ReturnAppStatus.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ReturnAppStatus.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/SelectBigString.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/SelectBigString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/TooFewParams.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/TooFewParams.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ViolateUniqueness.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ViolateUniqueness.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ViolateUniquenessAndCatchException.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/failureprocs/ViolateUniquenessAndCatchException.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPMultiStatementQuery.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPMultiStatementQuery.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPPopulatePartitionTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fallbackbuffers/SPPopulatePartitionTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/BoxedByteArrays.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/BoxedByteArrays.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/GotBadParamCountsInJava.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/GotBadParamCountsInJava.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InPrimitiveArrays.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InPrimitiveArrays.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/Insert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InsertBatch.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InsertBatch.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InsertBoxed.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/InsertBoxed.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG1232.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG1232.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG1232_2.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG1232_2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG2423.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/fixedsql/TestENG2423.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/CheckMultiMultiIntGTEFailure.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/CheckMultiMultiIntGTEFailure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/CompiledInLists.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/CompiledInLists.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/Insert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/indexes/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/malicious/GoSleep.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/malicious/GoSleep.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AddPerson.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AddPerson.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AddThing.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AddThing.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AggAges.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AggAges.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AggThings.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/AggThings.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/DeletePerson.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/DeletePerson.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/Eng798Insert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/Eng798Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/OverflowTest.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/OverflowTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/SelectAllPeople.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/SelectAllPeople.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateMatViewDataMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateMatViewDataMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncatePeople.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncatePeople.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateTables.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/TruncateTables.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/UpdatePerson.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/matviewprocs/UpdatePerson.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MispartitionedInsert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MispartitionedInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MispartitionedUpdate.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MispartitionedUpdate.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteDelete.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteDelete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteIndexSelect.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteIndexSelect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteSelect.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteSelect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteSelectDuped.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/multipartitionprocs/MultiSiteSelectDuped.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/InsertO1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/InsertO1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/InsertO3.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/InsertO3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByCountStarAlias.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByCountStarAlias.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByNonIndex.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByNonIndex.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByOneIndex.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/orderbyprocs/OrderByOneIndex.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/CountT1A1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/CountT1A1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/InsertDims.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/InsertDims.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/InsertF.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/InsertF.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/SumGroupSingleJoin.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/plansgroupbyprocs/SumGroupSingleJoin.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/proceduredetail/ProcedureDetailTestMP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/proceduredetail/ProcedureDetailTestMP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/proceduredetail/ProcedureDetailTestSP.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/proceduredetail/ProcedureDetailTestSP.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/AdHocPartitionReadOnlyProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/AdHocPartitionReadOnlyProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionReadOnlyProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionReadOnlyProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionReadWriteProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionReadWriteProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionWriteReadProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/PartitionWriteReadProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedReadOnlyProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedReadOnlyProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedReadWriteProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedReadWriteProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedWriteReadProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/ReplicatedWriteReadProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/SPPartitionReadOnlyProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/querytimeout/SPPartitionReadOnlyProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/replication/EvilDeterminism.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/replication/EvilDeterminism.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/replication/SelectEmptyTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/replication/SelectEmptyTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesJavaAbort.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesJavaAbort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesJavaError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesJavaError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesMultiOpsJavaError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesMultiOpsJavaError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesUpdateJavaAbort.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesUpdateJavaAbort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesUpdateJavaError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/AllTypesUpdateJavaError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/FetchNORowUsingIndex.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/FetchNORowUsingIndex.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/InsertAllTypes.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/InsertAllTypes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionConstraintError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionConstraintError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionJavaAbort.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionJavaAbort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionJavaError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionJavaError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/MultiPartitionParamSerializationError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/ReadMatView.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/ReadMatView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionConstraintError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionConstraintError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionConstraintFailureAndContinue.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionConstraintFailureAndContinue.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionJavaAbort.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionJavaAbort.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionJavaError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionJavaError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionParamSerializationError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionUpdateConstraintError.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/rollbackprocs/SinglePartitionUpdateConstraintError.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/GetTxnId.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/GetTxnId.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/MatView.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/MatView.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/SaveRestoreSelect.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/saverestore/SaveRestoreSelect.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing1.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing1.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing2.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing2.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing3.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/securityprocs/DoNothing3.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/BatchedMultiPartitionTest.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/BatchedMultiPartitionTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/FeaturesSelectAll.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/FeaturesSelectAll.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PassAllArgTypes.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PassAllArgTypes.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PassByteArrayArg.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PassByteArrayArg.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PopulateTruncateTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/PopulateTruncateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelectOrderLineByDistInfo.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelectOrderLineByDistInfo.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelectWithJoinOrder.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelectWithJoinOrder.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelfJoinTest.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/SelfJoinTest.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/TruncateTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/TruncateTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/UpdateTests.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/UpdateTests.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/WorkWithBigString.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/WorkWithBigString.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/manycolumnddl.py
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqlfeatureprocs/manycolumnddl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Delete.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Delete.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Insert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Insert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertAddedTable.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertAddedTable.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertBase.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertBase.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertBoxed.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertBoxed.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertMulti.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/InsertMulti.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Loopback.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Loopback.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/ParamSetArrays.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/ParamSetArrays.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/RollbackInsert.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/RollbackInsert.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Select.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Select.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Update.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/Update.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/UpdateDecimal.java
+++ b/tests/testprocs/org/voltdb_testprocs/regressionsuites/sqltypesprocs/UpdateDecimal.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/rejoinfuzz/NonOrgVoltDBProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/rejoinfuzz/NonOrgVoltDBProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/BadClassLoadClass.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/BadClassLoadClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/BadInnerClassesTestProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/BadInnerClassesTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/InnerClassesTestProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/InnerClassesTestProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/NoMeaningClass.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/NoMeaningClass.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithInvalidSQLStmt.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithInvalidSQLStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithSQLStmt.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/TestProcWithSQLStmt.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/jars/TestProcedure.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/jars/TestProcedure.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/testBadInitializerProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/testBadInitializerProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/testCreateProcFromClassProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/testCreateProcFromClassProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testprocs/org/voltdb_testprocs/updateclasses/testImportProc.java
+++ b/tests/testprocs/org/voltdb_testprocs/updateclasses/testImportProc.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tests/testrunner-ng/test.py
+++ b/tests/testrunner-ng/test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testrunner-ng/testsupport/__init__.py
+++ b/tests/testrunner-ng/testsupport/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testrunner-ng/testsupport/cpptest.py
+++ b/tests/testrunner-ng/testsupport/cpptest.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testrunner-ng/testsupport/junit.py
+++ b/tests/testrunner-ng/testsupport/junit.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testrunner-ng/testsupport/runner.py
+++ b/tests/testrunner-ng/testsupport/runner.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/testverbs/voltverbstest.py
+++ b/tests/testverbs/voltverbstest.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/third_party/cpp/boost_ext/FastAllocator.hpp
+++ b/third_party/cpp/boost_ext/FastAllocator.hpp
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This file contains original code and/or modifications of original code.
  * Any modifications made by VoltDB Inc. are licensed under the following

--- a/third_party/java/src/org/json_voltpatches/JSONWriter.java
+++ b/third_party/java/src/org/json_voltpatches/JSONWriter.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/catalog-tool
+++ b/tools/catalog-tool
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/catalog-tool.d/catalog-tool.py
+++ b/tools/catalog-tool.d/catalog-tool.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 ############################################################################################
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/docker/custom/src/run/include/volt.m4
+++ b/tools/docker/custom/src/run/include/volt.m4
@@ -1,6 +1,6 @@
 ############################################################################################
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 ############################################################################################
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/docker/local-host-cluster.sh
+++ b/tools/docker/local-host-cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ############################################################################################
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/tools/gen_sp_from_catalog.py
+++ b/tools/gen_sp_from_catalog.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/jenkins/jenkinsbot.py
+++ b/tools/jenkins/jenkinsbot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 
 # Script that runs jenkinsbot for VoltDB Slack
 

--- a/tools/jenkins/junit-stats.py
+++ b/tools/jenkins/junit-stats.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 
 # A command line tool for getting junit job statistics from Jenkins CI
 

--- a/tools/jenkins/resv.py
+++ b/tools/jenkins/resv.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 
 # A command line tool for reserving equipment via jenkins REST API
 # usage:  resv help

--- a/tools/jenkins/sql_coverage_reporter.py
+++ b/tools/jenkins/sql_coverage_reporter.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 
 import logging
 import os

--- a/tools/kafka/kafka10-message-prober.groovy
+++ b/tools/kafka/kafka10-message-prober.groovy
@@ -2,7 +2,7 @@
 
 /*
  * This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/kafka/kafka10-offset-info.groovy
+++ b/tools/kafka/kafka10-offset-info.groovy
@@ -2,7 +2,7 @@
 
 /*
  * This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/kafka/kafka10-reset-consumer-offset.groovy
+++ b/tools/kafka/kafka10-reset-consumer-offset.groovy
@@ -2,7 +2,7 @@
 
 /*
  * This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/kafka/testkafkaimporter
+++ b/tools/kafka/testkafkaimporter
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/kvm_fragmentation/fragmentation.c
+++ b/tools/kvm_fragmentation/fragmentation.c
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/latencylogger
+++ b/tools/latencylogger
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/lib/python/mysqlutil.py
+++ b/tools/lib/python/mysqlutil.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/meshmonitor/src/MeshMonitor.java
+++ b/tools/meshmonitor/src/MeshMonitor.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as

--- a/tools/postinstall-script/postlaunch-script.sh
+++ b/tools/postinstall-script/postlaunch-script.sh
@@ -1,7 +1,7 @@
 # !/usr/bin/env bash
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/toolrunner.py
+++ b/tools/toolrunner.py
@@ -1,6 +1,6 @@
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/vmc_stats_emulator.py
+++ b/tools/vmc_stats_emulator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.6
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/voltdb-install.py
+++ b/tools/voltdb-install.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/voltify
+++ b/tools/voltify
@@ -2,7 +2,7 @@
 
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/voltify.d/template/Client.java
+++ b/tools/voltify.d/template/Client.java
@@ -1,5 +1,5 @@
 /* This file is part of VoltDB.
- * Copyright (C) 2008-2019 VoltDB Inc.
+ * Copyright (C) 2008-2020 VoltDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/tools/voltify.d/voltify.py
+++ b/tools/voltify.d/voltify.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/voter
+++ b/tools/voter
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # This file is part of VoltDB.
 
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # This file contains original code and/or modifications of original code.
 # Any modifications made by VoltDB Inc. are licensed under the following

--- a/tools/voter.d/voter.py
+++ b/tools/voter.d/voter.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/watch_flow.py
+++ b/tools/watch_flow.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tools/watch_performance.py
+++ b/tools/watch_performance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of VoltDB.
-# Copyright (C) 2008-2019 VoltDB Inc.
+# Copyright (C) 2008-2020 VoltDB Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the


### PR DESCRIPTION
Modified, in voltdb (community), all the copyright dates, of all the
licenses, of all the files, using the new 'license_copyright_updater.sh'
script.