### PR TITLE
ENG-19061 -- remove redundant try/catch from snmp calls

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4214,13 +4214,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public void halt() {
         SnmpTrapSender snmp = getSnmpTrapSender();
         if (snmp != null) {
-            try {
-                snmp.hostDown(FaultLevel.INFO, m_messenger.getHostId(), "Host is shutting down because of @StopNode");
-                snmp.shutdown();
-            } catch (Throwable t) {
-                VoltLogger log = new VoltLogger("HOST");
-                log.warn("failed to issue a crash SNMP trap", t);
-            }
+	    snmp.hostDown(FaultLevel.INFO, m_messenger.getHostId(), "Host is shutting down because of @StopNode");
+	    snmp.shutdown();
         }
         Thread shutdownThread = new Thread() {
             @Override

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4214,8 +4214,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public void halt() {
         SnmpTrapSender snmp = getSnmpTrapSender();
         if (snmp != null) {
-	    snmp.hostDown(FaultLevel.INFO, m_messenger.getHostId(), "Host is shutting down because of @StopNode");
-	    snmp.shutdown();
+            snmp.hostDown(FaultLevel.INFO, m_messenger.getHostId(), "Host is shutting down because of @StopNode");
+            snmp.shutdown();
         }
         Thread shutdownThread = new Thread() {
             @Override

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -1220,12 +1220,7 @@ public class VoltDB {
         if (snmp == null) {
             return;
         }
-        try {
-            snmp.crash(msg);
-        } catch (Throwable t) {
-            VoltLogger log = new VoltLogger("HOST");
-            log.warn("failed to issue a crash SNMP trap", t);
-        }
+        snmp.crash(msg);
     }
     /**
      * Exit the process with an error message, optionally with a stack trace.

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1639,12 +1639,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 consoleLogLimited.log(warnMsg, EstTime.currentTimeMillis() );
                 SnmpTrapSender snmp = VoltDB.instance().getSnmpTrapSender();
                 if (snmp != null) {
-                    try {
-                        snmp.streamBlocked(warnMsg);
-                    } catch (Throwable t) {
-                        VoltLogger log = new VoltLogger("HOST");
-                        log.warn("failed to issue a streamBlocked SNMP trap", t);
-                    }
+		    snmp.streamBlocked(warnMsg);
                 }
             }
         }

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1639,7 +1639,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 consoleLogLimited.log(warnMsg, EstTime.currentTimeMillis() );
                 SnmpTrapSender snmp = VoltDB.instance().getSnmpTrapSender();
                 if (snmp != null) {
-		    snmp.streamBlocked(warnMsg);
+                    snmp.streamBlocked(warnMsg);
                 }
             }
         }

--- a/src/frontend/org/voltdb/snmp/SnmpTrapSender.java
+++ b/src/frontend/org/voltdb/snmp/SnmpTrapSender.java
@@ -25,11 +25,16 @@ import org.voltdb.compiler.deploymentfile.SnmpType;
  */
 public interface SnmpTrapSender {
 
-    //From deployment build the Snmp sender.
+    // From deployment build the SNMP sender.
     public void initialize(SnmpType snmpType, HostMessenger hm, int clusterId);
     public void shutdown();
-    //Update Snmp properties.
+
+    // Update SNMP properties.
     public void notifyOfCatalogUpdate(SnmpType snmpType);
+
+    // Methods to send specific SNMP traps, where enabled.
+    // At the discretion of the implementation, a log message may
+    // also be written.
     public void crash(String msg);
     public void hostDown(FaultLevel level, int hostId, String msg);
     public void hostUp(String msg);


### PR DESCRIPTION

The implementation of the snmp methods already catches exceptions, so having the caller do it is redundant.
