### PR TITLE
ENG-18751-resolve-newline:

### DIFF
--- a/src/frontend/org/voltdb/utils/generate_logkeys.py
+++ b/src/frontend/org/voltdb/utils/generate_logkeys.py
@@ -79,4 +79,4 @@ for line in open( "voltdb_logstrings.properties", 'r' ).readlines():
         f.write( "    " )
         f.write( parts[0].strip() )
         f.write( ",\n" )
-f.write ("    NOT_USED;\n}")
+f.write ("    NOT_USED;\n}\n")


### PR DESCRIPTION
Dave P. pointed out that when I updated the license copyright dates (see
ENG-18751-copyright-script & -update), I also added a final newline to
<voltdb>/src/frontend/org/voltdb/utils/LogKeys.java (and a bunch of
other files, it turns out); this is because my copyright script uses
sed, and I ran it on a Mac (same script on Linux does not add newlines).
The trouble for this particular file is that it gets regenerated each
time you do a build (pro, at least), without a final newline, so git
(e.g. 'git status') thinks that you've altered it and need to check it
in. However, rather than revert LogKeys.java to its previous
no-final-newline state, I decided to modify
<voltdb>/src/frontend/org/voltdb/utils/generate_logkeys.py, which
generates it, to include a final newline, since every Java (or other
text) file should have one, so this seemed more correct.