### PR TITLE
source changes for gcc 7 compatibility

### DIFF
--- a/src/ee/common/NValue.cpp
+++ b/src/ee/common/NValue.cpp
@@ -533,7 +533,9 @@ void NValue::streamTimestamp(std::stringstream& value) const
         // and converting it to 1000000 micros
         micro += 1000000;
     }
-    char mbstr[27];    // Format: "YYYY-MM-DD HH:MM:SS."- 20 characters + terminator
+    char mbstr[64];    // Format: "YYYY-MM-DD HH:MM:SS."- 27 characters + terminator
+                       //         But GCC-7 thinks it may be longer.  So we need
+                       //         extra space.
     snprintf(mbstr, sizeof(mbstr), "%04d-%02d-%02d %02d:%02d:%02d.%06d",
              (int)as_date.year(), (int)as_date.month(), (int)as_date.day(),
              (int)as_time.hours(), (int)as_time.minutes(), (int)as_time.seconds(), (int)micro);
@@ -649,6 +651,7 @@ int64_t NValue::parseTimestampString(const std::string &str)
         if (micro >= 2000000 || micro < 1000000) {
             throwTimestampFormatError(str);
         }
+        /* fall through */ // gcc-7 needs this comment.
     case 10:
         if (date_str.at(4) != '-' || date_str.at(7) != '-') {
             throwTimestampFormatError(str);

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -787,6 +787,7 @@ void TableCatalogDelegate::initTupleWithDefaultValues(Pool* pool,
                 nowFields.push_back(col->index());
                 break;
             }
+            /* fall through */ // gcc-7 needs this comment.
             // else, fall through to default case
         default:
             NValue defaultValue = ValueFactory::nvalueFromSQLDefaultType(defaultColType,

--- a/tests/ee/storage/tabletuple_export_test.cpp
+++ b/tests/ee/storage/tabletuple_export_test.cpp
@@ -257,6 +257,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(7, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 7:
       {
           NValue nv = ValueFactory::getStringValue("ABCDEabcde"); // 10 char
@@ -264,6 +265,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(6, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 6:
       {
           NValue nv = ValueFactory::getDecimalValueFromString("-12.34");
@@ -271,6 +273,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(5, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 5:
       {
           NValue nv = ValueFactory::getTimestampValue(9999);
@@ -278,6 +281,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(4, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 4:
       {
           NValue nv = ValueFactory::getBigIntValue(1024);
@@ -285,6 +289,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(3, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 3:
       {
           NValue nv = ValueFactory::getIntegerValue(512);
@@ -292,6 +297,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(2, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 2:
       {
           NValue nv = ValueFactory::getSmallIntValue(256);
@@ -299,6 +305,7 @@ TableTupleExportTest::serElSize(std::vector<uint16_t> &keep_offsets,
           tt->setNValueAllocateForObjectCopies(1, nv, NULL);
           nv.free();
       }
+      /* fall through */ // gcc-7 needs this comment.
       case 1:
       {
           NValue nv = ValueFactory::getTinyIntValue(120);

--- a/third_party/cpp/crc/crc32c.cc
+++ b/third_party/cpp/crc/crc32c.cc
@@ -47,11 +47,11 @@ CRC32CFunctionPtr detectBestCRC32C() {
  *
  * Copyright (c) 2004-2006 Intel Corporation - All Rights Reserved
  *
- * This software program is licensed subject to the BSD License, 
+ * This software program is licensed subject to the BSD License,
  * available at http://www.opensource.org/licenses/bsd-license.html
  *
  * Abstract: The main routine
- * 
+ *
  --*/
 
 uint32_t crc32cSlicingBy8(uint32_t crc, const void* data, size_t length) {
@@ -66,7 +66,7 @@ uint32_t crc32cSlicingBy8(uint32_t crc, const void* data, size_t length) {
 
     length -= initial_bytes;
     size_t running_length = length & ~(sizeof(uint64_t) - 1);
-    size_t end_bytes = length - running_length; 
+    size_t end_bytes = length - running_length;
 
     for (size_t li = 0; li < running_length/8; li++) {
         crc ^= *(const uint32_t*) p_buf;
@@ -75,7 +75,7 @@ uint32_t crc32cSlicingBy8(uint32_t crc, const void* data, size_t length) {
                 crc_tableil8_o80[(crc >> 8) & 0x000000FF];
         uint32_t term2 = crc >> 16;
         crc = term1 ^
-              crc_tableil8_o72[term2 & 0x000000FF] ^ 
+              crc_tableil8_o72[term2 & 0x000000FF] ^
               crc_tableil8_o64[(term2 >> 8) & 0x000000FF];
         term1 = crc_tableil8_o56[(*(const uint32_t *)p_buf) & 0x000000FF] ^
                 crc_tableil8_o48[((*(const uint32_t *)p_buf) >> 8) & 0x000000FF];
@@ -136,21 +136,25 @@ uint32_t crc32cHardware64(uint32_t crc, const void* data, size_t length) {
     switch (length) {
         case 7:
             crc32bit = _mm_crc32_u8(crc32bit, *p_buf++);
+            /* fall through */ // gcc-7 needs this comment.
         case 6:
             crc32bit = _mm_crc32_u16(crc32bit, *(const uint16_t*) p_buf);
             p_buf += 2;
+            /* fall through */ // gcc-7 needs this comment.
         // case 5 is below: 4 + 1
         case 4:
             crc32bit = _mm_crc32_u32(crc32bit, *(const uint32_t*) p_buf);
             break;
         case 3:
             crc32bit = _mm_crc32_u8(crc32bit, *p_buf++);
+            /* fall through */ // gcc-7 needs this comment.
         case 2:
             crc32bit = _mm_crc32_u16(crc32bit, *(const uint16_t*) p_buf);
             break;
         case 5:
             crc32bit = _mm_crc32_u32(crc32bit, *(const uint32_t*) p_buf);
             p_buf += 4;
+            /* fall through */ // gcc-7 needs this comment.
         case 1:
             crc32bit = _mm_crc32_u8(crc32bit, *p_buf);
             break;

--- a/third_party/cpp/murmur3/MurmurHash3.cpp
+++ b/third_party/cpp/murmur3/MurmurHash3.cpp
@@ -140,21 +140,34 @@ int32_t MurmurHash3_x64_128 ( const void * key, const int len,
   switch(len & 15)
   {
   case 15: k2 ^= uint64_t(tail[14]) << 48;
+      /* fall through */ // gcc-7 needs this comment.
   case 14: k2 ^= uint64_t(tail[13]) << 40;
+      /* fall through */ // gcc-7 needs this comment.
   case 13: k2 ^= uint64_t(tail[12]) << 32;
+      /* fall through */ // gcc-7 needs this comment.
   case 12: k2 ^= uint64_t(tail[11]) << 24;
+      /* fall through */ // gcc-7 needs this comment.
   case 11: k2 ^= uint64_t(tail[10]) << 16;
+      /* fall through */ // gcc-7 needs this comment.
   case 10: k2 ^= uint64_t(tail[ 9]) << 8;
+      /* fall through */ // gcc-7 needs this comment.
   case  9: k2 ^= uint64_t(tail[ 8]) << 0;
            k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
-
+           /* fall through */ // gcc-7 needs this comment.
   case  8: k1 ^= uint64_t(tail[ 7]) << 56;
+      /* fall through */ // gcc-7 needs this comment.
   case  7: k1 ^= uint64_t(tail[ 6]) << 48;
+      /* fall through */ // gcc-7 needs this comment.
   case  6: k1 ^= uint64_t(tail[ 5]) << 40;
+      /* fall through */ // gcc-7 needs this comment.
   case  5: k1 ^= uint64_t(tail[ 4]) << 32;
+      /* fall through */ // gcc-7 needs this comment.
   case  4: k1 ^= uint64_t(tail[ 3]) << 24;
+      /* fall through */ // gcc-7 needs this comment.
   case  3: k1 ^= uint64_t(tail[ 2]) << 16;
+      /* fall through */ // gcc-7 needs this comment.
   case  2: k1 ^= uint64_t(tail[ 1]) << 8;
+      /* fall through */ // gcc-7 needs this comment.
   case  1: k1 ^= uint64_t(tail[ 0]) << 0;
            k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
   };
@@ -218,7 +231,9 @@ uint32_t MurmurHash3_x86_32 ( const void * key, uint32_t len,
   switch(len & 3)
   {
   case 3: k1 ^= tail[2] << 16;
+      /* fall through */ // gcc-7 needs this comment.
   case 2: k1 ^= tail[1] << 8;
+      /* fall through */ // gcc-7 needs this comment.
   case 1: k1 ^= tail[0];
           k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };


### PR DESCRIPTION

Changes to make it possible to compile with gcc 7.x.

Mostly switch-statement fall-through comments.

One snprintf buffer size increase.

All copied from 9.3.
