### PR TITLE
Memcheck allocator

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1444,14 +1444,19 @@ template<typename Chunks, typename Tag, typename E> inline bool
 IterableTableTupleChunks<Chunks, Tag, E>::elastic_iterator::drained() noexcept {
     if (super::drained()) {
         return true;
-    } else if (super::storage().empty() ||
-            less<position_type>()(*super::storage().last(), *this) ||
-            less<position_type>()(m_txnBoundary, *this) ||
-            m_txnBoundary == *this) {
-        super::m_cursor = nullptr;
-        return true;
     } else {
-        return false;
+        refresh();
+        if (super::drained()) {
+            return true;
+        } else if (super::storage().empty() ||
+                less<position_type>()(*super::storage().last(), *this) ||
+                less<position_type>()(m_txnBoundary, *this) ||
+                m_txnBoundary == *this) {
+            super::m_cursor = nullptr;
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -82,8 +82,8 @@ inline static size_t chunkSize(size_t tupleSize) noexcept {
 // We remove member initialization from init list to save from
 // storing chunk size into object
 template<typename Alloc> inline ChunkHolder<Alloc>::ChunkHolder(size_t id, size_t tupleSize, size_t storageSize) :
-    super(storageSize), m_id(id), m_tupleSize(tupleSize),
-    m_end(super::get() + storageSize), m_next(super::get()) {
+    Alloc(storageSize), m_id(id), m_tupleSize(tupleSize),
+    m_end(Alloc::get() + storageSize), m_next(Alloc::get()) {
     vassert(tupleSize <= 4 * 0x100000);
     vassert(m_next != nullptr);
 }
@@ -118,7 +118,7 @@ template<typename Alloc> inline bool ChunkHolder<Alloc>::empty() const noexcept 
 }
 
 template<typename Alloc> inline void* const ChunkHolder<Alloc>::begin() const noexcept {
-    return reinterpret_cast<void*>(super::get());
+    return reinterpret_cast<void*>(Alloc::get());
 }
 
 template<typename Alloc> inline void* const ChunkHolder<Alloc>::end() const noexcept {
@@ -133,7 +133,7 @@ template<typename Alloc> inline size_t ChunkHolder<Alloc>::tupleSize() const noe
     return m_tupleSize;
 }
 
-inline EagerNonCompactingChunk::EagerNonCompactingChunk(size_t s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
+inline EagerNonCompactingChunk::EagerNonCompactingChunk(id_type s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
 
 inline void* EagerNonCompactingChunk::allocate() noexcept {
     if (m_freed.empty()) {
@@ -167,7 +167,7 @@ inline bool EagerNonCompactingChunk::full() const noexcept {
     return super::full() && m_freed.empty();
 }
 
-inline LazyNonCompactingChunk::LazyNonCompactingChunk(size_t s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
+inline LazyNonCompactingChunk::LazyNonCompactingChunk(id_type s1, size_t s2, size_t s3) : super(s1, s2, s3) {}
 
 inline void LazyNonCompactingChunk::free(void* src) {
     vassert(src >= begin() && src < next());
@@ -184,8 +184,9 @@ inline void LazyNonCompactingChunk::free(void* src) {
     }
 }
 
-template<typename Chunk, typename E>
-inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(void const* k) const {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
+ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
     if (! m_byAddr.empty()) {
         auto const& iter = prev(m_byAddr.upper_bound(k));                    // find first entry whose begin() > k
         return iter != m_byAddr.cend() && iter->second->contains(k) ? &iter->second : nullptr;
@@ -194,56 +195,65 @@ inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(v
     }
 }
 
-template<typename Chunk, typename E>
-inline typename ChunkList<Chunk, E>::iterator const* ChunkList<Chunk, E>::find(size_t id) const {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
+ChunkList<Chunk, Col1, Col2, E>::find(id_type id) const {
     auto const iter = m_byId.find(id);
     return iter == m_byId.cend() ? nullptr : &iter->second;
 }
 
-template<typename Chunk, typename E> inline ChunkList<Chunk, E>::ChunkList(size_t tsize) noexcept :
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+ChunkList<Chunk, Col1, Col2, E>::ChunkList(size_t tsize) noexcept :
 super(), m_tupleSize(tsize), m_chunkSize(::chunkSize(m_tupleSize)) {}
 
-template<typename Chunk, typename E> inline size_t& ChunkList<Chunk, E>::lastChunkId() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline id_type&
+ChunkList<Chunk, Col1, Col2, E>::lastChunkId() {
     return m_lastChunkId;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::tupleSize() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::chunkSize() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::chunkSize() const noexcept {
     return m_chunkSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::size() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
+ChunkList<Chunk, Col1, Col2, E>::size() const noexcept {
     return m_size;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator const&
-ChunkList<Chunk, E>::last() const noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+typename ChunkList<Chunk, Col1, Col2, E>::iterator const&
+ChunkList<Chunk, Col1, Col2, E>::last() const noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator&
-ChunkList<Chunk, E>::last() noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline
+typename ChunkList<Chunk, Col1, Col2, E>::iterator&
+ChunkList<Chunk, Col1, Col2, E>::last() noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::add(
-        typename ChunkList<Chunk, E>::iterator iter) {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::add(typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
     m_byAddr.emplace(iter->begin(), iter);
     m_byId.emplace(iter->id(), iter);
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::remove(
-        typename ChunkList<Chunk, E>::iterator iter) {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::remove(
+        typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
     m_byAddr.erase(iter->begin());
     m_byId.erase(iter->id());
 }
 
-template<typename Chunk, typename E>
-template<typename... Args>
-inline typename ChunkList<Chunk, E>::iterator ChunkList<Chunk, E>::emplace_back(Args&&... args) {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+template<typename... Args> inline typename ChunkList<Chunk, Col1, Col2, E>::iterator
+ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
     if (super::empty()) {
         super::emplace_front(forward<Args>(args)...);
         m_back = super::begin();
@@ -255,7 +265,8 @@ inline typename ChunkList<Chunk, E>::iterator ChunkList<Chunk, E>::emplace_back(
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::pop_front() {
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
@@ -268,7 +279,8 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front(
     }
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back() {
+template<typename Chunk, typename Col1, typename Col2, typename E> inline void
+ChunkList<Chunk, Col1, Col2, E>::pop_back() {
     if (super::empty()) {
         throw underflow_error("pop_back() called on empty chunk list");
     } else {
@@ -283,8 +295,8 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back()
     }
 }
 
-template<typename Chunk, typename E>
-template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
             vassert(m_byAddr.count(iter->begin()));
@@ -299,8 +311,8 @@ template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
     super::remove_if(pred);
 }
 
-template<typename Chunk, typename E>
-inline void ChunkList<Chunk, E>::clear() noexcept {
+template<typename Chunk, typename Col1, typename Col2, typename E>
+inline void ChunkList<Chunk, Col1, Col2, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();
@@ -357,7 +369,7 @@ template<typename C, typename E> inline void NonCompactingChunks<C, E>::free(voi
     }
 }
 
-inline CompactingChunk::CompactingChunk(size_t id, size_t s, size_t s2) : super(id, s, s2) {}
+inline CompactingChunk::CompactingChunk(id_type id, size_t s, size_t s2) : super(id, s, s2) {}
 
 inline void CompactingChunk::free(void* dst, void const* src) {     // cross-chunk free(): update only on dst chunk
     vassert(contains(dst));
@@ -434,7 +446,7 @@ inline typename CompactingStorageTrait::list_type::iterator CompactingStorageTra
     }
 }
 
-size_t CompactingChunks::s_id = 0;
+id_type CompactingChunks::s_id = 0;
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(this), m_id(gen_id()),
@@ -467,11 +479,11 @@ inline bool CompactingChunks::TxnLeftBoundary::empty() const noexcept {
     return m_next == nullptr;
 }
 
-size_t CompactingChunks::gen_id() {
+id_type CompactingChunks::gen_id() {
     return s_id++;
 }
 
-inline size_t CompactingChunks::id() const noexcept {
+inline id_type CompactingChunks::id() const noexcept {
     return m_id;
 }
 
@@ -492,7 +504,7 @@ CompactingChunks::find(void const* p) const noexcept {
 }
 
 inline typename CompactingChunks::list_type::iterator const*
-CompactingChunks::find(size_t id) const noexcept {
+CompactingChunks::find(id_type id) const noexcept {
     auto const iter = list_type::find(id);
     return iter == nullptr ||
         less<CompactingChunks::list_type::iterator>()(*iter, beginTxn().iterator()) ?
@@ -920,7 +932,7 @@ template<typename Chunks, typename Tag, typename E> Tag IterableTableTupleChunks
 template<iterator_view_type, iterator_permission_type,
     typename container_type, typename = typename container_type::Compact>
 struct IteratorPermissible {
-    void operator()(set<size_t> const&, container_type) const noexcept {
+    void operator()(set<id_type> const&, container_type) const noexcept {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
     }
 };
@@ -931,7 +943,7 @@ struct IteratorPermissible {
 template<typename container_type>
 struct IteratorPermissible<iterator_view_type::snapshot, iterator_permission_type::rw,
     container_type, integral_constant<bool, true>> {
-    void operator()(set<size_t>& exists, container_type cont) const {
+    void operator()(set<id_type>& exists, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = exists.find(cont.id());
         if (iter == exists.end()) {            // add entry
@@ -951,7 +963,7 @@ struct IteratorPermissible<iterator_view_type::snapshot, iterator_permission_typ
 template<iterator_view_type, iterator_permission_type,
     typename container_type, typename = typename container_type::Compact>
 struct IteratorDeregistration {
-    void operator()(set<size_t> const&, container_type) const noexcept {       // No-op for irrelavent types
+    void operator()(set<id_type> const&, container_type) const noexcept {       // No-op for irrelavent types
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
     }
 };
@@ -959,7 +971,7 @@ struct IteratorDeregistration {
 template<typename container_type>
 struct IteratorDeregistration<iterator_view_type::snapshot, iterator_permission_type::rw,
     container_type, integral_constant<bool, true>> {
-    void operator()(set<size_t>& m, container_type cont) const {
+    void operator()(set<id_type>& m, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = m.find(cont.id());
         if (iter != m.end()) {
@@ -1268,7 +1280,7 @@ namespace std {                                    // Need to declare these befo
 template<typename IterableTableTupleChunks, typename ElasticIterator,
     typename Compact = typename IterableTableTupleChunks::chunk_type::Compact>
 struct ElasticIterator_refresh {
-    inline void operator()(ElasticIterator const&, size_t const&,
+    inline void operator()(ElasticIterator const&, id_type const&,
             typename IterableTableTupleChunks::chunk_type const&,
             typename IterableTableTupleChunks::chunk_type::list_type::const_iterator&,
             void const*&) const {
@@ -1278,7 +1290,7 @@ struct ElasticIterator_refresh {
 
 template<typename I, typename ElasticIterator>
 struct ElasticIterator_refresh<I, ElasticIterator, integral_constant<bool, true>> {
-    inline void operator()(ElasticIterator& iter, size_t& chunkId,
+    inline void operator()(ElasticIterator& iter, id_type& chunkId,
             typename I::chunk_type const& storage,
             ChunkList<CompactingChunk>::const_iterator& chunkIter,
             void const*& cursor) const {
@@ -1401,7 +1413,7 @@ inline position_type::position_type(CompactingChunks const& c, void const* p) : 
         // semantics of less<position_type>.
         const_cast<void*&>(m_addr) = nullptr;
     } else {
-        const_cast<size_t&>(m_chunkId) = (*iterp)->id();
+        const_cast<remove_const<decltype(m_chunkId)>::type&>(m_chunkId) = (*iterp)->id();
     }
 }
 
@@ -1409,7 +1421,7 @@ template<typename iterator>
 inline position_type::position_type(void const* p, iterator const& iter) noexcept :
 m_chunkId(iter->id()), m_addr(p) {}
 
-inline size_t position_type::chunkId() const noexcept {
+inline id_type position_type::chunkId() const noexcept {
     return m_chunkId;
 }
 inline void const* position_type::address() const noexcept {
@@ -1423,7 +1435,7 @@ inline bool position_type::operator==(position_type const& o) const noexcept {
 }
 
 inline position_type& position_type::operator=(position_type const& o) noexcept {
-    const_cast<size_t&>(m_chunkId) = o.chunkId();
+    const_cast<id_type&>(m_chunkId) = o.chunkId();
     m_addr = o.address();
     return *this;
 }

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -184,9 +184,9 @@ inline void LazyNonCompactingChunk::free(void* src) {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
-ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
+template<typename Chunk, typename Col, typename E>
+inline typename ChunkList<Chunk, Col, E>::iterator const*
+ChunkList<Chunk, Col, E>::find(void const* k) const {
     if (! m_byAddr.empty()) {
         auto const& iter = prev(m_byAddr.upper_bound(k));                    // find first entry whose begin() > k
         return iter != m_byAddr.cend() && iter->second->contains(k) ? &iter->second : nullptr;
@@ -195,65 +195,65 @@ ChunkList<Chunk, Col1, Col2, E>::find(void const* k) const {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline typename ChunkList<Chunk, Col1, Col2, E>::iterator const*
-ChunkList<Chunk, Col1, Col2, E>::find(id_type id) const {
+template<typename Chunk, typename Col, typename E>
+inline typename ChunkList<Chunk, Col, E>::iterator const*
+ChunkList<Chunk, Col, E>::find(id_type id) const {
     auto const iter = m_byId.find(id);
     return iter == m_byId.cend() ? nullptr : &iter->second;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-ChunkList<Chunk, Col1, Col2, E>::ChunkList(size_t tsize) noexcept :
+template<typename Chunk, typename Col, typename E> inline
+ChunkList<Chunk, Col, E>::ChunkList(size_t tsize) noexcept :
 super(), m_tupleSize(tsize), m_chunkSize(::chunkSize(m_tupleSize)) {}
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline id_type&
-ChunkList<Chunk, Col1, Col2, E>::lastChunkId() {
+template<typename Chunk, typename Col, typename E> inline id_type&
+ChunkList<Chunk, Col, E>::lastChunkId() {
     return m_lastChunkId;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::tupleSize() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::chunkSize() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::chunkSize() const noexcept {
     return m_chunkSize;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline size_t
-ChunkList<Chunk, Col1, Col2, E>::size() const noexcept {
+template<typename Chunk, typename Col, typename E> inline size_t
+ChunkList<Chunk, Col, E>::size() const noexcept {
     return m_size;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-typename ChunkList<Chunk, Col1, Col2, E>::iterator const&
-ChunkList<Chunk, Col1, Col2, E>::last() const noexcept {
+template<typename Chunk, typename Col, typename E> inline
+typename ChunkList<Chunk, Col, E>::iterator const&
+ChunkList<Chunk, Col, E>::last() const noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline
-typename ChunkList<Chunk, Col1, Col2, E>::iterator&
-ChunkList<Chunk, Col1, Col2, E>::last() noexcept {
+template<typename Chunk, typename Col, typename E> inline
+typename ChunkList<Chunk, Col, E>::iterator&
+ChunkList<Chunk, Col, E>::last() noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::add(typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::add(typename ChunkList<Chunk, Col, E>::iterator iter) {
     m_byAddr.emplace(iter->begin(), iter);
     m_byId.emplace(iter->id(), iter);
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::remove(
-        typename ChunkList<Chunk, Col1, Col2, E>::iterator iter) {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::remove(
+        typename ChunkList<Chunk, Col, E>::iterator iter) {
     m_byAddr.erase(iter->begin());
     m_byId.erase(iter->id());
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-template<typename... Args> inline typename ChunkList<Chunk, Col1, Col2, E>::iterator
-ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
+template<typename Chunk, typename Col, typename E>
+template<typename... Args> inline typename ChunkList<Chunk, Col, E>::iterator
+ChunkList<Chunk, Col, E>::emplace_back(Args&&... args) {
     if (super::empty()) {
         super::emplace_front(forward<Args>(args)...);
         m_back = super::begin();
@@ -265,8 +265,8 @@ ChunkList<Chunk, Col1, Col2, E>::emplace_back(Args&&... args) {
     return m_back;
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::pop_front() {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::pop_front() {
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
@@ -279,8 +279,8 @@ ChunkList<Chunk, Col1, Col2, E>::pop_front() {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E> inline void
-ChunkList<Chunk, Col1, Col2, E>::pop_back() {
+template<typename Chunk, typename Col, typename E> inline void
+ChunkList<Chunk, Col, E>::pop_back() {
     if (super::empty()) {
         throw underflow_error("pop_back() called on empty chunk list");
     } else {
@@ -295,8 +295,8 @@ ChunkList<Chunk, Col1, Col2, E>::pop_back() {
     }
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(Pred pred) {
+template<typename Chunk, typename Col, typename E>
+template<typename Pred> inline void ChunkList<Chunk, Col, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
             vassert(m_byAddr.count(iter->begin()));
@@ -311,8 +311,8 @@ template<typename Pred> inline void ChunkList<Chunk, Col1, Col2, E>::remove_if(P
     super::remove_if(pred);
 }
 
-template<typename Chunk, typename Col1, typename Col2, typename E>
-inline void ChunkList<Chunk, Col1, Col2, E>::clear() noexcept {
+template<typename Chunk, typename Col, typename E>
+inline void ChunkList<Chunk, Col, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -799,11 +799,13 @@ inline size_t CompactingChunks::DelayedRemover::add(void* p) {
     }
 }
 
-inline map<void*, void*> const& CompactingChunks::DelayedRemover::movements() const{
+inline typename CompactingChunks::list_type::collections::map<void*, void*> const&
+CompactingChunks::DelayedRemover::movements() const{
     return m_move;
 }
 
-inline set<void*> const& CompactingChunks::DelayedRemover::removed() const{
+inline typename CompactingChunks::list_type::collections::set<void*> const&
+CompactingChunks::DelayedRemover::removed() const{
     return m_remove;
 }
 //
@@ -954,7 +956,7 @@ struct IteratorPermissible {
  */
 template<typename container_type>
 struct IteratorPermissible<iterator_view_type::snapshot, iterator_permission_type::rw,
-    container_type, integral_constant<bool, true>> {
+    container_type, true_type> {
     void operator()(set<id_type>& exists, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = exists.find(cont.id());
@@ -982,7 +984,7 @@ struct IteratorDeregistration {
 
 template<typename container_type>
 struct IteratorDeregistration<iterator_view_type::snapshot, iterator_permission_type::rw,
-    container_type, integral_constant<bool, true>> {
+    container_type, true_type> {
     void operator()(set<id_type>& m, container_type cont) const {
         static_assert(is_lvalue_reference<container_type>::value, "container_type should be reference type");
         auto iter = m.find(cont.id());
@@ -1027,7 +1029,7 @@ struct iterator_begin {
     }
 };
 template<typename Cont, iterator_permission_type perm>
-struct iterator_begin<Cont, perm, iterator_view_type::txn, integral_constant<bool, true>> {
+struct iterator_begin<Cont, perm, iterator_view_type::txn, true_type> {
     using iterator = typename conditional<perm == iterator_permission_type::ro,
           typename Cont::const_iterator, typename Cont::iterator>::type;
     iterator operator()(Cont& c) const noexcept {
@@ -1043,7 +1045,7 @@ struct HasTxnInvisibleChunks {
 };
 
 template<typename Chunks>
-struct HasTxnInvisibleChunks<Chunks, iterator_view_type::snapshot, integral_constant<bool, true>> {
+struct HasTxnInvisibleChunks<Chunks, iterator_view_type::snapshot, true_type> {
     inline bool operator()(Chunks const& c) const noexcept {
         return c.frozen() && (c.empty() ||
                 less_rolling(c.frozenBoundaries().left().chunkId(), c.begin()->id()));
@@ -1133,7 +1135,7 @@ struct ChunkBoundary {
 };
 
 template<typename ChunkList, typename Iter>
-struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, integral_constant<bool, true>> {
+struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, true_type> {
     inline void const* operator()(ChunkList const& l, Iter const& iter, bool hasTxnInvisibleChunks) const noexcept {
         auto const& frozenBoundaries = reinterpret_cast<CompactingChunks const&>(l).frozenBoundaries();
         if (frozenBoundaries.left().empty()) {        // not frozen
@@ -1177,7 +1179,7 @@ struct ChunkDeleter {
 };
 
 template<typename ChunkList, typename Iter>
-struct ChunkDeleter<ChunkList, Iter, iterator_permission_type::rw, iterator_view_type::snapshot, integral_constant<bool, true>> {
+struct ChunkDeleter<ChunkList, Iter, iterator_permission_type::rw, iterator_view_type::snapshot, true_type> {
     inline void operator()(ChunkList& l, Iter& iter) const noexcept {
         if (reinterpret_cast<CompactingChunks const&>(l).frozen() &&
                 less<Iter>()(iter, reinterpret_cast<CompactingChunks const&>(l).beginTxn().iterator())) {
@@ -1287,7 +1289,7 @@ struct ElasticIterator_refresh {
 };
 
 template<typename I, typename ElasticIterator>
-struct ElasticIterator_refresh<I, ElasticIterator, integral_constant<bool, true>> {
+struct ElasticIterator_refresh<I, ElasticIterator, true_type> {
     inline void operator()(ElasticIterator& iter, bool& isEmpty, id_type& chunkId,
             typename I::chunk_type const& storage,
             typename I::chunk_type::iterator const& last, position_type const& boundary,
@@ -1698,7 +1700,8 @@ HookedCompactingChunks<Hook, E>::remove(typename CompactingChunks::remove_direct
 }
 
 template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E>::remove(
-        set<void*> const& src, function<void(map<void*, void*>const&)> const& cb) {
+        set<void*> const& src,
+        function<void(CompactingChunks::DelayedRemover_movments_type)> const& cb) {
     using Remover = typename CompactingChunks::DelayedRemover;
     auto batch = accumulate(src.cbegin(), src.cend(), Remover{*this},
             [](Remover& batch, void* p) {
@@ -1719,7 +1722,7 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
     // moves (i.e. memcpy) before call back
     auto const tuple_size = tupleSize();
     for_each(batch.movements().cbegin(), batch.movements().cend(),
-            [tuple_size](typename map<void*, void*>::value_type const& entry) {
+            [tuple_size](pair<void*, void*> const& entry) {
                 memcpy(entry.first, entry.second, tuple_size);
             });
     cb(batch.movements());
@@ -1730,7 +1733,8 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
     return CompactingChunks::m_batched.add(p);
 }
 
-template<typename Hook, typename E> inline map<void*, void*> const& HookedCompactingChunks<Hook, E>::remove_moves() {
+template<typename Hook, typename E> inline typename
+CompactingChunks::DelayedRemover_movments_type HookedCompactingChunks<Hook, E>::remove_moves() {
     return CompactingChunks::m_batched.prepare(true).movements();
 }
 

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -585,6 +585,31 @@ void* CompactingChunks::free(void* dst) {
     }
 }
 
+namespace std {                                    // Need to declare these before using (for Mac clang++)
+    using namespace voltdb::storage;
+    template<> struct less<position_type> {
+        inline bool operator()(position_type const& lhs, position_type const& rhs) const noexcept {
+            bool const e1 = lhs.empty(), e2 = rhs.empty();
+            if (e1 || e2) { // NOTE: anything but empty < empty, and empty < anything but empty.
+                return ! (e1 && e2);               // That is, empty !< empty (since empty == empty)
+            } else {
+                auto const id1 = lhs.chunkId(), id2 = rhs.chunkId();
+                return (id1 == id2 && lhs.address() < rhs.address()) || less_rolling(id1, id2);
+            }
+        }
+    };
+    template<> struct less_equal<position_type> {
+        inline bool operator()(position_type const& lhs, position_type const& rhs) const noexcept {
+            return lhs.address() == rhs.address() || less<position_type>()(lhs, rhs);
+        }
+    };
+    template<> struct less<ChunkHolder<>> {
+        inline bool operator()(ChunkHolder<> const& lhs, ChunkHolder<> const& rhs) const noexcept {
+            return less_rolling(lhs.id(), rhs.id());
+        }
+    };
+}
+
 inline void CompactingChunks::free(typename CompactingChunks::remove_direction dir, void const* p) {
     switch (dir) {
         case remove_direction::from_head:
@@ -641,13 +666,8 @@ inline void CompactingChunks::free(typename CompactingChunks::remove_direction d
                 if (last()->begin() == (last()->m_next = const_cast<void*>(p))) { // delete last chunk
                     pop_back();
                 }
-                if (frozen()) {
-                    if (empty()) {
-                        m_frozenTxnBoundaries.right() = {};
-                    } else {
-                        m_frozenTxnBoundaries.right() = *last();
-                    }
-                }
+                vassert(! frozen() || empty() ||
+                        less_equal<position_type>()(m_frozenTxnBoundaries.right(), *last()));
                 --m_allocs;
             }
             break;
@@ -1123,19 +1143,27 @@ struct ChunkBoundary {
 template<typename ChunkList, typename Iter>
 struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, integral_constant<bool, true>> {
     inline void const* operator()(ChunkList const& l, Iter const& iter, bool hasTxnInvisibleChunks) const noexcept {
-        auto const& boundaries = reinterpret_cast<CompactingChunks const&>(l).frozenBoundaries();
-        if (boundaries.left().empty()) {        // not frozen
+        auto const& frozenBoundaries = reinterpret_cast<CompactingChunks const&>(l).frozenBoundaries();
+        if (frozenBoundaries.left().empty()) {        // not frozen
             return iter->next();
         } else {
-            auto const leftId = boundaries.left().chunkId(),
-                 rightId = boundaries.right().chunkId(),
+            auto const leftId = frozenBoundaries.left().chunkId(),
+                 rightId = frozenBoundaries.right().chunkId(),
+                 txnBeginChunkId = reinterpret_cast<CompactingChunks const&>(l).beginTxn().iterator()->id(),
                  iterId = iter->id();
-            if(less_rolling(leftId, iterId)) {  // in chunk visible to frozen iterator only
-                return iter->end();
+            if(less_rolling(iterId, txnBeginChunkId)) {  // in chunk visible to frozen iterator only
+                if (less_rolling(iterId, rightId)) {
+                    return iter->end();
+                } else {
+                    vassert(iterId == rightId);
+                    return frozenBoundaries.right().address();
+                }
             } else if (leftId == iterId) {      // in the left boundary of frozen state
-                return hasTxnInvisibleChunks ? iter->end() : boundaries.left().address();
+                return hasTxnInvisibleChunks ? iter->end() : frozenBoundaries.left().address();
             } else if (rightId == iterId) {     // in the right boundary
-                return boundaries.right().address();
+                return frozenBoundaries.right().address();
+            } else if (txnBeginChunkId == iterId) {
+                return iter->end();
             } else {
                 return iter->next();
             }
@@ -1246,31 +1274,6 @@ typename IterableTableTupleChunks<Chunks, Tag, E>::elastic_iterator
 IterableTableTupleChunks<Chunks, Tag, E>::elastic_iterator::begin(
         typename IterableTableTupleChunks<Chunks, Tag, E>::elastic_iterator::container_type c) {
     return {c};
-}
-
-namespace std {                                    // Need to declare these before using (for Mac clang++)
-    using namespace voltdb::storage;
-    template<> struct less<position_type> {
-        inline bool operator()(position_type const& lhs, position_type const& rhs) const noexcept {
-            bool const e1 = lhs.empty(), e2 = rhs.empty();
-            if (e1 || e2) { // NOTE: anything but empty < empty, and empty < anything but empty.
-                return ! (e1 && e2);               // That is, empty !< empty (since empty == empty)
-            } else {
-                auto const id1 = lhs.chunkId(), id2 = rhs.chunkId();
-                return (id1 == id2 && lhs.address() < rhs.address()) || less_rolling(id1, id2);
-            }
-        }
-    };
-    template<> struct less_equal<position_type> {
-        inline bool operator()(position_type const& lhs, position_type const& rhs) const noexcept {
-            return lhs.address() == rhs.address() || less<position_type>()(lhs, rhs);
-        }
-    };
-    template<> struct less<ChunkHolder<>> {
-        inline bool operator()(ChunkHolder<> const& lhs, ChunkHolder<> const& rhs) const noexcept {
-            return less_rolling(lhs.id(), rhs.id());
-        }
-    };
 }
 
 // Helper for elastic_iterator::refresh() on compacting chunks.
@@ -1458,10 +1461,7 @@ IterableTableTupleChunks<Chunks, Tag, E>::elastic_iterator::drained() noexcept {
     if (super::drained()) {
         return true;
     } else {
-        refresh();
-        if (super::drained()) {
-            return true;
-        } else if (super::storage().empty() ||
+        if (super::storage().empty() ||
                 less<position_type>()(*super::storage().last(), *this) ||
                 less<position_type>()(m_txnBoundary, *this) ||
                 m_txnBoundary == *this) {

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -703,16 +703,8 @@ inline position_type const& CompactingChunks::FrozenTxnBoundaries::right() const
     return m_right;
 }
 
-inline position_type& CompactingChunks::FrozenTxnBoundaries::right() noexcept {
-    return m_right;
-}
-
 inline typename CompactingChunks::FrozenTxnBoundaries const& CompactingChunks::frozenBoundaries() const noexcept {
     return m_frozenTxnBoundaries;
-}
-
-inline position_type& CompactingChunks::frozenRight() noexcept {
-    return m_frozenTxnBoundaries.right();
 }
 
 namespace batch_remove_aid {

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -104,13 +104,13 @@ namespace voltdb {
             using super::get;
         };
 
+        using id_type = size_t;                        // chunk id type
         /**
          * Holder for a chunk, whether it is self-compacting or not.
          */
         template<typename Alloc = StdAllocator>
         class ChunkHolder : private Alloc {
-            using super = Alloc;
-            size_t const m_id;                         // chunk id
+            id_type const m_id;                         // chunk id
             size_t const m_tupleSize;                  // size of a table tuple per allocation
             void*const m_end;                          // indication of chunk capacity
         protected:
@@ -120,7 +120,7 @@ namespace voltdb {
             ChunkHolder(ChunkHolder&&) = delete;
             friend class CompactingChunks;              // for batch free
         public:
-            ChunkHolder(size_t id, size_t tupleSize, size_t chunkSize);
+            ChunkHolder(id_type id, size_t tupleSize, size_t chunkSize);
             ~ChunkHolder() = default;
             void* allocate() noexcept;                 // returns NULL if this chunk is full.
             bool contains(void const*) const;          // query if a table tuple is stored in current chunk
@@ -130,7 +130,7 @@ namespace voltdb {
             void*const end() const noexcept;
             void*const next() const noexcept;
             size_t tupleSize() const noexcept;
-            size_t id() const noexcept;
+            id_type id() const noexcept;
         };
 
         /**
@@ -147,7 +147,7 @@ namespace voltdb {
             EagerNonCompactingChunk& operator=(EagerNonCompactingChunk const&) = delete;
             EagerNonCompactingChunk(EagerNonCompactingChunk&&) = delete;
         public:
-            EagerNonCompactingChunk(size_t, size_t, size_t);
+            EagerNonCompactingChunk(id_type, size_t, size_t);
             ~EagerNonCompactingChunk() = default;
             void* allocate() noexcept;
             void free(void*);
@@ -171,7 +171,7 @@ namespace voltdb {
             LazyNonCompactingChunk& operator=(LazyNonCompactingChunk const&) = delete;
             LazyNonCompactingChunk(LazyNonCompactingChunk&&) = delete;
         public:
-            LazyNonCompactingChunk(size_t, size_t, size_t);
+            LazyNonCompactingChunk(id_type, size_t, size_t);
             ~LazyNonCompactingChunk() = default;
             // void* allocate() noexcept; same as ChunkHolder
             // when contains(void const*) returns true, the addr may
@@ -180,6 +180,11 @@ namespace voltdb {
             // but gives conservative, ignoring any holes.
             void free(void*);
             // bool empty() const noexcept is identical to ChunkHolder.
+        };
+
+        template<typename Key, typename Value> struct StdCollections {
+            using set = std::set<Key>;
+            using map = std::map<Key, Value>;
         };
 
         /**
@@ -191,20 +196,22 @@ namespace voltdb {
          * and limit insertion to tail and erase to front.
          */
         template<typename Chunk,
+            typename Collectible1 = StdCollections<void const*, typename forward_list<Chunk>::iterator>,
+            typename Collectible2 = StdCollections<id_type, typename forward_list<Chunk>::iterator>,
             typename = typename enable_if<is_base_of<ChunkHolder<>, Chunk>::value>::type>
         class ChunkList : private forward_list<Chunk> {
             using super = forward_list<Chunk>;
             size_t const m_tupleSize;
             size_t const m_chunkSize;                  // how many bytes per chunk
             size_t m_size = 0;
-            size_t m_lastChunkId = 0;
+            id_type m_lastChunkId = 0;
             typename super::iterator m_back = super::end();
-            map<void const*, typename super::iterator> m_byAddr{};
-            map<size_t, typename super::iterator> m_byId{};
+            typename Collectible1::map m_byAddr{};
+            typename Collectible2::map m_byId{};
             void add(typename super::iterator);
             void remove(typename super::iterator);
         protected:
-            size_t& lastChunkId();
+            id_type& lastChunkId();
             template<typename Pred> void remove_if(Pred p);
             typename super::iterator& last() noexcept;
         public:
@@ -229,7 +236,7 @@ namespace voltdb {
             iterator const& last() const noexcept;
             // the O(log(n)) killer
             iterator const* find(void const*) const;
-            iterator const* find(size_t) const;
+            iterator const* find(id_type) const;
         };
 
         /**
@@ -285,7 +292,7 @@ namespace voltdb {
          */
         struct CompactingChunk final : public ChunkHolder<> {
             using super = ChunkHolder<>;
-            CompactingChunk(size_t id, size_t tupleSize, size_t chunkSize);
+            CompactingChunk(id_type, size_t, size_t);
             CompactingChunk(CompactingChunk&&) = delete;
             CompactingChunk(CompactingChunk const&) = delete;
             CompactingChunk& operator=(CompactingChunk const&) = delete;
@@ -295,11 +302,6 @@ namespace voltdb {
             void* free();                           // release tuple from the last chunk of the list, from the last allocation
             // void* allocate() noexcept, bool contains(void const*) const, bool full() const noexcept,
             // begin() and end(), all have same implementation as ChunkHolder
-        };
-
-        template<typename Key, typename Value> struct stdCollections {
-            using set = std::set<Key>;
-            using map = std::map<Key, Value>;
         };
 
         /**
@@ -370,7 +372,7 @@ namespace voltdb {
          */
         class CompactingChunks;
         class position_type {
-            size_t const m_chunkId = 0;
+            id_type const m_chunkId = 0;
             void const* m_addr = nullptr;
         public:
             position_type() noexcept = default;        // empty initiator
@@ -380,7 +382,7 @@ namespace voltdb {
             position_type(position_type const&) noexcept = default;
             position_type(position_type&&) noexcept = default;
             position_type& operator=(position_type const&) noexcept;
-            size_t chunkId() const noexcept;
+            id_type chunkId() const noexcept;
             void const* address() const noexcept;
             bool empty() const noexcept;               // makes it behave like std::optional<position_type>
             bool operator==(position_type const&) const noexcept;
@@ -420,10 +422,10 @@ namespace voltdb {
         private:
             template<typename, typename, typename> friend struct IterableTableTupleChunks;
             using list_type = ChunkList<CompactingChunk>;
-            static size_t s_id;
-            static size_t gen_id();
+            static id_type s_id;
+            static id_type gen_id();
 
-            size_t const m_id;                    // equivalent to "table id", to ensure injection relation to rw iterator
+            id_type const m_id;                    // equivalent to "table id", to ensure injection relation to rw iterator
             char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
             TxnLeftBoundary m_txnFirstChunk;     // (moving) left boundary for txn
             FrozenTxnBoundaries m_frozenTxnBoundaries{};  // frozen boundaries for txn
@@ -480,14 +482,14 @@ namespace voltdb {
              */
             size_t chunks() const noexcept;            // number of chunks
             size_t size() const noexcept;              // number of allocation requested
-            size_t id() const noexcept;
+            id_type id() const noexcept;
             using list_type::tupleSize; using list_type::chunkSize;
             using list_type::empty; using list_type::begin; using list_type::end;
             using CompactingStorageTrait::frozen;
 
             // search in txn memory region (i.e. excludes snapshot-related, front portion of list)
             list_type::iterator const* find(void const*) const noexcept;
-            list_type::iterator const* find(size_t) const noexcept;
+            list_type::iterator const* find(id_type) const noexcept;
             TxnLeftBoundary const& beginTxn() const noexcept;   // (moving) txn left boundary
             TxnLeftBoundary& beginTxn() noexcept;               // NOTE: this should really be private. Use it with care!!!
             FrozenTxnBoundaries const& frozenBoundaries() const noexcept;  // txn boundaries when freezing
@@ -559,7 +561,7 @@ namespace voltdb {
             is_base_of<CompactingChunks, typename remove_const<T>::type>::value>;
 
         template<typename Alloc, typename Trait,
-            typename Collections = stdCollections<void const*, void const*>,
+            typename Collections = StdCollections<void const*, void const*>,
             typename = typename enable_if<is_chunks<Alloc>::value && is_base_of<BaseHistoryRetainTrait, Trait>::value>::type>
         class TxnPreHook : private Trait {
             using set = typename Collections::set;
@@ -713,7 +715,7 @@ namespace voltdb {
                     add_lvalue_reference<typename conditional<perm == iterator_permission_type::ro,
                     Chunks const, Chunks>::type>::type;
                 class Constructible {
-                    set<size_t> m_inUse{};
+                    set<id_type> m_inUse{};
                 public:
                     void validate(container_type);
                     void remove(container_type);
@@ -759,7 +761,7 @@ namespace voltdb {
                 using container_type = typename super::container_type;
                 using value_type = typename super::value_type;
                 position_type const m_txnBoundary;
-                size_t m_chunkId;
+                id_type m_chunkId;
                 void refresh();
             public:
                 elastic_iterator(container_type);

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -414,7 +414,6 @@ namespace voltdb {
                 FrozenTxnBoundaries(ChunkList<CompactingChunk> const&) noexcept;
                 position_type const& left() const noexcept;
                 position_type const& right() const noexcept;
-                position_type& right() noexcept;
                 void clear();
             };
         private:
@@ -471,7 +470,6 @@ namespace voltdb {
             } m_batched;
             using list_type::last;
             using list_type::pop_back;
-            position_type& frozenRight() noexcept;  // txn right boundary when freezing. Need to be adjusted for LW tail removal
         public:
             using Compact = integral_constant<bool, true>;
             CompactingChunks(size_t tupleSize) noexcept;

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -213,6 +213,7 @@ namespace voltdb {
             template<typename Pred> void remove_if(Pred p);
             typename super::iterator& last() noexcept;
         public:
+            using collections = Col;
             using iterator = typename super::iterator;
             using const_iterator = typename super::const_iterator;
             using reference = typename super::reference;
@@ -272,7 +273,7 @@ namespace voltdb {
         protected:
             size_t& emptyChunks();
         public:
-            using Compact = integral_constant<bool, false>;
+            using Compact = false_type;
             NonCompactingChunks(size_t) noexcept;
             ~NonCompactingChunks() = default;
             size_t size() const noexcept;              // number of allocation requests, <= sum(allocated memory from system), considering modulo and non-full spaces
@@ -434,9 +435,10 @@ namespace voltdb {
             typename list_type::iterator releasable();
             void pop_front();
             void pop_back();
-            class BatchRemoveAccumulator : private map<list_type::iterator, vector<void*>> {
+            class BatchRemoveAccumulator :
+                private list_type::collections::template map<list_type::iterator, vector<void*>> {
+                using map_type = list_type::collections::template map<list_type::iterator, vector<void*>>;
                 CompactingChunks* m_self;
-                using map_type = map<list_type::iterator, vector<void*>>;
             protected:
                 CompactingChunks& chunks() noexcept;
                 // force "removing" the chunk to be compacted from, either by deleting (when not frozen), or
@@ -453,25 +455,29 @@ namespace voltdb {
             size_t m_allocs = 0;
             class DelayedRemover : protected BatchRemoveAccumulator {
                 using super = BatchRemoveAccumulator;
+                template<typename K, typename V> using map_type = list_type::collections::template map<K, V>;
+                template<typename K> using set_type = list_type::collections::template set<K>;
                 size_t m_size = 0;
                 bool m_prepared = false;
-                set<void*> m_remove{};
-                map<void*, void*> m_move{};
+                set_type<void*> m_remove{};
+                map_type<void*, void*> m_move{};
             public:
                 explicit DelayedRemover(CompactingChunks&);
                 // Register a single allocation to be removed later
                 size_t add(void*);
                 // Memory movements (src to be removed => dst to be copied over) due to batch remove
                 DelayedRemover& prepare(bool);
-                map<void*, void*> const& movements() const;
-                set<void*> const& removed() const;
+                map_type<void*, void*> const& movements() const;
+                set_type<void*> const& removed() const;
                 // Actuate batch remove
                 size_t force(bool);
             } m_batched;
             using list_type::last;
             using list_type::pop_back;
         public:
-            using Compact = integral_constant<bool, true>;
+            using Compact = true_type;
+            // for use in HookedCompactingChunks::remove() [batch mode]:
+            using DelayedRemover_movments_type = typename list_type::collections::map<void*, void*> const&;
             CompactingChunks(size_t tupleSize) noexcept;
             /**
              * Queries
@@ -589,7 +595,7 @@ namespace voltdb {
             void remove(void const*);
         public:
             enum class ChangeType : char {Update, Insertion, Deletion};
-            using is_hook = integral_constant<bool, true>;
+            using is_hook = true_type;
             TxnPreHook(size_t);
             TxnPreHook(TxnPreHook const&) = delete;
             TxnPreHook(TxnPreHook&&) = delete;
@@ -650,12 +656,13 @@ namespace voltdb {
              * occurs. Map for removed addr => addr that fills in
              * the removed address
              */
-            size_t remove(set<void*> const&, function<void(map<void*, void*>const&)> const&);
+            size_t remove(set<void*> const&,
+                    function<void(typename CompactingChunks::DelayedRemover_movments_type)> const&);
             /**
              * Batch removal using separate calls
              */
             size_t remove_add(void*);
-            map<void*, void*>const& remove_moves();
+            typename CompactingChunks::DelayedRemover_movments_type remove_moves();
             size_t remove_force();
         };
 

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -82,68 +82,68 @@ BANNER("Configuring the VoltDB Execution Engine Unit Tests."
 SET (VOLTDB_MANUAL_SUCCEEDING_TEST_PROGRAMS
   # These two need to run first, since they take
   # the longest to run.
-  storage/LargeTempTableSortTest
-  storage/DRBinaryLog_test
-  catalog/catalog_test
-  catalog/ExportTupleStreamTest
-  common/debuglog_test
-  common/elastic_hashinator_test
-  common/nvalue_test
-  common/LargeTempTableBlockIdTest
-  common/PerFragmentStatsTest
-  common/PoolCheckingTest
-  common/pool_test
-  common/serializeio_test
-  common/tabletuple_test
-  common/ThreadLocalPoolTest
-  common/tupleschema_test
-  common/undolog_test
-  common/uniqueid_test
-  common/valuearray_test
-  execution/add_drop_table
-  execution/engine_test
-  execution/ExecutorVectorTest
-  execution/FragmentManagerTest
-  executors/CommonTableExpressionTest
-  executors/MergeReceiveExecutorTest
-  executors/OptimizedProjectorTest
-  expressions/expression_test
-  expressions/function_test
-  indexes/CompactingHashIndexTest
-  indexes/CompactingTreeMultiIndexTest
-  indexes/CoveringCellIndexTest
-  indexes/index_key_test
-  indexes/index_scripted_test
-  indexes/index_test
-  harness_test/harness_tester
-  logging/logging_test
-  memleaktests/no_losses
-  plannodes/PlanNodeFragmentTest
-  plannodes/PlanNodeUtilTest
-  plannodes/WindowFunctionPlanNodeTest
-  storage/CompactionTest
-  storage/constraint_test
-  storage/CopyOnWriteTest
-  storage/DRTupleStream_test
-  storage/ExportTupleStream_test
-  storage/filter_test
-  storage/LargeTempTableBlockTest
-  storage/LargeTempTableTest
-  storage/persistent_table_log_test
-  storage/PersistentTableMemStatsTest
-  storage/persistenttable_test
-  storage/serialize_test
-  storage/StreamedTable_test
-  storage/table_and_indexes_test
-  storage/table_test
-  storage/tabletuple_export_test
-  storage/tabletuplefilter_test
-  storage/TempTableLimitsTest
-  structures/CompactingHashTest
-  structures/CompactingMapBenchmark
-  structures/CompactingMapIndexCountTest
-  structures/CompactingMapTest
-  structures/CompactingPoolTest
+  #   storage/LargeTempTableSortTest
+  #   storage/DRBinaryLog_test
+  #   catalog/catalog_test
+  #   catalog/ExportTupleStreamTest
+  #   common/debuglog_test
+  #   common/elastic_hashinator_test
+  #   common/nvalue_test
+  #   common/LargeTempTableBlockIdTest
+  #   common/PerFragmentStatsTest
+  #   common/PoolCheckingTest
+  #   common/pool_test
+  #   common/serializeio_test
+  #   common/tabletuple_test
+  #   common/ThreadLocalPoolTest
+  #   common/tupleschema_test
+  #   common/undolog_test
+  #   common/uniqueid_test
+  #   common/valuearray_test
+  #   execution/add_drop_table
+  #   execution/engine_test
+  #   execution/ExecutorVectorTest
+  #   execution/FragmentManagerTest
+  #   executors/CommonTableExpressionTest
+  #   executors/MergeReceiveExecutorTest
+  #   executors/OptimizedProjectorTest
+  #   expressions/expression_test
+  #   expressions/function_test
+  #   indexes/CompactingHashIndexTest
+  #   indexes/CompactingTreeMultiIndexTest
+  #   indexes/CoveringCellIndexTest
+  #   indexes/index_key_test
+  #   indexes/index_scripted_test
+  #   indexes/index_test
+  #   harness_test/harness_tester
+  #   logging/logging_test
+  #   memleaktests/no_losses
+  #   plannodes/PlanNodeFragmentTest
+  #   plannodes/PlanNodeUtilTest
+  #   plannodes/WindowFunctionPlanNodeTest
+  #   storage/constraint_test
+  #   storage/CopyOnWriteTest
+  #   storage/DRTupleStream_test
+  #   storage/ExportTupleStream_test
+  #   storage/filter_test
+  #   storage/LargeTempTableBlockTest
+  #   storage/LargeTempTableTest
+  #   storage/persistent_table_log_test
+  #   storage/PersistentTableMemStatsTest
+  #   storage/persistenttable_test
+  #   storage/serialize_test
+  #   storage/StreamedTable_test
+  #   storage/table_and_indexes_test
+  #   storage/table_test
+  #   storage/tabletuple_export_test
+  #   storage/tabletuplefilter_test
+  #   storage/TempTableLimitsTest
+  #   structures/CompactingHashTest
+  #   structures/CompactingMapBenchmark
+  #   structures/CompactingMapIndexCountTest
+  #   structures/CompactingMapTest
+  #   structures/CompactingPoolTest
+  storage/TableTupleAllocatorTest
 )
 
 #
@@ -158,7 +158,6 @@ SET(VOLTDB_MANUAL_VALGRIND_FAILING_TEST_PROGRAMS
   memleaktests/still_reachable_losses
   memleaktests/possible_losses
   memleaktests/rw_deleted
-  storage/TableTupleAllocatorTest
 )
 #
 # These are expected to fail.  There are none of

--- a/tests/ee/CMakeLists.txt
+++ b/tests/ee/CMakeLists.txt
@@ -82,68 +82,69 @@ BANNER("Configuring the VoltDB Execution Engine Unit Tests."
 SET (VOLTDB_MANUAL_SUCCEEDING_TEST_PROGRAMS
   # These two need to run first, since they take
   # the longest to run.
-  #   storage/LargeTempTableSortTest
-  #   storage/DRBinaryLog_test
-  #   catalog/catalog_test
-  #   catalog/ExportTupleStreamTest
-  #   common/debuglog_test
-  #   common/elastic_hashinator_test
-  #   common/nvalue_test
-  #   common/LargeTempTableBlockIdTest
-  #   common/PerFragmentStatsTest
-  #   common/PoolCheckingTest
-  #   common/pool_test
-  #   common/serializeio_test
-  #   common/tabletuple_test
-  #   common/ThreadLocalPoolTest
-  #   common/tupleschema_test
-  #   common/undolog_test
-  #   common/uniqueid_test
-  #   common/valuearray_test
-  #   execution/add_drop_table
-  #   execution/engine_test
-  #   execution/ExecutorVectorTest
-  #   execution/FragmentManagerTest
-  #   executors/CommonTableExpressionTest
-  #   executors/MergeReceiveExecutorTest
-  #   executors/OptimizedProjectorTest
-  #   expressions/expression_test
-  #   expressions/function_test
-  #   indexes/CompactingHashIndexTest
-  #   indexes/CompactingTreeMultiIndexTest
-  #   indexes/CoveringCellIndexTest
-  #   indexes/index_key_test
-  #   indexes/index_scripted_test
-  #   indexes/index_test
-  #   harness_test/harness_tester
-  #   logging/logging_test
-  #   memleaktests/no_losses
-  #   plannodes/PlanNodeFragmentTest
-  #   plannodes/PlanNodeUtilTest
-  #   plannodes/WindowFunctionPlanNodeTest
-  #   storage/constraint_test
-  #   storage/CopyOnWriteTest
-  #   storage/DRTupleStream_test
-  #   storage/ExportTupleStream_test
-  #   storage/filter_test
-  #   storage/LargeTempTableBlockTest
-  #   storage/LargeTempTableTest
-  #   storage/persistent_table_log_test
-  #   storage/PersistentTableMemStatsTest
-  #   storage/persistenttable_test
-  #   storage/serialize_test
-  #   storage/StreamedTable_test
-  #   storage/table_and_indexes_test
-  #   storage/table_test
-  #   storage/tabletuple_export_test
-  #   storage/tabletuplefilter_test
-  #   storage/TempTableLimitsTest
-  #   structures/CompactingHashTest
-  #   structures/CompactingMapBenchmark
-  #   structures/CompactingMapIndexCountTest
-  #   structures/CompactingMapTest
-  #   structures/CompactingPoolTest
+  storage/LargeTempTableSortTest
+  storage/DRBinaryLog_test
+  catalog/catalog_test
+  catalog/ExportTupleStreamTest
+  common/debuglog_test
+  common/elastic_hashinator_test
+  common/nvalue_test
+  common/LargeTempTableBlockIdTest
+  common/PerFragmentStatsTest
+  common/PoolCheckingTest
+  common/pool_test
+  common/serializeio_test
+  common/tabletuple_test
+  common/ThreadLocalPoolTest
+  common/tupleschema_test
+  common/undolog_test
+  common/uniqueid_test
+  common/valuearray_test
+  execution/add_drop_table
+  execution/engine_test
+  execution/ExecutorVectorTest
+  execution/FragmentManagerTest
+  executors/CommonTableExpressionTest
+  executors/MergeReceiveExecutorTest
+  executors/OptimizedProjectorTest
+  expressions/expression_test
+  expressions/function_test
+  indexes/CompactingHashIndexTest
+  indexes/CompactingTreeMultiIndexTest
+  indexes/CoveringCellIndexTest
+  indexes/index_key_test
+  indexes/index_scripted_test
+  indexes/index_test
+  harness_test/harness_tester
+  logging/logging_test
+  memleaktests/no_losses
+  plannodes/PlanNodeFragmentTest
+  plannodes/PlanNodeUtilTest
+  plannodes/WindowFunctionPlanNodeTest
+  storage/CompactionTest
+  storage/constraint_test
+  storage/CopyOnWriteTest
+  storage/DRTupleStream_test
+  storage/ExportTupleStream_test
+  storage/filter_test
+  storage/LargeTempTableBlockTest
+  storage/LargeTempTableTest
+  storage/persistent_table_log_test
+  storage/PersistentTableMemStatsTest
+  storage/persistenttable_test
+  storage/serialize_test
+  storage/StreamedTable_test
+  storage/table_and_indexes_test
+  storage/table_test
+  storage/tabletuple_export_test
+  storage/tabletuplefilter_test
+  storage/TempTableLimitsTest
   storage/TableTupleAllocatorTest
+  structures/CompactingHashTest
+  structures/CompactingMapBenchmark
+  structures/CompactingMapIndexCountTest
+  structures/CompactingMapTest
+  structures/CompactingPoolTest
 )
 
 #

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -78,8 +78,7 @@ public:
         return query(m_state++);
     }
     inline unsigned char* fill(unsigned char* dst) {
-        memcpy(dst, get(), sizeof m_queryBuf);
-        dst[len] = 0;
+        memcpy(dst, get(), len);
         return dst;
     }
     inline void* fill(void* dst) {
@@ -92,7 +91,6 @@ public:
     }
     inline static bool same(void const* dst, size_t state) {
         static unsigned char buf[len+1];
-//        return ! memcmp(dst, query(state, buf), len);
         bool const eq = ! memcmp(dst, query(state, buf), len);
         if (! eq) {
             printf("Expect %s, got %s", hex(state).c_str(), hex(dst).c_str());
@@ -171,18 +169,18 @@ void testNonCompactingChunks(size_t outOfOrder) {
     assert(alloc.empty());                 // everything gone
 }
 
-TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
-    CompactingChunks alloc(TupleSize);
-    array<void*, 3 * AllocsPerChunk> addresses;
-    for(auto i = 0; i < addresses.size(); ++i) {
-        addresses[i] = alloc.allocate();
-    }
-    for(auto i = 0; i < addresses.size(); ++i) {
-        auto const* iter = alloc.find(addresses[i]);
-        ASSERT_NE(iter, nullptr);
-        ASSERT_TRUE((*iter)->contains(addresses[i]));
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
+//    CompactingChunks alloc(TupleSize);
+//    array<void*, 3 * AllocsPerChunk> addresses;
+//    for(auto i = 0; i < addresses.size(); ++i) {
+//        addresses[i] = alloc.allocate();
+//    }
+//    for(auto i = 0; i < addresses.size(); ++i) {
+//        auto const* iter = alloc.find(addresses[i]);
+//        ASSERT_NE(iter, nullptr);
+//        ASSERT_TRUE((*iter)->contains(addresses[i]));
+//    }
+//}
 
 template<typename Chunks>
 void testIteratorOfNonCompactingChunks() {
@@ -265,17 +263,17 @@ void testIteratorOfNonCompactingChunks() {
             alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });*/
 }
 
-TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
-    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
-        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
-        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
+//    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
+//        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
+//        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
+//    }
+//}
 
-TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
-    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
-    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
-}
+//TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
+//    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
+//    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
+//}
 
 void testCompactingChunks() {
     using Gen = StringGen<TupleSize>;
@@ -458,15 +456,15 @@ void testCustomizedIterator(size_t skipped) {      // iterator that skips on eve
     }
 }
 
-TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
-    testCompactingChunks();
-    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
-        testCustomizedIterator<CompactingChunks, 3>(skipped);
-        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
-        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
-        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
+//    testCompactingChunks();
+//    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
+//        testCustomizedIterator<CompactingChunks, 3>(skipped);
+//        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
+//        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
+//        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
+//    }
+//}
 
 // expression template used to apply variadic NthBitChecker
 template<typename Tuple, size_t N> struct Apply {
@@ -714,10 +712,9 @@ struct TestTxnHook {
 TestTxnHook1<NonCompactingChunks<EagerNonCompactingChunk>> const TestTxnHook::sChain1{};
 TestTxnHook1<NonCompactingChunks<LazyNonCompactingChunk>> const TestTxnHook::sChain2{};
 
-TEST_F(TableTupleAllocatorTest, TestTxnHook) {
-    TestTxnHook tst;
-    tst();
-}
+//TEST_F(TableTupleAllocatorTest, TestTxnHook) {
+//    TestTxnHook()();
+//}
 
 /**
  * Test of HookedCompactingChunks using its RW iterator that
@@ -1091,58 +1088,58 @@ void testHookedCompactingChunksBatchRemove_multi2() {
     alloc.thaw();
 }
 
-TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
-    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-    using Alloc = HookedCompactingChunks<Hook>;
-    using Gen = StringGen<TupleSize>;
-    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
-    Gen gen;
-    Alloc alloc(TupleSize);
-    addresses_type addresses;
-    assert(alloc.empty());
-    size_t i;
-    for(i = 0; i < addresses.size(); ++i) {
-        addresses[i] = alloc.allocate();
-        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
-    }
-    set<void*> batch;
-    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
-        batch.emplace(const_cast<void*>(addresses[i]));
-    }
-    alloc.remove(batch, [](map<void*, void*> const&){});
-    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
-}
-
-TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
-    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-    using Alloc = HookedCompactingChunks<Hook>;
-    auto constexpr N = AllocsPerChunk * 3 + 2;
-    array<void const*, N> addresses;
-    Alloc alloc(TupleSize);
-    ASSERT_EQ(TupleSize, alloc.tupleSize());
-    ASSERT_EQ(0, alloc.chunks());
-    ASSERT_EQ(0, alloc.size());
-    size_t i;
-    for(i = 0; i < N; ++i) {
-        addresses[i] = alloc.allocate();
-    }
-    ASSERT_EQ(4, alloc.chunks());
-    ASSERT_EQ(N, alloc.size());
-    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
-    alloc.remove(const_cast<void*>(addresses[1]));
-    ASSERT_EQ(4, alloc.chunks());
-    ASSERT_EQ(N - 2, alloc.size());
-    // batch remove last 30 entries, compacts/removes head chunk
-    set<void*> s;
-    for(i = 2; i < AllocsPerChunk; ++i) {
-        s.emplace(const_cast<void*>(addresses[N - i + 1]));
-    }
-    alloc.remove(s, [](map<void*, void*> const&){});
-    ASSERT_EQ(3, alloc.chunks());
-    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
-}
+//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
+//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+//    using Alloc = HookedCompactingChunks<Hook>;
+//    using Gen = StringGen<TupleSize>;
+//    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
+//    Gen gen;
+//    Alloc alloc(TupleSize);
+//    addresses_type addresses;
+//    assert(alloc.empty());
+//    size_t i;
+//    for(i = 0; i < addresses.size(); ++i) {
+//        addresses[i] = alloc.allocate();
+//        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
+//    }
+//    set<void*> batch;
+//    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
+//        batch.emplace(const_cast<void*>(addresses[i]));
+//    }
+//    alloc.remove(batch, [](map<void*, void*> const&){});
+//    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
+//}
+//
+//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
+//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+//    using Alloc = HookedCompactingChunks<Hook>;
+//    auto constexpr N = AllocsPerChunk * 3 + 2;
+//    array<void const*, N> addresses;
+//    Alloc alloc(TupleSize);
+//    ASSERT_EQ(TupleSize, alloc.tupleSize());
+//    ASSERT_EQ(0, alloc.chunks());
+//    ASSERT_EQ(0, alloc.size());
+//    size_t i;
+//    for(i = 0; i < N; ++i) {
+//        addresses[i] = alloc.allocate();
+//    }
+//    ASSERT_EQ(4, alloc.chunks());
+//    ASSERT_EQ(N, alloc.size());
+//    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
+//    alloc.remove(const_cast<void*>(addresses[1]));
+//    ASSERT_EQ(4, alloc.chunks());
+//    ASSERT_EQ(N - 2, alloc.size());
+//    // batch remove last 30 entries, compacts/removes head chunk
+//    set<void*> s;
+//    for(i = 2; i < AllocsPerChunk; ++i) {
+//        s.emplace(const_cast<void*>(addresses[N - i + 1]));
+//    }
+//    alloc.remove(s, [](map<void*, void*> const&){});
+//    ASSERT_EQ(3, alloc.chunks());
+//    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
+//}
 
 template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
     inline void operator()() const {
@@ -1185,8 +1182,7 @@ TestHookedCompactingChunks1<EagerNonCompactingChunk> const TestHookedCompactingC
 TestHookedCompactingChunks1<LazyNonCompactingChunk> const TestHookedCompactingChunks::s2{};
 
 TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
-    TestHookedCompactingChunks t;
-    t();
+    TestHookedCompactingChunks()();
 }
 
 /**
@@ -1317,10 +1313,9 @@ struct TestInterleavedCompactingChunks {
 TestInterleavedCompactingChunks1<EagerNonCompactingChunk> const TestInterleavedCompactingChunks::s1{};
 TestInterleavedCompactingChunks1<LazyNonCompactingChunk> const TestInterleavedCompactingChunks::s2{};
 
-TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
-    TestInterleavedCompactingChunks t;
-    t();
-}
+//TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
+//    TestInterleavedCompactingChunks()();
+//}
 
 template<typename Chunk, gc_policy pol>
 void testSingleChunkSnapshot() {
@@ -1384,9 +1379,9 @@ struct TestSingleChunkSnapshot {
 TestSingleChunkSnapshot1<EagerNonCompactingChunk> const TestSingleChunkSnapshot::s1{};
 TestSingleChunkSnapshot1<LazyNonCompactingChunk> const TestSingleChunkSnapshot::s2{};
 
-TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
-    TestSingleChunkSnapshot()();
-}
+//TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
+//    TestSingleChunkSnapshot()();
+//}
 
 template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 void testRemovesFromEnds(size_t batch) {
@@ -1495,205 +1490,205 @@ struct TestRemovesFromEnds {
     }
 };
 
-TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
-    TestRemovesFromEnds()();
-}
-
-TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    void* addr = alloc.allocate();
-    ASSERT_EQ(addr, alloc.remove(addr));
-    // empty: reallocate
-    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
-    size_t i = 0;
-    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
-                ASSERT_EQ(addr, p);
-                ASSERT_TRUE(Gen::same(p, i++));
-            });
-    ASSERT_EQ(1, i);
-}
-
-// Test that it should work without txn in progress
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    size_t i;
-    for(i = 0; i < NumTuples; ++i) {
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    i = 0;
-    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
-            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
-                ASSERT_TRUE(Gen::same(p, i++));
-            });
-    ASSERT_EQ(NumTuples, i);
-}
-
-// Test that it should work with insertions
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    size_t i;
-    for(i = 0; i < NumTuples/ 2; ++i) {
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    while (! iter.drained()) {
-        ASSERT_TRUE(Gen::same(*iter++, i++));
-    }
-    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
-}
-
-// Test that it should work with normal, compacting removals that only eats what had
-// been iterated
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
-        // expensive O(n) check (actually almost O(AllocsPerChunk))
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        try {
-            alloc.remove(const_cast<void*>(addresses[i++]));
-        } catch (range_error const&) {                         // OK bc. compaction
-            continue;
-        }
-    }
-}
-
-// Test that it should work with normal, compacting removals in
-// opposite direction of the/any iterator
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-    }
-    while (! iter.drained()) {
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        ++iter;
-        ++i;
-    }
+//TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
+//    TestRemovesFromEnds()();
+//}
+//
+//TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    void* addr = alloc.allocate();
+//    ASSERT_EQ(addr, alloc.remove(addr));
+//    // empty: reallocate
+//    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
+//    size_t i = 0;
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
+//                ASSERT_EQ(addr, p);
+//                ASSERT_TRUE(Gen::same(p, i++));
+//            });
+//    ASSERT_EQ(1, i);
+//}
+//
+//// Test that it should work without txn in progress
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    size_t i;
+//    for(i = 0; i < NumTuples; ++i) {
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    i = 0;
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
+//            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
+//                ASSERT_TRUE(Gen::same(p, i++));
+//            });
 //    ASSERT_EQ(NumTuples, i);
-}
-
-// Test that it should work with lightweight, non-compacting removals that only eats
-// what had been iterated
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples; ++i) {
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        // Removing from head, unless forced by calling again
-        // with NULL next, would not have any effect except
-        // removing crosses boundary. This means that we are
-        // iterating over values that actually should *not* be
-        // visible (i.e. garbage). But that is ok, since we are
-        // not forcing it every time (in which case it becomes
-        // normal, compacting removal).
-        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
-    }
-    ASSERT_TRUE(iter.drained());
-}
-
-// Test that it should work with lightweight, non-compacting removals from tail
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        // Removing from head, unless forced by calling again
-        // with NULL next, would not have any effect except
-        // removing crosses boundary. This means that we are
-        // iterating over values that actually should *not* be
-        // visible (i.e. garbage). But that is ok, since we are
-        // not forcing it every time (in which case it becomes
-        // normal, compacting removal).
-        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
-    }
-    ASSERT_TRUE(iter.drained());
-    ASSERT_EQ(NumTuples / 2, i);
-}
-
-TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    // Remove last 10, making 1st chunk non-full
-    for (i = 0; i < 10; ++i) {
-        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-    }
-    alloc.template freeze<truth>();
-    i = 0;
-    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
-    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
-            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
-                ASSERT_TRUE(end != find(beg, end, p) ||
-                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
-                ++i;
-            });
-    ASSERT_EQ(i, NumTuples - 10);
-    alloc.thaw();
-}
+//}
+//
+//// Test that it should work with insertions
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    size_t i;
+//    for(i = 0; i < NumTuples/ 2; ++i) {
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    while (! iter.drained()) {
+//        ASSERT_TRUE(Gen::same(*iter++, i++));
+//    }
+//    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
+//}
+//
+//// Test that it should work with normal, compacting removals that only eats what had
+//// been iterated
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
+//        // expensive O(n) check (actually almost O(AllocsPerChunk))
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        try {
+//            alloc.remove(const_cast<void*>(addresses[i++]));
+//        } catch (range_error const&) {                         // OK bc. compaction
+//            continue;
+//        }
+//    }
+//}
+//
+//// Test that it should work with normal, compacting removals in
+//// opposite direction of the/any iterator
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+//    }
+//    while (! iter.drained()) {
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        ++iter;
+//        ++i;
+//    }
+////    ASSERT_EQ(NumTuples, i);
+//}
+//
+//// Test that it should work with lightweight, non-compacting removals that only eats
+//// what had been iterated
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples; ++i) {
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        // Removing from head, unless forced by calling again
+//        // with NULL next, would not have any effect except
+//        // removing crosses boundary. This means that we are
+//        // iterating over values that actually should *not* be
+//        // visible (i.e. garbage). But that is ok, since we are
+//        // not forcing it every time (in which case it becomes
+//        // normal, compacting removal).
+//        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
+//    }
+//    ASSERT_TRUE(iter.drained());
+//}
+//
+//// Test that it should work with lightweight, non-compacting removals from tail
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        // Removing from head, unless forced by calling again
+//        // with NULL next, would not have any effect except
+//        // removing crosses boundary. This means that we are
+//        // iterating over values that actually should *not* be
+//        // visible (i.e. garbage). But that is ok, since we are
+//        // not forcing it every time (in which case it becomes
+//        // normal, compacting removal).
+//        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
+//    }
+//    ASSERT_TRUE(iter.drained());
+//    ASSERT_EQ(NumTuples / 2, i);
+//}
+//
+//TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    // Remove last 10, making 1st chunk non-full
+//    for (i = 0; i < 10; ++i) {
+//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+//    }
+//    alloc.template freeze<truth>();
+//    i = 0;
+//    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
+//            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
+//                ASSERT_TRUE(end != find(beg, end, p) ||
+//                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
+//                ++i;
+//            });
+//    ASSERT_EQ(i, NumTuples - 10);
+//    alloc.thaw();
+//}
 
 #endif
 

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1308,9 +1308,9 @@ struct TestInterleavedCompactingChunks {
 TestInterleavedCompactingChunks1<EagerNonCompactingChunk> const TestInterleavedCompactingChunks::s1{};
 TestInterleavedCompactingChunks1<LazyNonCompactingChunk> const TestInterleavedCompactingChunks::s2{};
 
-//TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
-//    TestInterleavedCompactingChunks()();
-//}
+TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
+    TestInterleavedCompactingChunks()();
+}
 
 template<typename Chunk, gc_policy pol>
 void testSingleChunkSnapshot() {

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1412,7 +1412,6 @@ void testRemovesFromEnds(size_t batch) {
             alloc.thaw();
         }
     } else {                                                   // remove from tail
-        alloc.template freeze<truth>();
         for (i = NumTuples - 1; i >= NumTuples - batch && i < NumTuples; --i) {
             alloc.remove(dir, addresses[i]);
         }
@@ -1425,17 +1424,6 @@ void testRemovesFromEnds(size_t batch) {
                     return ++i >= NumTuples - batch;
                 });
         assert(i == NumTuples - batch);
-        i = 0;
-        fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
-                static_cast<Alloc const&>(alloc), [&i](void const* p) {
-                    assert(Gen::same(p, i++));
-                });
-        // NOTE: since these light-weight removes involves no
-        // compaction, what gets deleted (that would normaly move
-        // "1st" tuple to last, and in snapshot, the head chunk
-        // would be preserved) is now lost forever.
-        assert(i == NumTuples - batch);
-        alloc.thaw();
     }
 }
 
@@ -1631,7 +1619,7 @@ TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
     ASSERT_TRUE(iter.drained());
 }
 
- Test that it should work with lightweight, non-compacting removals from tail
+// Test that it should work with lightweight, non-compacting removals from tail
 TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
     using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
     using Gen = StringGen<TupleSize>;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -169,18 +169,18 @@ void testNonCompactingChunks(size_t outOfOrder) {
     assert(alloc.empty());                 // everything gone
 }
 
-//TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
-//    CompactingChunks alloc(TupleSize);
-//    array<void*, 3 * AllocsPerChunk> addresses;
-//    for(auto i = 0; i < addresses.size(); ++i) {
-//        addresses[i] = alloc.allocate();
-//    }
-//    for(auto i = 0; i < addresses.size(); ++i) {
-//        auto const* iter = alloc.find(addresses[i]);
-//        ASSERT_NE(iter, nullptr);
-//        ASSERT_TRUE((*iter)->contains(addresses[i]));
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
+    CompactingChunks alloc(TupleSize);
+    array<void*, 3 * AllocsPerChunk> addresses;
+    for(auto i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.allocate();
+    }
+    for(auto i = 0; i < addresses.size(); ++i) {
+        auto const* iter = alloc.find(addresses[i]);
+        ASSERT_NE(iter, nullptr);
+        ASSERT_TRUE((*iter)->contains(addresses[i]));
+    }
+}
 
 template<typename Chunks>
 void testIteratorOfNonCompactingChunks() {
@@ -263,17 +263,17 @@ void testIteratorOfNonCompactingChunks() {
             alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });*/
 }
 
-//TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
-//    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
-//        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
-//        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
+    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
+        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
+        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
+    }
+}
 
-//TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
-//    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
-//    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
-//}
+TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
+    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
+    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
+}
 
 void testCompactingChunks() {
     using Gen = StringGen<TupleSize>;
@@ -456,15 +456,15 @@ void testCustomizedIterator(size_t skipped) {      // iterator that skips on eve
     }
 }
 
-//TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
-//    testCompactingChunks();
-//    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
-//        testCustomizedIterator<CompactingChunks, 3>(skipped);
-//        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
-//        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
-//        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
+    testCompactingChunks();
+    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
+        testCustomizedIterator<CompactingChunks, 3>(skipped);
+        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
+        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
+        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
+    }
+}
 
 // expression template used to apply variadic NthBitChecker
 template<typename Tuple, size_t N> struct Apply {
@@ -712,9 +712,9 @@ struct TestTxnHook {
 TestTxnHook1<NonCompactingChunks<EagerNonCompactingChunk>> const TestTxnHook::sChain1{};
 TestTxnHook1<NonCompactingChunks<LazyNonCompactingChunk>> const TestTxnHook::sChain2{};
 
-//TEST_F(TableTupleAllocatorTest, TestTxnHook) {
-//    TestTxnHook()();
-//}
+TEST_F(TableTupleAllocatorTest, TestTxnHook) {
+    TestTxnHook()();
+}
 
 /**
  * Test of HookedCompactingChunks using its RW iterator that
@@ -1064,11 +1064,6 @@ void testHookedCompactingChunksBatchRemove_multi2() {
                 assert(p == nullptr || Gen::same(p, i++));
             });
         assert(i == NumTuples);
-        i = 0;
-        for_each<snapshot_iterator>(alloc, [&i](void const* p) {
-                assert(p == nullptr || Gen::same(p, i++));
-                });
-        assert(i == NumTuples);
     };
     alloc.template freeze<truth>();
 
@@ -1088,58 +1083,58 @@ void testHookedCompactingChunksBatchRemove_multi2() {
     alloc.thaw();
 }
 
-//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
-//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-//    using Alloc = HookedCompactingChunks<Hook>;
-//    using Gen = StringGen<TupleSize>;
-//    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
-//    Gen gen;
-//    Alloc alloc(TupleSize);
-//    addresses_type addresses;
-//    assert(alloc.empty());
-//    size_t i;
-//    for(i = 0; i < addresses.size(); ++i) {
-//        addresses[i] = alloc.allocate();
-//        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
-//    }
-//    set<void*> batch;
-//    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
-//        batch.emplace(const_cast<void*>(addresses[i]));
-//    }
-//    alloc.remove(batch, [](map<void*, void*> const&){});
-//    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
-//}
-//
-//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
-//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-//    using Alloc = HookedCompactingChunks<Hook>;
-//    auto constexpr N = AllocsPerChunk * 3 + 2;
-//    array<void const*, N> addresses;
-//    Alloc alloc(TupleSize);
-//    ASSERT_EQ(TupleSize, alloc.tupleSize());
-//    ASSERT_EQ(0, alloc.chunks());
-//    ASSERT_EQ(0, alloc.size());
-//    size_t i;
-//    for(i = 0; i < N; ++i) {
-//        addresses[i] = alloc.allocate();
-//    }
-//    ASSERT_EQ(4, alloc.chunks());
-//    ASSERT_EQ(N, alloc.size());
-//    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
-//    alloc.remove(const_cast<void*>(addresses[1]));
-//    ASSERT_EQ(4, alloc.chunks());
-//    ASSERT_EQ(N - 2, alloc.size());
-//    // batch remove last 30 entries, compacts/removes head chunk
-//    set<void*> s;
-//    for(i = 2; i < AllocsPerChunk; ++i) {
-//        s.emplace(const_cast<void*>(addresses[N - i + 1]));
-//    }
-//    alloc.remove(s, [](map<void*, void*> const&){});
-//    ASSERT_EQ(3, alloc.chunks());
-//    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
-//}
+TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
+    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    using Gen = StringGen<TupleSize>;
+    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
+    Gen gen;
+    Alloc alloc(TupleSize);
+    addresses_type addresses;
+    assert(alloc.empty());
+    size_t i;
+    for(i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.allocate();
+        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
+    }
+    set<void*> batch;
+    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
+        batch.emplace(const_cast<void*>(addresses[i]));
+    }
+    alloc.remove(batch, [](map<void*, void*> const&){});
+    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
+}
+
+TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
+    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    auto constexpr N = AllocsPerChunk * 3 + 2;
+    array<void const*, N> addresses;
+    Alloc alloc(TupleSize);
+    ASSERT_EQ(TupleSize, alloc.tupleSize());
+    ASSERT_EQ(0, alloc.chunks());
+    ASSERT_EQ(0, alloc.size());
+    size_t i;
+    for(i = 0; i < N; ++i) {
+        addresses[i] = alloc.allocate();
+    }
+    ASSERT_EQ(4, alloc.chunks());
+    ASSERT_EQ(N, alloc.size());
+    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
+    alloc.remove(const_cast<void*>(addresses[1]));
+    ASSERT_EQ(4, alloc.chunks());
+    ASSERT_EQ(N - 2, alloc.size());
+    // batch remove last 30 entries, compacts/removes head chunk
+    set<void*> s;
+    for(i = 2; i < AllocsPerChunk; ++i) {
+        s.emplace(const_cast<void*>(addresses[N - i + 1]));
+    }
+    alloc.remove(s, [](map<void*, void*> const&){});
+    ASSERT_EQ(3, alloc.chunks());
+    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
+}
 
 template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
     inline void operator()() const {
@@ -1379,9 +1374,9 @@ struct TestSingleChunkSnapshot {
 TestSingleChunkSnapshot1<EagerNonCompactingChunk> const TestSingleChunkSnapshot::s1{};
 TestSingleChunkSnapshot1<LazyNonCompactingChunk> const TestSingleChunkSnapshot::s2{};
 
-//TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
-//    TestSingleChunkSnapshot()();
-//}
+TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
+    TestSingleChunkSnapshot()();
+}
 
 template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 void testRemovesFromEnds(size_t batch) {
@@ -1490,205 +1485,205 @@ struct TestRemovesFromEnds {
     }
 };
 
-//TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
-//    TestRemovesFromEnds()();
-//}
-//
-//TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    void* addr = alloc.allocate();
-//    ASSERT_EQ(addr, alloc.remove(addr));
-//    // empty: reallocate
-//    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
-//    size_t i = 0;
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
-//                ASSERT_EQ(addr, p);
-//                ASSERT_TRUE(Gen::same(p, i++));
-//            });
-//    ASSERT_EQ(1, i);
-//}
-//
-//// Test that it should work without txn in progress
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    size_t i;
-//    for(i = 0; i < NumTuples; ++i) {
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    i = 0;
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
-//            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
-//                ASSERT_TRUE(Gen::same(p, i++));
-//            });
+TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
+    TestRemovesFromEnds()();
+}
+
+TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    void* addr = alloc.allocate();
+    ASSERT_EQ(addr, alloc.remove(addr));
+    // empty: reallocate
+    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
+    size_t i = 0;
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
+                ASSERT_EQ(addr, p);
+                ASSERT_TRUE(Gen::same(p, i++));
+            });
+    ASSERT_EQ(1, i);
+}
+
+// Test that it should work without txn in progress
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    size_t i;
+    for(i = 0; i < NumTuples; ++i) {
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    i = 0;
+    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
+            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
+                ASSERT_TRUE(Gen::same(p, i++));
+            });
+    ASSERT_EQ(NumTuples, i);
+}
+
+// Test that it should work with insertions
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    size_t i;
+    for(i = 0; i < NumTuples/ 2; ++i) {
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    while (! iter.drained()) {
+        ASSERT_TRUE(Gen::same(*iter++, i++));
+    }
+    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
+}
+
+// Test that it should work with normal, compacting removals that only eats what had
+// been iterated
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
+        // expensive O(n) check (actually almost O(AllocsPerChunk))
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        try {
+            alloc.remove(const_cast<void*>(addresses[i++]));
+        } catch (range_error const&) {                         // OK bc. compaction
+            continue;
+        }
+    }
+}
+
+// Test that it should work with normal, compacting removals in
+// opposite direction of the/any iterator
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+    }
+    while (! iter.drained()) {
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        ++iter;
+        ++i;
+    }
 //    ASSERT_EQ(NumTuples, i);
-//}
-//
-//// Test that it should work with insertions
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    size_t i;
-//    for(i = 0; i < NumTuples/ 2; ++i) {
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    while (! iter.drained()) {
-//        ASSERT_TRUE(Gen::same(*iter++, i++));
-//    }
-//    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
-//}
-//
-//// Test that it should work with normal, compacting removals that only eats what had
-//// been iterated
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
-//        // expensive O(n) check (actually almost O(AllocsPerChunk))
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        try {
-//            alloc.remove(const_cast<void*>(addresses[i++]));
-//        } catch (range_error const&) {                         // OK bc. compaction
-//            continue;
-//        }
-//    }
-//}
-//
-//// Test that it should work with normal, compacting removals in
-//// opposite direction of the/any iterator
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-//    }
-//    while (! iter.drained()) {
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        ++iter;
-//        ++i;
-//    }
-////    ASSERT_EQ(NumTuples, i);
-//}
-//
-//// Test that it should work with lightweight, non-compacting removals that only eats
-//// what had been iterated
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples; ++i) {
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        // Removing from head, unless forced by calling again
-//        // with NULL next, would not have any effect except
-//        // removing crosses boundary. This means that we are
-//        // iterating over values that actually should *not* be
-//        // visible (i.e. garbage). But that is ok, since we are
-//        // not forcing it every time (in which case it becomes
-//        // normal, compacting removal).
-//        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
-//    }
-//    ASSERT_TRUE(iter.drained());
-//}
-//
-//// Test that it should work with lightweight, non-compacting removals from tail
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        // Removing from head, unless forced by calling again
-//        // with NULL next, would not have any effect except
-//        // removing crosses boundary. This means that we are
-//        // iterating over values that actually should *not* be
-//        // visible (i.e. garbage). But that is ok, since we are
-//        // not forcing it every time (in which case it becomes
-//        // normal, compacting removal).
-//        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
-//    }
-//    ASSERT_TRUE(iter.drained());
-//    ASSERT_EQ(NumTuples / 2, i);
-//}
-//
-//TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    // Remove last 10, making 1st chunk non-full
-//    for (i = 0; i < 10; ++i) {
-//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-//    }
-//    alloc.template freeze<truth>();
-//    i = 0;
-//    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
-//            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
-//                ASSERT_TRUE(end != find(beg, end, p) ||
-//                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
-//                ++i;
-//            });
-//    ASSERT_EQ(i, NumTuples - 10);
-//    alloc.thaw();
-//}
+}
+
+// Test that it should work with lightweight, non-compacting removals that only eats
+// what had been iterated
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples; ++i) {
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        // Removing from head, unless forced by calling again
+        // with NULL next, would not have any effect except
+        // removing crosses boundary. This means that we are
+        // iterating over values that actually should *not* be
+        // visible (i.e. garbage). But that is ok, since we are
+        // not forcing it every time (in which case it becomes
+        // normal, compacting removal).
+        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
+    }
+    ASSERT_TRUE(iter.drained());
+}
+
+ Test that it should work with lightweight, non-compacting removals from tail
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        // Removing from head, unless forced by calling again
+        // with NULL next, would not have any effect except
+        // removing crosses boundary. This means that we are
+        // iterating over values that actually should *not* be
+        // visible (i.e. garbage). But that is ok, since we are
+        // not forcing it every time (in which case it becomes
+        // normal, compacting removal). TODO: memcheck
+        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
+    }
+    ASSERT_TRUE(iter.drained());
+    ASSERT_EQ(NumTuples / 2, i);
+}
+
+TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    // Remove last 10, making 1st chunk non-full
+    for (i = 0; i < 10; ++i) {
+        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+    }
+    alloc.template freeze<truth>();
+    i = 0;
+    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
+            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
+                ASSERT_TRUE(end != find(beg, end, p) ||
+                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
+                ++i;
+            });
+    ASSERT_EQ(i, NumTuples - 10);
+    alloc.thaw();
+}
 
 #endif
 


### PR DESCRIPTION
Fixed `eecheck` failure in VoltMini, in the progress of fixing `eecheck` memcheck failures; and enabled memcheck on the table tuple allocator. (And a few more changes to help future adoption to different set/map implementations).