### PR TITLE
Eng 19061 19115 backport snmp changes to v8.4

### DIFF
--- a/src/frontend/org/voltcore/logging/VoltLogger.java
+++ b/src/frontend/org/voltcore/logging/VoltLogger.java
@@ -343,6 +343,23 @@ public class VoltLogger {
         submitl7d(level, key, params, t);
     }
 
+    public void log(Level level, Object message, Throwable t) {
+        switch (level) {
+        case WARN:
+        case INFO:
+        case DEBUG:
+        case TRACE:
+            execute(level, message, t);
+            break;
+        case FATAL:
+        case ERROR:
+            submit(level, message, t);
+            break;
+        default:
+            throw new AssertionError("Unrecognized level " + level);
+        }
+    }
+
     public long getLogLevels(VoltLogger loggers[]) {
         return m_logger.getLogLevels(loggers);
     }


### PR DESCRIPTION

Copy from 9.3 a general logging method needed for SNMP trap logging.
