### PR TITLE
ENG-18982: Add PersistedMetadata

### DIFF
--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -61,6 +61,7 @@ import org.voltdb.catalog.Table;
 import org.voltdb.export.AdvertisedDataSource.ExportFormat;
 import org.voltdb.exportclient.ExportClientBase;
 import org.voltdb.exportclient.ExportRowSchema;
+import org.voltdb.exportclient.PersistedMetadata;
 import org.voltdb.iv2.MpInitiator;
 import org.voltdb.snmp.SnmpTrapSender;
 import org.voltdb.sysprocs.ExportControl.OperationMode;
@@ -198,7 +199,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     private static class PollTask {
-        private SettableFuture<AckingContainer> m_pollFuture;
+        private final SettableFuture<AckingContainer> m_pollFuture;
 
         public PollTask(SettableFuture<AckingContainer> fut) {
             m_pollFuture = fut;
@@ -769,10 +770,10 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             try {
                 // Create a block to offer: NOTE this block should not
                 // be used for anything else than offering, as it doesn't have metadata.
-                BinaryDequeReader.Entry<ExportRowSchema> entry = new BinaryDequeReader.Entry<ExportRowSchema>() {
+                BinaryDequeReader.Entry<PersistedMetadata> entry = new BinaryDequeReader.Entry<PersistedMetadata>() {
 
                     @Override
-                    public ExportRowSchema getExtraHeader() {
+                    public PersistedMetadata getExtraHeader() {
                         return null;
                     }
 

--- a/src/frontend/org/voltdb/export/StreamBlock.java
+++ b/src/frontend/org/voltdb/export/StreamBlock.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.VoltDB;
 import org.voltdb.exportclient.ExportRowSchema;
+import org.voltdb.exportclient.PersistedMetadata;
 import org.voltdb.iv2.UniqueIdGenerator;
 import org.voltdb.utils.BinaryDequeReader;
 
@@ -55,8 +56,8 @@ public class StreamBlock {
     public static final int ROW_NUMBER_OFFSET = 16;
     public static final int UNIQUE_ID_OFFSET = 20;
 
-    public StreamBlock(BinaryDequeReader.Entry<ExportRowSchema> entry, long startSequenceNumber, long committedSequenceNumber,
-            int rowCount, long uniqueId, boolean isPersisted) {
+    public StreamBlock(BinaryDequeReader.Entry<PersistedMetadata> entry, long startSequenceNumber,
+            long committedSequenceNumber, int rowCount, long uniqueId, boolean isPersisted) {
         assert(entry != null);
         m_entry  = entry;
         m_startSequenceNumber = startSequenceNumber;
@@ -86,7 +87,7 @@ public class StreamBlock {
     }
 
     public ExportRowSchema getSchema() {
-        return m_entry.getExtraHeader();
+        return m_entry.getExtraHeader().getSchema();
     }
 
     public long startSequenceNumber() {
@@ -151,11 +152,11 @@ public class StreamBlock {
     }
 
     private final long m_startSequenceNumber;
-    private long m_committedSequenceNumber;
+    private final long m_committedSequenceNumber;
     private final int m_rowCount;
     private final long m_uniqueId;
     private final long m_totalSize;
-    private BinaryDequeReader.Entry<ExportRowSchema> m_entry;
+    private final BinaryDequeReader.Entry<PersistedMetadata> m_entry;
     // index of the last row that has been released.
     private int m_releaseOffset = -1;
 

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -49,20 +49,20 @@ import au.com.bytecode.opencsv_voltpatches.CSVWriter;
  */
 public class ExportRow {
 
-    public List<String> names;
+    public final List<String> names;
     public final Object[] values;
-    public List<VoltType> types;
-    public List<Integer> lengths;
+    public final List<VoltType> types;
+    public final List<Integer> lengths;
     public final int partitionColIndex;
     public final Object partitionValue;
     //Partition id is here for convenience.
     public final int partitionId;
-    public String tableName;
+    public final String tableName;
     public final long generation;
     public static final int INTERNAL_FIELD_COUNT = 6;
     public static final int EXPORT_TIMESTAMP_COLUMN = 1;
     public static final int INTERNAL_OPERATION_COLUMN = 5;
-    public enum ROW_OPERATION { INVALID, INSERT, DELETE, UPDATE_OLD, UPDATE_NEW, MIGRATE };
+    public enum ROW_OPERATION { INVALID, INSERT, DELETE, UPDATE_OLD, UPDATE_NEW, MIGRATE }
 
     public ExportRow(String tableName, List<String> columnNames, List<VoltType> t, List<Integer> l,
             Object[] vals, Object pval, int partitionColIndex, int pid, long generation) {

--- a/src/frontend/org/voltdb/exportclient/PersistedMetadata.java
+++ b/src/frontend/org/voltdb/exportclient/PersistedMetadata.java
@@ -1,0 +1,63 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.voltdb.exportclient;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.voltcore.utils.DeferredSerialization;
+
+/**
+ * Class which holds all of the metadata which is persisted with export rows within a PBD. Primarily it holds the schema
+ * of the rows
+ */
+public class PersistedMetadata implements DeferredSerialization {
+    private static short LATEST_VERSION = 1;
+    private final ExportRowSchema m_schema;
+
+    static PersistedMetadata deserialize(ByteBuffer buf) throws IOException {
+        short version = buf.getShort();
+        if (version != LATEST_VERSION) {
+            throw new IOException("Unsupported serialization version: " + version);
+        }
+        return new PersistedMetadata(ExportRowSchema.deserialize(buf));
+    }
+
+    public PersistedMetadata(ExportRowSchema schema) {
+        super();
+        this.m_schema = schema;
+    }
+
+    public ExportRowSchema getSchema() {
+        return m_schema;
+    }
+
+    @Override
+    public void serialize(ByteBuffer buf) throws IOException {
+        buf.putShort(LATEST_VERSION);
+        m_schema.serialize(buf);
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    @Override
+    public int getSerializedSize() throws IOException {
+        return Short.BYTES + m_schema.getSerializedSize();
+    }
+}

--- a/src/frontend/org/voltdb/exportclient/PersistedMetadataSerializer.java
+++ b/src/frontend/org/voltdb/exportclient/PersistedMetadataSerializer.java
@@ -26,11 +26,9 @@ import org.voltdb.utils.BinaryDequeDeferredSerializer;
  * @author rdykiel
  *
  */
-public class ExportRowSchemaSerializer extends BinaryDequeDeferredSerializer<ExportRowSchema> {
-
+public class PersistedMetadataSerializer extends BinaryDequeDeferredSerializer<PersistedMetadata> {
     @Override
-    public ExportRowSchema read(ByteBuffer buffer) throws IOException {
-        return ExportRowSchema.deserialize(buffer);
+    public PersistedMetadata read(ByteBuffer buffer) throws IOException {
+        return PersistedMetadata.deserialize(buffer);
     }
-
 }

--- a/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
+++ b/tests/frontend/org/voltdb/export/TestStreamBlockQueue.java
@@ -39,7 +39,7 @@ import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.MockVoltDB;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltType;
-import org.voltdb.exportclient.ExportRowSchema;
+import org.voltdb.exportclient.PersistedMetadata;
 import org.voltdb.utils.BinaryDequeReader;
 import org.voltdb.utils.VoltFile;
 
@@ -71,10 +71,10 @@ public class TestStreamBlockQueue extends TestCase {
     private static StreamBlock getStreamBlockWithFill(byte fillValue) {
         g_seqNo += 100;
         BBContainer cont = DBBPool.wrapBB(getFilledBuffer(fillValue));
-        BinaryDequeReader.Entry<ExportRowSchema> entry = new BinaryDequeReader.Entry<ExportRowSchema>() {
+        BinaryDequeReader.Entry<PersistedMetadata> entry = new BinaryDequeReader.Entry<PersistedMetadata>() {
 
             @Override
-            public ExportRowSchema getExtraHeader() {
+            public PersistedMetadata getExtraHeader() {
                 return null;
             }
 


### PR DESCRIPTION
Add PersistedMetadata as the extra header which is stored for export. This allows cleanly adding more metadata to the header but not making it part of ExportRowSchema.

Cleanup:
ExportRow: Make all public fields final

ExportRowSchema:
* Remove unnecessary implementation of DeferredSerializer.
* Fix serialization of strings so that length of bytes and not length of chars is used.