### PR TITLE
Prepare to use other types/impls of maps

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -82,8 +82,8 @@ inline static size_t chunkSize(size_t tupleSize) noexcept {
 // We remove member initialization from init list to save from
 // storing chunk size into object
 template<typename Alloc> inline ChunkHolder<Alloc>::ChunkHolder(size_t id, size_t tupleSize, size_t storageSize) :
-    super(storageSize), m_id(id), m_tupleSize(tupleSize),
-    m_end(super::get() + storageSize), m_next(super::get()) {
+    Alloc(storageSize), m_id(id), m_tupleSize(tupleSize),
+    m_end(Alloc::get() + storageSize), m_next(Alloc::get()) {
     vassert(tupleSize <= 4 * 0x100000);
     vassert(m_next != nullptr);
 }
@@ -118,7 +118,7 @@ template<typename Alloc> inline bool ChunkHolder<Alloc>::empty() const noexcept 
 }
 
 template<typename Alloc> inline void* const ChunkHolder<Alloc>::begin() const noexcept {
-    return reinterpret_cast<void*>(super::get());
+    return reinterpret_cast<void*>(Alloc::get());
 }
 
 template<typename Alloc> inline void* const ChunkHolder<Alloc>::end() const noexcept {
@@ -133,7 +133,7 @@ template<typename Alloc> inline size_t ChunkHolder<Alloc>::tupleSize() const noe
     return m_tupleSize;
 }
 
-inline EagerNonCompactingChunk::EagerNonCompactingChunk(size_t s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
+inline EagerNonCompactingChunk::EagerNonCompactingChunk(id_type s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
 
 inline void* EagerNonCompactingChunk::allocate() noexcept {
     if (m_freed.empty()) {
@@ -167,7 +167,7 @@ inline bool EagerNonCompactingChunk::full() const noexcept {
     return super::full() && m_freed.empty();
 }
 
-inline LazyNonCompactingChunk::LazyNonCompactingChunk(size_t s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
+inline LazyNonCompactingChunk::LazyNonCompactingChunk(id_type s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
 
 inline void LazyNonCompactingChunk::free(void* src) {
     vassert(src >= begin() && src < next());
@@ -184,8 +184,9 @@ inline void LazyNonCompactingChunk::free(void* src) {
     }
 }
 
-template<typename Chunk, typename E>
-inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(void const* k) const {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
+ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
     if (! m_byAddr.empty()) {
         auto const& iter = prev(m_byAddr.upper_bound(k));                    // find first entry whose begin() > k
         return iter != m_byAddr.cend() && iter->second->contains(k) ? &iter->second : nullptr;
@@ -194,56 +195,65 @@ inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(v
     }
 }
 
-template<typename Chunk, typename E>
-inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(size_t id) const {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
+ChunkList<Chunk, Col1, Col2, E>::find(id_type id) const {
     auto const iter = m_byId.find(id);
     return iter == m_byId.cend() ? nullptr : &iter->second;
 }
 
-template<typename Chunk, typename E> inline ChunkList<Chunk, E>::ChunkList(size_t tsize) noexcept :
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+ChunkList<Chunk, Col1, Col2, E>::ChunkList(size_t tsize) noexcept :
 super(), m_tupleSize(tsize), m_chunkSize(::chunkSize(m_tupleSize)) {}
 
-template<typename Chunk, typename E> inline size_t& ChunkList<Chunk, E>::lastChunkId() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline id_type&
+ChunkList<Chunk, Col1, Col2, E>::lastChunkId() {
     return m_lastChunkId;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::tupleSize() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::chunkSize() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::chunkSize() const noexcept {
     return m_chunkSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::size() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::size() const noexcept {
     return m_size;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator const&
-ChunkList<Chunk, E>::last() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+typename ChunkList<Chunk, Col1, Col2, E>::iterator const&
+ChunkList<Chunk, Col1, Col2, E>::last() const noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator&
-ChunkList<Chunk, E>::last() noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+typename ChunkList<Chunk, Col1, Col2, E>::iterator&
+ChunkList<Chunk, Col1, Col2, E>::last() noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::add(
-        typename ChunkList<Chunk, E>::iterator iter) {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::add(typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
     m_byAddr.emplace(iter->begin(), iter);
     m_byId.emplace(iter->id(), iter);
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::remove(
-        typename ChunkList<Chunk, E>::iterator iter) {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::remove(
+        typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
     m_byAddr.erase(iter->begin());
     m_byId.erase(iter->id());
 }
 
-template<typename Chunk, typename E>
-template<typename... Args>
-inline typename ChunkList<Chunk, E>::iterator ChunkList<Chunk, E>::emplace_back(Args&&... args) {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+template<typename... Args> inline typename ChunkList<Chunk, Col1, Col2, E>::iterator
+ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
     if (super::empty()) {
         super::emplace_front(forward<Args>(args)...);
         m_back = super::begin();
@@ -255,7 +265,8 @@ inline typename ChunkList<Chunk, E>::iterator ChunkList<Chunk, E>::emplace_back(
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::pop_front() {
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
@@ -268,7 +279,8 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front(
     }
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::pop_back() {
     if (super::empty()) {
         throw underflow_error("pop_back() called on empty chunk list");
     } else {
@@ -283,8 +295,8 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back()
     }
 }
 
-template<typename Chunk, typename E>
-template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
             vassert(m_byAddr.count(iter->begin()));
@@ -299,8 +311,8 @@ template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
     super::remove_if(pred);
 }
 
-template<typename Chunk, typename E>
-inline void ChunkList<Chunk, E>::clear() noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline void ChunkList<Chunk, Col1, Col2, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();
@@ -357,7 +369,7 @@ template<typename C, typename E> inline void NonCompactingChunks<C, E>::free(voi
     }
 }
 
-inline CompactingChunk::CompactingChunk(size_t id, size_t s, size_t s2) : super(id, s, s2) {}
+inline CompactingChunk::CompactingChunk(id_type id, size_t s, size_t s2) : super(id, s, s2) {}
 
 inline void CompactingChunk::free(void* dst, void const* src) {     // cross-chunk free(): update only on dst chunk
     vassert(contains(dst));
@@ -434,7 +446,7 @@ inline typename CompactingStorageTrait::list_type::iterator CompactingStorageTra
     }
 }
 
-size_t CompactingChunks::s_id = 0;
+id_type CompactingChunks::s_id = 0;
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(this), m_id(gen_id()),
@@ -467,11 +479,11 @@ inline bool CompactingChunks::TxnLeftBoundary::empty() const noexcept {
     return m_next == nullptr;
 }
 
-size_t CompactingChunks::gen_id() {
+id_type CompactingChunks::gen_id() {
     return s_id++;
 }
 
-inline size_t CompactingChunks::id() const noexcept {
+inline id_type CompactingChunks::id() const noexcept {
     return m_id;
 }
 
@@ -492,7 +504,7 @@ CompactingChunks::find(void const* p) const noexcept {
 }
 
 inline typename CompactingChunks::list_type::iterator const*
-CompactingChunks::find(size_t id) const noexcept {
+CompactingChunks::find(id_type id) const noexcept {
     auto const iter = list_type::find(id);
     return iter == nullptr ||
         less<CompactingChunks::list_type::iterator>()(*iter, beginTxn().iterator()) ?
@@ -920,7 +932,7 @@ template<typename Chunks, typename Tag, typename E> Tag IterableTableTupleChunks
 template<iterator_view_type, iterator_permission_type,
     typename container_type, typename = typename container_type::Compact>
 struct IteratorPermissible {
-    void operator()(set<size_t> const&, container_type) const noexcept {
+    void operator()(set<id_type> const&, container_type) const noexcept {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
     }
 };
@@ -931,7 +943,7 @@ struct IteratorPermissible {
 template<typename container_type>
 struct IteratorPermissible<iterator_view_type::snapshot, iterator_permission_type::rw,
     container_type, integral_constant<bool, true>> {
-    void operator()(set<size_t>& exists, container_type cont) const {
+    void operator()(set<id_type>& exists, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = exists.find(cont.id());
         if (iter == exists.end()) {            // add entry
@@ -951,7 +963,7 @@ struct IteratorPermissible<iterator_view_type::snapshot, iterator_permission_typ
 template<iterator_view_type, iterator_permission_type,
     typename container_type, typename = typename container_type::Compact>
 struct IteratorDeregistration {
-    void operator()(set<size_t> const&, container_type) const noexcept {       // No-op for irrelavent types
+    void operator()(set<id_type> const&, container_type) const noexcept {       // No-op for irrelavent types
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
     }
 };
@@ -959,7 +971,7 @@ struct IteratorDeregistration {
 template<typename container_type>
 struct IteratorDeregistration<iterator_view_type::snapshot, iterator_permission_type::rw,
     container_type, integral_constant<bool, true>> {
-    void operator()(set<size_t>& m, container_type cont) const {
+    void operator()(set<id_type>& m, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = m.find(cont.id());
         if (iter != m.end()) {
@@ -1268,7 +1280,7 @@ namespace std {                                    // Need to declare these befo
 template<typename IterableTableTupleChunks, typename ElasticIterator,
     typename Compact = typename IterableTableTupleChunks::chunk_type::Compact>
 struct ElasticIterator_refresh {
-    inline void operator()(ElasticIterator const&, size_t const&,
+    inline void operator()(ElasticIterator const&, id_type const&,
             typename IterableTableTupleChunks::chunk_type const&,
             typename IterableTableTupleChunks::chunk_type::list_type::const_iterator&,
             void const*&) const {
@@ -1278,7 +1290,7 @@ struct ElasticIterator_refresh {
 
 template<typename I, typename ElasticIterator>
 struct ElasticIterator_refresh<I, ElasticIterator, integral_constant<bool, true>> {
-    inline void operator()(ElasticIterator& iter, size_t& chunkId,
+    inline void operator()(ElasticIterator& iter, id_type& chunkId,
             typename I::chunk_type const& storage,
             ChunkList<CompactingChunk>::const_iterator& chunkIter,
             void const*& cursor) const {
@@ -1401,7 +1413,7 @@ inline position_type::position_type(CompactingChunks const& c, void const* p) : 
         // semantics of less<position_type>.
         const_cast<void*&>(m_addr) = nullptr;
     } else {
-        const_cast<size_t&>(m_chunkId) = (*iterp)->id();
+        const_cast<remove_const<decltype(m_chunkId)>::type&>(m_chunkId) = (*iterp)->id();
     }
 }
 
@@ -1409,7 +1421,7 @@ template<typename iterator>
 inline position_type::position_type(void const* p, iterator const& iter) noexcept :
 m_chunkId(iter->id()), m_addr(p) {}
 
-inline size_t position_type::chunkId() const noexcept {
+inline id_type position_type::chunkId() const noexcept {
     return m_chunkId;
 }
 inline void const* position_type::address() const noexcept {
@@ -1423,7 +1435,7 @@ inline bool position_type::operator==(position_type const& o) const noexcept {
 }
 
 inline position_type& position_type::operator=(position_type const& o) noexcept {
-    const_cast<size_t&>(m_chunkId) = o.chunkId();
+    const_cast<id_type&>(m_chunkId) = o.chunkId();
     m_addr = o.address();
     return *this;
 }

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -184,9 +184,9 @@ inline void LazyNonCompactingChunk::free(void* src) {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
-ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
+template<typename Chunk, typename Col, typename E>
+inline typename ChunkList<Chunk, Col, E>::iterator const*
+ChunkList<Chunk, Col, E>::find(void const* k) const {
     if (! m_byAddr.empty()) {
         auto const& iter = prev(m_byAddr.upper_bound(k));                    // find first entry whose begin() > k
         return iter != m_byAddr.cend() && iter->second->contains(k) ? &iter->second : nullptr;
@@ -195,65 +195,65 @@ ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
-ChunkList<Chunk, Col1, Col2, E>::find(id_type id) const {
+template<typename Chunk, typename Col, typename E>
+inline typename ChunkList<Chunk, Col, E>::iterator const*
+ChunkList<Chunk, Col, E>::find(id_type id) const {
     auto const iter = m_byId.find(id);
     return iter == m_byId.cend() ? nullptr : &iter->second;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-ChunkList<Chunk, Col1, Col2, E>::ChunkList(size_t tsize) noexcept :
+template<typename Chunk, typename Col, typename E> inline
+ChunkList<Chunk, Col, E>::ChunkList(size_t tsize) noexcept :
 super(), m_tupleSize(tsize), m_chunkSize(::chunkSize(m_tupleSize)) {}
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline id_type&
-ChunkList<Chunk, Col1, Col2, E>::lastChunkId() {
+template<typename Chunk, typename Col, typename E> inline id_type&
+ChunkList<Chunk, Col, E>::lastChunkId() {
     return m_lastChunkId;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::tupleSize() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::chunkSize() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::chunkSize() const noexcept {
     return m_chunkSize;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::size() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::size() const noexcept {
     return m_size;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-typename ChunkList<Chunk, Col1, Col2, E>::iterator const&
-ChunkList<Chunk, Col1, Col2, E>::last() const noexcept {
+template<typename Chunk, typename Col, typename E> inline
+typename ChunkList<Chunk, Col, E>::iterator const&
+ChunkList<Chunk, Col, E>::last() const noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-typename ChunkList<Chunk, Col1, Col2, E>::iterator&
-ChunkList<Chunk, Col1, Col2, E>::last() noexcept {
+template<typename Chunk, typename Col, typename E> inline
+typename ChunkList<Chunk, Col, E>::iterator&
+ChunkList<Chunk, Col, E>::last() noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::add(typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::add(typename ChunkList<Chunk, Col, E>::iterator iter) {
     m_byAddr.emplace(iter->begin(), iter);
     m_byId.emplace(iter->id(), iter);
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::remove(
-        typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::remove(
+        typename ChunkList<Chunk, Col, E>::iterator iter) {
     m_byAddr.erase(iter->begin());
     m_byId.erase(iter->id());
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-template<typename... Args> inline typename ChunkList<Chunk, Col1, Col2, E>::iterator
-ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
+template<typename Chunk, typename Col, typename E>
+template<typename... Args> inline typename ChunkList<Chunk, Col, E>::iterator
+ChunkList<Chunk, Col, E>::emplace_back(Args&&... args) {
     if (super::empty()) {
         super::emplace_front(forward<Args>(args)...);
         m_back = super::begin();
@@ -265,8 +265,8 @@ ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::pop_front() {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::pop_front() {
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
@@ -279,8 +279,8 @@ ChunkList<Chunk, Col1, Col2, E>::pop_front() {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::pop_back() {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::pop_back() {
     if (super::empty()) {
         throw underflow_error("pop_back() called on empty chunk list");
     } else {
@@ -295,8 +295,8 @@ ChunkList<Chunk, Col1, Col2, E>::pop_back() {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(Pred pred) {
+template<typename Chunk, typename Col, typename E>
+template<typename Pred> inline void ChunkList<Chunk, Col, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
             vassert(m_byAddr.count(iter->begin()));
@@ -311,8 +311,8 @@ template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(P
     super::remove_if(pred);
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline void ChunkList<Chunk, Col1, Col2, E>::clear() noexcept {
+template<typename Chunk, typename Col, typename E>
+inline void ChunkList<Chunk, Col, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -104,13 +104,13 @@ namespace voltdb {
             using super::get;
         };
 
+        using id_type = size_t;                        // chunk id type
         /**
          * Holder for a chunk, whether it is self-compacting or not.
          */
         template<typename Alloc = StdAllocator>
         class ChunkHolder : private Alloc {
-            using super = Alloc;
-            size_t const m_id;                         // chunk id
+            id_type const m_id;                         // chunk id
             size_t const m_tupleSize;                  // size of a table tuple per allocation
             void*const m_end;                          // indication of chunk capacity
         protected:
@@ -120,7 +120,7 @@ namespace voltdb {
             ChunkHolder(ChunkHolder&&) = delete;
             friend class CompactingChunks;              // for batch free
         public:
-            ChunkHolder(size_t id, size_t tupleSize, size_t chunkSize);
+            ChunkHolder(id_type id, size_t tupleSize, size_t chunkSize);
             ~ChunkHolder() = default;
             void* allocate() noexcept;                 // returns NULL if this chunk is full.
             bool contains(void const*) const;          // query if a table tuple is stored in current chunk
@@ -130,7 +130,7 @@ namespace voltdb {
             void*const end() const noexcept;
             void*const next() const noexcept;
             size_t tupleSize() const noexcept;
-            size_t id() const noexcept;
+            id_type id() const noexcept;
         };
 
         /**
@@ -147,7 +147,7 @@ namespace voltdb {
             EagerNonCompactingChunk& operator=(EagerNonCompactingChunk const&) = delete;
             EagerNonCompactingChunk(EagerNonCompactingChunk&&) = delete;
         public:
-            EagerNonCompactingChunk(size_t, size_t, size_t);
+            EagerNonCompactingChunk(id_type, size_t, size_t);
             ~EagerNonCompactingChunk() = default;
             void* allocate() noexcept;
             void free(void*);
@@ -171,7 +171,7 @@ namespace voltdb {
             LazyNonCompactingChunk& operator=(LazyNonCompactingChunk const&) = delete;
             LazyNonCompactingChunk(LazyNonCompactingChunk&&) = delete;
         public:
-            LazyNonCompactingChunk(size_t, size_t, size_t);
+            LazyNonCompactingChunk(id_type, size_t, size_t);
             ~LazyNonCompactingChunk() = default;
             // void* allocate() noexcept; same as ChunkHolder
             // when contains(void const*) returns true, the addr may
@@ -180,6 +180,11 @@ namespace voltdb {
             // but gives conservative, ignoring any holes.
             void free(void*);
             // bool empty() const noexcept is identical to ChunkHolder.
+        };
+
+        template<typename Key, typename Value> struct StdCollections {
+            using set = std::set<Key>;
+            using map = std::map<Key, Value>;
         };
 
         /**
@@ -191,20 +196,22 @@ namespace voltdb {
          * and limit insertion to tail and erase to front.
          */
         template<typename Chunk,
+            typename Collectible1 = StdCollections<void const*, typename forward_list<Chunk>::iterator>,
+            typename Collectible2 = StdCollections<id_type, typename forward_list<Chunk>::iterator>,
             typename = typename enable_if<is_base_of<ChunkHolder<>, Chunk>::value>::type>
         class ChunkList : private forward_list<Chunk> {
             using super = forward_list<Chunk>;
             size_t const m_tupleSize;
             size_t const m_chunkSize;                  // how many bytes per chunk
             size_t m_size = 0;
-            size_t m_lastChunkId = 0;
+            id_type m_lastChunkId = 0;
             typename super::iterator m_back = super::end();
-            map<void const*, typename super::iterator> m_byAddr{};
-            map<size_t, typename super::iterator> m_byId{};
+            typename Collectible1::map m_byAddr{};
+            typename Collectible2::map m_byId{};
             void add(typename super::iterator);
             void remove(typename super::iterator);
         protected:
-            size_t& lastChunkId();
+            id_type& lastChunkId();
             template<typename Pred> void remove_if(Pred p);
             typename super::iterator& last() noexcept;
         public:
@@ -229,7 +236,7 @@ namespace voltdb {
             iterator const& last() const noexcept;
             // the O(log(n)) killer
             iterator const* find(void const*) const;
-            iterator const* find(size_t) const;
+            iterator const* find(id_type) const;
         };
 
         /**
@@ -285,7 +292,7 @@ namespace voltdb {
          */
         struct CompactingChunk final : public ChunkHolder<> {
             using super = ChunkHolder<>;
-            CompactingChunk(size_t id, size_t tupleSize, size_t chunkSize);
+            CompactingChunk(id_type, size_t, size_t);
             CompactingChunk(CompactingChunk&&) = delete;
             CompactingChunk(CompactingChunk const&) = delete;
             CompactingChunk& operator=(CompactingChunk const&) = delete;
@@ -295,11 +302,6 @@ namespace voltdb {
             void* free();                           // release tuple from the last chunk of the list, from the last allocation
             // void* allocate() noexcept, bool contains(void const*) const, bool full() const noexcept,
             // begin() and end(), all have same implementation as ChunkHolder
-        };
-
-        template<typename Key, typename Value> struct stdCollections {
-            using set = std::set<Key>;
-            using map = std::map<Key, Value>;
         };
 
         /**
@@ -370,7 +372,7 @@ namespace voltdb {
          */
         class CompactingChunks;
         class position_type {
-            size_t const m_chunkId = 0;
+            id_type const m_chunkId = 0;
             void const* m_addr = nullptr;
         public:
             position_type() noexcept = default;        // empty initiator
@@ -380,7 +382,7 @@ namespace voltdb {
             position_type(position_type const&) noexcept = default;
             position_type(position_type&&) noexcept = default;
             position_type& operator=(position_type const&) noexcept;
-            size_t chunkId() const noexcept;
+            id_type chunkId() const noexcept;
             void const* address() const noexcept;
             bool empty() const noexcept;               // makes it behave like std::optional<position_type>
             bool operator==(position_type const&) const noexcept;
@@ -420,10 +422,10 @@ namespace voltdb {
         private:
             template<typename, typename, typename> friend struct IterableTableTupleChunks;
             using list_type = ChunkList<CompactingChunk>;
-            static size_t s_id;
-            static size_t gen_id();
+            static id_type s_id;
+            static id_type gen_id();
 
-            size_t const m_id;                    // equivalent to "table id", to ensure injection relation to rw iterator
+            id_type const m_id;                    // equivalent to "table id", to ensure injection relation to rw iterator
             char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
             TxnLeftBoundary m_txnFirstChunk;     // (moving) left boundary for txn
             FrozenTxnBoundaries m_frozenTxnBoundaries{};  // frozen boundaries for txn
@@ -480,14 +482,14 @@ namespace voltdb {
              */
             size_t chunks() const noexcept;            // number of chunks
             size_t size() const noexcept;              // number of allocation requested
-            size_t id() const noexcept;
+            id_type id() const noexcept;
             using list_type::tupleSize; using list_type::chunkSize;
             using list_type::empty; using list_type::begin; using list_type::end;
             using CompactingStorageTrait::frozen;
 
             // search in txn memory region (i.e. excludes snapshot-related, front portion of list)
             list_type::iterator const* find(void const*) const noexcept;
-            list_type::iterator const* find(size_t) const noexcept;
+            list_type::iterator const* find(id_type) const noexcept;
             TxnLeftBoundary const& beginTxn() const noexcept;   // (moving) txn left boundary
             TxnLeftBoundary& beginTxn() noexcept;               // NOTE: this should really be private. Use it with care!!!
             FrozenTxnBoundaries const& frozenBoundaries() const noexcept;  // txn boundaries when freezing
@@ -559,7 +561,7 @@ namespace voltdb {
             is_base_of<CompactingChunks, typename remove_const<T>::type>::value>;
 
         template<typename Alloc, typename Trait,
-            typename Collections = stdCollections<void const*, void const*>,
+            typename Collections = StdCollections<void const*, void const*>,
             typename = typename enable_if<is_chunks<Alloc>::value && is_base_of<BaseHistoryRetainTrait, Trait>::value>::type>
         class TxnPreHook : private Trait {
             using set = typename Collections::set;
@@ -713,7 +715,7 @@ namespace voltdb {
                     add_lvalue_reference<typename conditional<perm == iterator_permission_type::ro,
                     Chunks const, Chunks>::type>::type;
                 class Constructible {
-                    set<size_t> m_inUse{};
+                    set<id_type> m_inUse{};
                 public:
                     void validate(container_type);
                     void remove(container_type);
@@ -759,7 +761,7 @@ namespace voltdb {
                 using container_type = typename super::container_type;
                 using value_type = typename super::value_type;
                 position_type const m_txnBoundary;
-                size_t m_chunkId;
+                id_type m_chunkId;
                 void refresh();
             public:
                 elastic_iterator(container_type);


### PR DESCRIPTION
Getting ready to drop-in replace other `map` implementations, and other `chunkId()` types.