### PR TITLE
ENG-19088 Fix eecheck on all os

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -534,6 +534,71 @@ void* CompactingChunks::free(void* dst) {
     }
 }
 
+inline void CompactingChunks::free(typename CompactingChunks::remove_direction dir, void const* p) {
+    switch (dir) {
+        case remove_direction::from_head:
+            // Schema change: it is called in the same
+            // order as txn iterator.
+            //
+            // NOTE: since we only do chunk-wise drop, any reads
+            // from the allocator when these dispersed calls are
+            // occurring *will* get spurious data.
+            if (p == nullptr) {                         // marks completion
+                if (m_lastFreeFromHead != nullptr && beginTxn().first->contains(m_lastFreeFromHead)) {
+                    // effects deletions in 1st chunk
+                    auto& iter = beginTxn().first;
+                    vassert(reinterpret_cast<char const*>(iter->next()) >= m_lastFreeFromHead + tupleSize());
+                    auto const offset = reinterpret_cast<char const*>(iter->next()) - m_lastFreeFromHead - tupleSize();
+                    if (offset) {                              // some memory ops are unavoidable
+                        char* dst = reinterpret_cast<char*>(iter->begin());
+                        char const* src = reinterpret_cast<char const*>(iter->next()) - offset;
+                        if (dst + offset < src) {
+                            memmove(dst, src, offset);
+                        } else {
+                            memcpy(dst, src, offset);
+                        }
+                        reinterpret_cast<char*&>(iter->m_next) = dst + offset;
+                    } else {                                   // right on the boundary
+                        pop_front();
+                        beginTxn() = empty() ? make_pair(end(), nullptr) : make_pair(begin(), begin()->next());
+                    }
+                    m_lastFreeFromHead = nullptr;
+                }
+            } else if (empty()) {
+                snprintf(buf, sizeof buf, "CompactingChunks::remove(from_head, %p): empty allocator", p);
+                buf[sizeof buf - 1] = 0;
+                throw underflow_error(buf);
+            } else {
+                vassert((m_lastFreeFromHead == nullptr && p == beginTxn().first->begin()) ||       // called for the first time?
+                        (beginTxn().first->contains(p) && m_lastFreeFromHead + tupleSize() == p) ||// same chunk,
+                        next(beginTxn().first)->begin() == p);                                     // or next chunk
+                if (! beginTxn().first->contains(m_lastFreeFromHead = reinterpret_cast<char const*>(p))) {
+                    pop_front();
+                    beginTxn() = {begin(), begin()->next()};
+                }
+                --m_allocs;
+            }
+            break;
+        case remove_direction::from_tail:
+            // Undo insert: it is called in the exactly
+            // opposite order of txn iterator.
+            if (empty()) {
+                snprintf(buf, sizeof buf, "CompactingChunks::remove(from_tail, %p): empty allocator", p);
+                buf[sizeof buf - 1] = 0;
+                throw underflow_error(buf);
+            } else {
+                vassert(reinterpret_cast<char const*>(p) + tupleSize() == last()->next());
+                if (last()->begin() == (last()->m_next = const_cast<void*>(p))) { // delete last chunk
+                    pop_back();
+                }
+                --m_allocs;
+            }
+            break;
+        default:;
+    }
+}
+
+
 inline pair<typename CompactingChunks::list_type::iterator, void const*> const&
 CompactingChunks::beginTxn() const noexcept {
     return m_txnFirstChunk;
@@ -1226,7 +1291,7 @@ inline HistoryRetainTrait<gc_policy::batched>::HistoryRetainTrait(
         HistoryRetainTrait::cb_type const& cb): BaseHistoryRetainTrait(cb) {}
 
 inline void HistoryRetainTrait<gc_policy::batched>::remove(void const* addr) {
-    if (++m_size == BatchSize) {
+    if (++m_size == static_cast<unsigned char>(gc_policy::batched)) {
         for_each(m_batched.begin(), m_batched.end(), m_cb);
         m_batched.clear();
         m_size = 0;
@@ -1391,71 +1456,11 @@ HookedCompactingChunks<Hook, E>::remove(void* dst) {
 }
 
 template<typename Hook, typename E> inline void
-HookedCompactingChunks<Hook, E>::remove(
-        typename HookedCompactingChunks<Hook, E>::remove_direction dir, void const* p) {
+HookedCompactingChunks<Hook, E>::remove(typename CompactingChunks::remove_direction dir, void const* p) {
     if (frozen()) {
         throw logic_error("Cannot remove from head or tail when frozen");
-    }
-    switch (dir) {
-        case remove_direction::from_head:
-            // Schema change: it is called in the same
-            // order as txn iterator.
-            //
-            // NOTE: since we only do chunk-wise drop, any reads
-            // from the allocator when these dispersed calls are
-            // occurring *will* get spurious data.
-            if (p == nullptr) {                         // marks completion
-                if (m_lastFreeFromHead != nullptr && beginTxn().first->contains(m_lastFreeFromHead)) {
-                    // effects deletions in 1st chunk
-                    auto& iter = beginTxn().first;
-                    auto const offset = reinterpret_cast<char const*>(iter->next()) - m_lastFreeFromHead - tupleSize();
-                    vassert(offset >= 0);
-                    if (offset) {                              // some memory ops are unavoidable
-                        char* dst = reinterpret_cast<char*>(iter->begin());
-                        char const* src = reinterpret_cast<char const*>(iter->next()) - offset;
-                        if (dst + offset < src) {
-                            memmove(dst, src, offset);
-                        } else {
-                            memcpy(dst, src, offset);
-                        }
-                        reinterpret_cast<char*&>(iter->m_next) = dst + offset;
-                    } else {                                   // right on the boundary
-                        pop_front();
-                        beginTxn() = empty() ? make_pair(end(), nullptr) : make_pair(begin(), begin()->next());
-                    }
-                    m_lastFreeFromHead = nullptr;
-                }
-            } else if (empty()) {
-                snprintf(buf, sizeof buf, "HookedCompactingChunks::remove(from_head, %p): empty allocator", p);
-                buf[sizeof buf - 1] = 0;
-                throw underflow_error(buf);
-            } else {
-                vassert((m_lastFreeFromHead == nullptr && p == beginTxn().first->begin()) ||       // called for the first time?
-                        (beginTxn().first->contains(p) && m_lastFreeFromHead + tupleSize() == p) ||// same chunk,
-                        next(beginTxn().first)->begin() == p);                                     // or next chunk
-                if (! beginTxn().first->contains(m_lastFreeFromHead = reinterpret_cast<char const*>(p))) {
-                    pop_front();
-                    beginTxn() = {begin(), begin()->next()};
-                }
-                --CompactingChunks::m_allocs;
-            }
-            break;
-        case remove_direction::from_tail:
-            // Undo insert: it is called in the exactly
-            // opposite order of txn iterator.
-            if (empty()) {
-                snprintf(buf, sizeof buf, "HookedCompactingChunks::remove(from_tail, %p): empty allocator", p);
-                buf[sizeof buf - 1] = 0;
-                throw underflow_error(buf);
-            } else {
-                vassert(reinterpret_cast<char const*>(p) + tupleSize() == last()->next());
-                if (last()->begin() == (last()->m_next = const_cast<void*>(p))) { // delete last chunk
-                    pop_back();
-                }
-                --CompactingChunks::m_allocs;
-            }
-            break;
-        default:;
+    } else {
+        free(dir, p);
     }
 }
 

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -553,9 +553,9 @@ inline void CompactingChunks::free(typename CompactingChunks::remove_direction d
                         char* dst = reinterpret_cast<char*>(iter->begin());
                         char const* src = reinterpret_cast<char const*>(iter->next()) - offset;
                         if (dst + offset < src) {
-                            memmove(dst, src, offset);
-                        } else {
                             memcpy(dst, src, offset);
+                        } else {
+                            memmove(dst, src, offset);
                         }
                         reinterpret_cast<char*&>(iter->m_next) = dst + offset;
                     } else {                                   // right on the boundary

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -55,7 +55,14 @@ namespace voltdb {
          * batched: it deletes in a batch style when fixed
          *       number of entries had been reverted. Kind-of lazy.
          */
-        enum class gc_policy: char {never, always, batched};
+        enum class gc_policy: unsigned char {
+            never, always, batched =
+#ifdef NDEBUG
+                numeric_limits<unsigned char>::max()
+#else
+                16                                     // for eecheck only
+#endif
+        };
 
         /**
          * More efficient stack than STL (which was backed by
@@ -377,6 +384,7 @@ namespace voltdb {
             static size_t gen_id();
 
             size_t const m_id;                    // equivalent to "table id", to ensure injection relation to rw iterator
+            char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
             pair<list_type::iterator, void const*> m_txnFirstChunk{list_type::end(), nullptr};     // (moving) left boundary for txn
             position_type m_frozenTxnBoundary{};  // (frozen) right boundary for txn
             // the end of allocations when snapshot started: (block id, end ptr)
@@ -450,6 +458,12 @@ namespace voltdb {
             // details.
             void* free(void*);
             /**
+             * Light weight free() operations from either end,
+             * involving no compaction.
+             */
+            enum class remove_direction : char {from_head, from_tail};
+            void free(remove_direction, void const*);
+            /**
              * State changes
              */
             void freeze();
@@ -487,12 +501,6 @@ namespace voltdb {
         };
 
         template<> struct HistoryRetainTrait<gc_policy::batched> : BaseHistoryRetainTrait {
-            static constexpr auto const BatchSize =
-#ifdef NDEBUG
-512lu;
-#else
-16lu;          // for eecheck only
-#endif
             size_t m_size = 0;
             forward_list<void const*> m_batched{};
             HistoryRetainTrait(cb_type const&);
@@ -569,7 +577,6 @@ namespace voltdb {
             using CompactingChunks::allocate; using CompactingChunks::free;// hide details
             using CompactingChunks::freeze; using Hook::freeze;
             using Hook::add; using Hook::copy;
-            char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
         public:
             using hook_type = Hook;                    // for hooked_iterator_type
             using Hook::release;                       // reminds to client: this must be called for GC to happen (instead of delaying it to thaw())
@@ -590,7 +597,6 @@ namespace voltdb {
              * (remove_direction::from_head, nullptr). Forgetting to do so will
              * result in uncleaned removal (i.e. part of remove calls are lost).
              */
-            enum class remove_direction : char {from_head, from_tail};
             void remove(remove_direction, void const*);
             /**
              * Batch removal using a single call

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -557,7 +557,7 @@ namespace voltdb {
             // NOTE: the deletion event need to happen before
             // calling add(...), unlike insertion/update.
             void add(CompactingChunks const&, ChangeType, void const*);
-            void const* operator()(void const*) const;               // revert history at this place!
+            void const* operator()(void const*) const;             // revert history at this place!
             void release(void const*);                             // local memory clean-up. Client need to call this upon having done what is needed to record current address in snapshot.
             // auxillary buffer that client must need for tuple deletion/update operation,
             // to hold value before change.

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -82,68 +82,68 @@ BANNER("Configuring the VoltDB Execution Engine Unit Tests."
 SET (VOLTDB_MANUAL_SUCCEEDING_TEST_PROGRAMS
   # These two need to run first, since they take
   # the longest to run.
-  #   storage/LargeTempTableSortTest
-  #   storage/DRBinaryLog_test
-  #   catalog/catalog_test
-  #   catalog/ExportTupleStreamTest
-  #   common/debuglog_test
-  #   common/elastic_hashinator_test
-  #   common/nvalue_test
-  #   common/LargeTempTableBlockIdTest
-  #   common/PerFragmentStatsTest
-  #   common/PoolCheckingTest
-  #   common/pool_test
-  #   common/serializeio_test
-  #   common/tabletuple_test
-  #   common/ThreadLocalPoolTest
-  #   common/tupleschema_test
-  #   common/undolog_test
-  #   common/uniqueid_test
-  #   common/valuearray_test
-  #   execution/add_drop_table
-  #   execution/engine_test
-  #   execution/ExecutorVectorTest
-  #   execution/FragmentManagerTest
-  #   executors/CommonTableExpressionTest
-  #   executors/MergeReceiveExecutorTest
-  #   executors/OptimizedProjectorTest
-  #   expressions/expression_test
-  #   expressions/function_test
-  #   indexes/CompactingHashIndexTest
-  #   indexes/CompactingTreeMultiIndexTest
-  #   indexes/CoveringCellIndexTest
-  #   indexes/index_key_test
-  #   indexes/index_scripted_test
-  #   indexes/index_test
-  #   harness_test/harness_tester
-  #   logging/logging_test
-  #   memleaktests/no_losses
-  #   plannodes/PlanNodeFragmentTest
-  #   plannodes/PlanNodeUtilTest
-  #   plannodes/WindowFunctionPlanNodeTest
-  #   storage/CompactionTest
-  #   storage/constraint_test
-  #   storage/CopyOnWriteTest
-  #   storage/DRTupleStream_test
-  #   storage/ExportTupleStream_test
-  #   storage/filter_test
-  #   storage/LargeTempTableBlockTest
-  #   storage/LargeTempTableTest
-  #   storage/persistent_table_log_test
-  #   storage/PersistentTableMemStatsTest
-  #   storage/persistenttable_test
-  #   storage/serialize_test
-  #   storage/StreamedTable_test
-  #   storage/table_and_indexes_test
-  #   storage/table_test
-  #   storage/tabletuple_export_test
-  #   storage/tabletuplefilter_test
-  #   storage/TempTableLimitsTest
-  #   structures/CompactingHashTest
-  #   structures/CompactingMapBenchmark
-  #   structures/CompactingMapIndexCountTest
-  #   structures/CompactingMapTest
-  #   structures/CompactingPoolTest
+  storage/LargeTempTableSortTest
+  storage/DRBinaryLog_test
+  catalog/catalog_test
+  catalog/ExportTupleStreamTest
+  common/debuglog_test
+  common/elastic_hashinator_test
+  common/nvalue_test
+  common/LargeTempTableBlockIdTest
+  common/PerFragmentStatsTest
+  common/PoolCheckingTest
+  common/pool_test
+  common/serializeio_test
+  common/tabletuple_test
+  common/ThreadLocalPoolTest
+  common/tupleschema_test
+  common/undolog_test
+  common/uniqueid_test
+  common/valuearray_test
+  execution/add_drop_table
+  execution/engine_test
+  execution/ExecutorVectorTest
+  execution/FragmentManagerTest
+  executors/CommonTableExpressionTest
+  executors/MergeReceiveExecutorTest
+  executors/OptimizedProjectorTest
+  expressions/expression_test
+  expressions/function_test
+  indexes/CompactingHashIndexTest
+  indexes/CompactingTreeMultiIndexTest
+  indexes/CoveringCellIndexTest
+  indexes/index_key_test
+  indexes/index_scripted_test
+  indexes/index_test
+  harness_test/harness_tester
+  logging/logging_test
+  memleaktests/no_losses
+  plannodes/PlanNodeFragmentTest
+  plannodes/PlanNodeUtilTest
+  plannodes/WindowFunctionPlanNodeTest
+  storage/CompactionTest
+  storage/constraint_test
+  storage/CopyOnWriteTest
+  storage/DRTupleStream_test
+  storage/ExportTupleStream_test
+  storage/filter_test
+  storage/LargeTempTableBlockTest
+  storage/LargeTempTableTest
+  storage/persistent_table_log_test
+  storage/PersistentTableMemStatsTest
+  storage/persistenttable_test
+  storage/serialize_test
+  storage/StreamedTable_test
+  storage/table_and_indexes_test
+  storage/table_test
+  storage/tabletuple_export_test
+  storage/tabletuplefilter_test
+  storage/TempTableLimitsTest
+  structures/CompactingHashTest
+  structures/CompactingMapBenchmark
+  structures/CompactingMapIndexCountTest
+  structures/CompactingMapTest
+  structures/CompactingPoolTest
 )
 
 #

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -82,68 +82,68 @@ BANNER("Configuring the VoltDB Execution Engine Unit Tests."
 SET (VOLTDB_MANUAL_SUCCEEDING_TEST_PROGRAMS
   # These two need to run first, since they take
   # the longest to run.
-  storage/LargeTempTableSortTest
-  storage/DRBinaryLog_test
-  catalog/catalog_test
-  catalog/ExportTupleStreamTest
-  common/debuglog_test
-  common/elastic_hashinator_test
-  common/nvalue_test
-  common/LargeTempTableBlockIdTest
-  common/PerFragmentStatsTest
-  common/PoolCheckingTest
-  common/pool_test
-  common/serializeio_test
-  common/tabletuple_test
-  common/ThreadLocalPoolTest
-  common/tupleschema_test
-  common/undolog_test
-  common/uniqueid_test
-  common/valuearray_test
-  execution/add_drop_table
-  execution/engine_test
-  execution/ExecutorVectorTest
-  execution/FragmentManagerTest
-  executors/CommonTableExpressionTest
-  executors/MergeReceiveExecutorTest
-  executors/OptimizedProjectorTest
-  expressions/expression_test
-  expressions/function_test
-  indexes/CompactingHashIndexTest
-  indexes/CompactingTreeMultiIndexTest
-  indexes/CoveringCellIndexTest
-  indexes/index_key_test
-  indexes/index_scripted_test
-  indexes/index_test
-  harness_test/harness_tester
-  logging/logging_test
-  memleaktests/no_losses
-  plannodes/PlanNodeFragmentTest
-  plannodes/PlanNodeUtilTest
-  plannodes/WindowFunctionPlanNodeTest
-  storage/CompactionTest
-  storage/constraint_test
-  storage/CopyOnWriteTest
-  storage/DRTupleStream_test
-  storage/ExportTupleStream_test
-  storage/filter_test
-  storage/LargeTempTableBlockTest
-  storage/LargeTempTableTest
-  storage/persistent_table_log_test
-  storage/PersistentTableMemStatsTest
-  storage/persistenttable_test
-  storage/serialize_test
-  storage/StreamedTable_test
-  storage/table_and_indexes_test
-  storage/table_test
-  storage/tabletuple_export_test
-  storage/tabletuplefilter_test
-  storage/TempTableLimitsTest
-  structures/CompactingHashTest
-  structures/CompactingMapBenchmark
-  structures/CompactingMapIndexCountTest
-  structures/CompactingMapTest
-  structures/CompactingPoolTest
+  #   storage/LargeTempTableSortTest
+  #   storage/DRBinaryLog_test
+  #   catalog/catalog_test
+  #   catalog/ExportTupleStreamTest
+  #   common/debuglog_test
+  #   common/elastic_hashinator_test
+  #   common/nvalue_test
+  #   common/LargeTempTableBlockIdTest
+  #   common/PerFragmentStatsTest
+  #   common/PoolCheckingTest
+  #   common/pool_test
+  #   common/serializeio_test
+  #   common/tabletuple_test
+  #   common/ThreadLocalPoolTest
+  #   common/tupleschema_test
+  #   common/undolog_test
+  #   common/uniqueid_test
+  #   common/valuearray_test
+  #   execution/add_drop_table
+  #   execution/engine_test
+  #   execution/ExecutorVectorTest
+  #   execution/FragmentManagerTest
+  #   executors/CommonTableExpressionTest
+  #   executors/MergeReceiveExecutorTest
+  #   executors/OptimizedProjectorTest
+  #   expressions/expression_test
+  #   expressions/function_test
+  #   indexes/CompactingHashIndexTest
+  #   indexes/CompactingTreeMultiIndexTest
+  #   indexes/CoveringCellIndexTest
+  #   indexes/index_key_test
+  #   indexes/index_scripted_test
+  #   indexes/index_test
+  #   harness_test/harness_tester
+  #   logging/logging_test
+  #   memleaktests/no_losses
+  #   plannodes/PlanNodeFragmentTest
+  #   plannodes/PlanNodeUtilTest
+  #   plannodes/WindowFunctionPlanNodeTest
+  #   storage/CompactionTest
+  #   storage/constraint_test
+  #   storage/CopyOnWriteTest
+  #   storage/DRTupleStream_test
+  #   storage/ExportTupleStream_test
+  #   storage/filter_test
+  #   storage/LargeTempTableBlockTest
+  #   storage/LargeTempTableTest
+  #   storage/persistent_table_log_test
+  #   storage/PersistentTableMemStatsTest
+  #   storage/persistenttable_test
+  #   storage/serialize_test
+  #   storage/StreamedTable_test
+  #   storage/table_and_indexes_test
+  #   storage/table_test
+  #   storage/tabletuple_export_test
+  #   storage/tabletuplefilter_test
+  #   storage/TempTableLimitsTest
+  #   structures/CompactingHashTest
+  #   structures/CompactingMapBenchmark
+  #   structures/CompactingMapIndexCountTest
+  #   structures/CompactingMapTest
+  #   structures/CompactingPoolTest
 )
 
 #

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1383,11 +1383,7 @@ TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
     TestSingleChunkSnapshot()();
 }
 
-template<typename Chunk, gc_policy pol>
-using remove_direction = typename
-HookedCompactingChunks<TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>::remove_direction;
-
-template<typename Chunk, gc_policy pol, remove_direction<Chunk, pol> dir>
+template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 void testRemovesFromEnds(size_t batch) {
     using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>;
     using Gen = StringGen<TupleSize>;
@@ -1402,7 +1398,7 @@ void testRemovesFromEnds(size_t batch) {
     }
     assert(alloc.size() == NumTuples);
     // remove tests
-    if (dir == remove_direction<Chunk, pol>::from_head) {      // remove from head
+    if (dir == CompactingChunks::remove_direction::from_head) {      // remove from head
         for (i = 0; i < batch; ++i) {
             alloc.remove(dir, addresses[i]);
         }
@@ -1453,7 +1449,7 @@ void testRemovesFromEnds(size_t batch) {
     }
 }
 
-template<typename Chunk, gc_policy pol, remove_direction<Chunk, pol> dir>
+template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 struct TestRemovesFromEnds3 {
     inline void operator()() const {
         testRemovesFromEnds<Chunk, pol, dir>(0);
@@ -1466,19 +1462,17 @@ struct TestRemovesFromEnds3 {
 };
 
 template<typename Chunk, gc_policy pol> struct TestRemovesFromEnds2 {
-    static TestRemovesFromEnds3<Chunk, pol, remove_direction<Chunk, pol>::from_head> const s1;
-    static TestRemovesFromEnds3<Chunk, pol, remove_direction<Chunk, pol>::from_tail> const s2;
-    using direction = typename
-        HookedCompactingChunks<TxnPreHook<NonCompactingChunks<Chunk>, HistoryRetainTrait<pol>>>::remove_direction;
+    static TestRemovesFromEnds3<Chunk, pol, CompactingChunks::remove_direction::from_head> const s1;
+    static TestRemovesFromEnds3<Chunk, pol, CompactingChunks::remove_direction::from_tail> const s2;
     inline void operator()() const {
         s1();
         s2();
     }
 };
 template<typename Chunk, gc_policy pol>
-TestRemovesFromEnds3<Chunk, pol, remove_direction<Chunk, pol>::from_head> const TestRemovesFromEnds2<Chunk, pol>::s1{};
+TestRemovesFromEnds3<Chunk, pol, CompactingChunks::remove_direction::from_head> const TestRemovesFromEnds2<Chunk, pol>::s1{};
 template<typename Chunk, gc_policy pol>
-TestRemovesFromEnds3<Chunk, pol, remove_direction<Chunk, pol>::from_tail> const TestRemovesFromEnds2<Chunk, pol>::s2{};
+TestRemovesFromEnds3<Chunk, pol, CompactingChunks::remove_direction::from_tail> const TestRemovesFromEnds2<Chunk, pol>::s2{};
 
 template<typename Chunk> struct TestRemovesFromEnds1 {
     static TestRemovesFromEnds2<Chunk, gc_policy::never> const s1;


### PR DESCRIPTION
1. Lifted implementation of light-weight delete operations from `HookedCompactingChunks<...>` to `CompactingChunks`, now that these two operations don't need to take extra care about snapshot status.
2. Minor: moved `HistoryRetainTrait` batch size constant off and combined into enum def
3. Bug fix: ptr aliasing check done wrong.
4. Added additional test on single-tuple -> remove -> re-insert -> using iterator with `until` API.