### PR TITLE
Calcite. Hash Aggregate to Serial Aggregate optimization

### DIFF
--- a/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSerialAggregate.java
+++ b/src/frontend/org/voltdb/plannerv2/rel/physical/VoltPhysicalSerialAggregate.java
@@ -66,7 +66,7 @@ public class VoltPhysicalSerialAggregate extends VoltPhysicalAggregate {
             RelOptPlanner planner, RelMetadataQuery mq) {
         double rowCount =
                 PlanCostUtil.discountSerialAggregateRowCount(getInput().estimateRowCount(mq), getGroupCount());
-        return planner.getCostFactory().makeCost(rowCount, 0, 0);
+        return planner.getCostFactory().makeCost(rowCount, rowCount, 0);
     }
 
     @Override

--- a/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/PlannerRules.java
@@ -66,6 +66,7 @@ import org.voltdb.plannerv2.rules.physical.VoltPCalcRule;
 import org.voltdb.plannerv2.rules.physical.VoltPCalcScanToIndexRule;
 import org.voltdb.plannerv2.rules.physical.VoltPExchangeRule;
 import org.voltdb.plannerv2.rules.physical.VoltPExchangeTransposeRule;
+import org.voltdb.plannerv2.rules.physical.VoltPHashToSerialAggregateRule;
 import org.voltdb.plannerv2.rules.physical.VoltPJoinCommuteRule;
 import org.voltdb.plannerv2.rules.physical.VoltPJoinPushThroughJoinRule;
 import org.voltdb.plannerv2.rules.physical.VoltPJoinRule;
@@ -241,6 +242,12 @@ public class PlannerRules {
             VoltPNestLoopIndexToMergeJoinRule.INSTANCE_MJ_CALC_ISCAN,
             VoltPNestLoopIndexToMergeJoinRule.INSTANCE_CALC_MJ_ISCAN,
             VoltPNestLoopIndexToMergeJoinRule.INSTANCE_CALC_MJ_CALC_ISCAN,
+
+            // Aggregate Rules
+            VoltPHashToSerialAggregateRule.INSTANCE_AGGR_CALC_INDEX_SCAN,
+            VoltPHashToSerialAggregateRule.INSTANCE_AGGR_INDEX_SCAN,
+            VoltPHashToSerialAggregateRule.INSTANCE_AGGR_CALC_SEQ_SCAN,
+            VoltPHashToSerialAggregateRule.INSTANCE_AGGR_SEQ_SCAN,
 
             // Exchange Transpose Rules
             VoltPExchangeTransposeRule.INSTANCE_LIMIT_EXCHANGE,

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPAggregateRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPAggregateRule.java
@@ -17,33 +17,19 @@
 
 package org.voltdb.plannerv2.rules.physical;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollationTraitDef;
-import org.apache.calcite.rel.RelCollations;
-import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.util.ImmutableBitSet;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalAggregate;
 import org.voltdb.plannerv2.rel.logical.VoltLogicalRel;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalHashAggregate;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalRel;
 import org.voltdb.plannerv2.rel.physical.VoltPhysicalSerialAggregate;
-import org.voltdb.plannerv2.rel.physical.VoltPhysicalSort;
-
-import com.google.common.collect.ImmutableMap;
-import com.google_voltpatches.common.base.Preconditions;
 
 
 /**
  * VoltDB physical rule that transform {@link VoltLogicalAggregate} to {@link VoltPhysicalHashAggregate}
- * or {@link VoltPhysicalSerialAggregate}.
  *
  * @author Michael Alexeev
  * @since 9.0
@@ -65,71 +51,19 @@ public class VoltPAggregateRule extends RelOptRule {
         RelTraitSet convertedInputTraits = input.getTraitSet().replace(VoltPhysicalRel.CONVENTION).simplify();
         final RelNode convertedInput = convert(input, convertedInputTraits);
 
-        if (needHashAggregator(aggregate)) {
-            // Transform to a physical Hash Aggregate
+        if (aggregate.getGroupSet().isEmpty()) {
+            // GROUP BY is empty - Serial Aggregate
+            call.transformTo(new VoltPhysicalSerialAggregate(
+                    aggregate.getCluster(), convertedAggrTraits, convertedInput, aggregate.indicator,
+                    aggregate.getGroupSet(), aggregate.getGroupSets(), aggregate.getAggCallList(), null,
+                    false));
+        } else {
+            // Transform to a physical Hash Aggregate.
             call.transformTo(new VoltPhysicalHashAggregate(
                     aggregate.getCluster(), convertedAggrTraits, convertedInput, aggregate.indicator,
                     aggregate.getGroupSet(), aggregate.getGroupSets(), aggregate.getAggCallList(), null,
                     false));
-            // We can't early return here, cause
-            // hash aggregation are replaced with serial aggregation in large query
         }
-
-        // Transform to a physical Serial Aggregate. To enforce a required ordering add a collation
-        // that matches the aggreagte's GROUP BY columns (for now) to the aggregate's input.
-        // Calcite will create a sort relation out of it.
-        // The aggregate's output would also be effectively sorted by the same GROUP BY columns
-        // (either because of an existing index or a Sort relation added by Calcite)
-        if (hasGroupBy(aggregate)) {
-            final RelCollation groupByCollation = buildGroupByCollation(aggregate);
-            convertedInputTraits = convertedInputTraits.plus(groupByCollation);
-            convertedAggrTraits = convertedAggrTraits.plus(groupByCollation);
-        }
-        final RelNode serialAggr = new VoltPhysicalSerialAggregate(
-                aggregate.getCluster(), convertedAggrTraits, convert(input, convertedInputTraits), aggregate.indicator,
-                aggregate.getGroupSet(), aggregate.getGroupSets(), aggregate.getAggCallList(), null,
-                false);
-        // The fact that the convertedAggrTraits does have non-empty collation would force Calcite to create
-        // a Sort relation on top of the aggregate. We can add the sort ourselves and also declare
-        // that both (a new sort and the serial aggregate) relations are equivalent to the original
-        // logical aggregate. This way Calcite will later eliminate the added sort because it would have
-        // higher processing cost
-        if (hasGroupBy(aggregate)) {
-            final VoltPhysicalSort sort = new VoltPhysicalSort(
-                    aggregate.getCluster(), convertedAggrTraits, serialAggr,
-                    convertedAggrTraits.getTrait(RelCollationTraitDef.INSTANCE), false);
-            call.transformTo(sort, ImmutableMap.of(serialAggr, aggregate));
-        } else {
-            call.transformTo(serialAggr);
-        }
-
     }
 
-    RelCollation buildGroupByCollation(VoltLogicalAggregate aggr) {
-        // Build a collation that represents each GROUP BY expression.
-        // This collation implies that this serial aggregate requires its input
-        // to be sorted in an order that is one of permutations of the fields from this collation
-        ImmutableBitSet groupBy = aggr.getGroupSet();
-        List<RelDataTypeField> rowTypeList = aggr.getRowType().getFieldList();
-        List<RelFieldCollation> collationFields = new ArrayList<>();
-        for (int index = groupBy.nextSetBit(0); index != -1;
-             index = groupBy.nextSetBit(index + 1)) {
-            Preconditions.checkState(index < rowTypeList.size());
-            collationFields.add(new RelFieldCollation(index));
-        }
-        return RelCollations.of(collationFields.toArray(new RelFieldCollation[collationFields.size()]));
-    }
-
-    private boolean needHashAggregator(VoltLogicalAggregate aggr) {
-        // A hash is required to build up per-group aggregates in parallel vs.
-        // when there is only one aggregation over the entire table
-
-        // TODO: should be `! isLargeQueryMode() && hasGroupBy(aggr);`
-        // update when we have introduce large query mode in calcite.
-        return hasGroupBy(aggr);
-    }
-
-    private boolean hasGroupBy(VoltLogicalAggregate aggr) {
-        return !aggr.getGroupSet().isEmpty();
-    }
 }

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPHashToSerialAggregateRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPHashToSerialAggregateRule.java
@@ -1,0 +1,286 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.plannerv2.rules.physical;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.json_voltpatches.JSONException;
+import org.voltdb.catalog.Index;
+import org.voltdb.catalog.Table;
+import org.voltdb.planner.AccessPath;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalCalc;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalHashAggregate;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalSerialAggregate;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalTableIndexScan;
+import org.voltdb.plannerv2.rel.physical.VoltPhysicalTableSequentialScan;
+import org.voltdb.plannerv2.utils.VoltRexUtil;
+import org.voltdb.types.IndexLookupType;
+import org.voltdb.types.SortDirectionType;
+
+import com.google_voltpatches.common.base.Preconditions;
+
+
+/**
+ * VoltDB physical rule that transform {@link VoltPhysicalHashAggregate} to {@link VoltPhysicalSerialAggregate}
+ *   VoltPhysicalHashAggregate                        to VoltPhysicalSerialAggregate
+ *     (VoltPhysicalCacl) VoltPhysicalTableIndexScan       (VoltPhysicalCacl) VoltPhysicalTableIndexScan
+ *
+ *   VoltPhysicalHashAggregate                               to VoltPhysicalSerialAggregate
+ *     (VoltPhysicalCacl) VoltPhysicalTableSequentialScan         (VoltPhysicalCacl) VoltPhysicalTableIndexScan
+ *
+ * Given a table T with indexes (A, B),  (A, B, C), (A, C, B) and (C, A, B) and a query
+ *  select max(B), a, b from T group by b ,a;
+ *
+ * The first index (A,B) would provide a right ordering for the SerialAggregate -
+ *      GROUP BY columns (B,A) match the all index columns
+ * The second index (A, B, C) also works because ORDER BY columns again match the first two index columns
+ * The (A, C, B) index won't because the GROUP BY columns B and A
+ *      match the first and the third index columns
+ * The (C, A, B) index is also in-eligible because the first index column is not part of the CROUP BY columns.
+ *
+ * @author Michael Alexeev
+ * @since 9.0
+ */
+public class VoltPHashToSerialAggregateRule extends RelOptRule {
+
+    enum AggrMatchType {
+        AGGR_INDEX_SCAN,
+        AGGR_CALC_INDEX_SCAN,
+        AGGR_SEQ_SCAN,
+        AGGR_CALC_SEQ_SCAN
+    }
+    /**
+     * Predicate to stop LIMIT_EXCHANGE to match on LIMIT / EXCHANGE / LIMIT
+    */
+    private static final Predicate<VoltPhysicalHashAggregate> HAS_GROUP_BY_PREDICATE = aggr -> !aggr.getGroupSet().isEmpty();
+
+    public static final VoltPHashToSerialAggregateRule INSTANCE_AGGR_INDEX_SCAN =
+            new VoltPHashToSerialAggregateRule(
+                    operandJ(VoltPhysicalHashAggregate.class, null, HAS_GROUP_BY_PREDICATE,
+                            operand(VoltPhysicalTableIndexScan.class, none())),
+                    AggrMatchType.AGGR_INDEX_SCAN);
+
+    public static final VoltPHashToSerialAggregateRule INSTANCE_AGGR_CALC_INDEX_SCAN =
+            new VoltPHashToSerialAggregateRule(
+                    operandJ(VoltPhysicalHashAggregate.class, null, HAS_GROUP_BY_PREDICATE,
+                            operand(VoltPhysicalCalc.class,
+                                    operand(VoltPhysicalTableIndexScan.class, none()))),
+                    AggrMatchType.AGGR_CALC_INDEX_SCAN);
+
+    public static final VoltPHashToSerialAggregateRule INSTANCE_AGGR_SEQ_SCAN =
+            new VoltPHashToSerialAggregateRule(
+                    operandJ(VoltPhysicalHashAggregate.class, null, HAS_GROUP_BY_PREDICATE,
+                            operand(VoltPhysicalTableSequentialScan.class, none())),
+                    AggrMatchType.AGGR_SEQ_SCAN);
+
+    public static final VoltPHashToSerialAggregateRule INSTANCE_AGGR_CALC_SEQ_SCAN =
+            new VoltPHashToSerialAggregateRule(
+                    operandJ(VoltPhysicalHashAggregate.class, null, HAS_GROUP_BY_PREDICATE,
+                            operand(VoltPhysicalCalc.class,
+                                    operand(VoltPhysicalTableSequentialScan.class, none()))),
+                    AggrMatchType.AGGR_CALC_SEQ_SCAN);
+
+    private final AggrMatchType maggrMatchType;
+
+    private VoltPHashToSerialAggregateRule(RelOptRuleOperand operand, AggrMatchType aggrMatchType) {
+        super(operand, aggrMatchType.toString());
+        maggrMatchType = aggrMatchType;
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        switch (maggrMatchType) {
+        case AGGR_INDEX_SCAN:
+        case AGGR_CALC_INDEX_SCAN:
+            aggrIndexScan(call);
+            break;
+        case AGGR_SEQ_SCAN:
+        case AGGR_CALC_SEQ_SCAN:
+            aggrSeqScan(call);
+            break;
+            }
+    }
+
+    private void aggrIndexScan(RelOptRuleCall call) {
+        final VoltPhysicalHashAggregate hashAggregate = call.rel(0);
+        final VoltPhysicalTableIndexScan scan;
+        final VoltPhysicalCalc calc;
+        final RelNode aggregateInput;
+        final RelCollation adjustedIndexCollation;
+        if (maggrMatchType == AggrMatchType.AGGR_INDEX_SCAN) {
+            scan = call.rel(1);
+            calc = null;
+            aggregateInput = scan;
+            adjustedIndexCollation = scan.getIndexCollation();
+        } else {
+            scan = call.rel(2);
+            calc = call.rel(1);
+            aggregateInput = calc;
+            adjustedIndexCollation = VoltRexUtil.adjustCollationForProgram(
+                    calc.getCluster().getRexBuilder(), calc.getProgram(), scan.getIndexCollation());
+        }
+
+        final ImmutableBitSet groupBy = hashAggregate.getGroupSet();
+        if (!collationMatchesGroupBy(adjustedIndexCollation, groupBy)) {
+            return;
+        }
+
+        final RelNode serialAggregate = new VoltPhysicalSerialAggregate(
+                hashAggregate.getCluster(),
+                hashAggregate.getTraitSet(),
+                aggregateInput,
+                hashAggregate.indicator,
+                hashAggregate.getGroupSet(),
+                hashAggregate.getGroupSets(),hashAggregate.getAggCallList(),
+                null,
+                false);
+        call.transformTo(serialAggregate);
+    }
+
+    /**
+     * A Collation matches a set of GROUP BY columns if it covers all GROUP BY columns
+     * starting from collations index 0 without gaps.
+     *
+     * @param collation
+     * @param groupBy
+     * @return
+     */
+    private boolean collationMatchesGroupBy(RelCollation collation, ImmutableBitSet groupBy) {
+        List<RelFieldCollation> collationFields = collation.getFieldCollations();
+        int[] targets = new int[collationFields.size()];
+        Arrays.fill(targets, -1);
+
+        for(int groupByIdx : groupBy.asList()) {
+            RelFieldCollation collationField = new RelFieldCollation(groupByIdx);
+            int index = collationFields.indexOf(collationField);
+            if (index == -1) {
+                // Group By filed is not part of the index
+                return false;
+            }
+            targets[index] = 0;
+        }
+        // All GROUP BY fields are covered by index's ones
+        Preconditions.checkState(groupBy.asList().size() <= targets.length);
+        int firstMiss = Arrays.asList(targets).indexOf(-1);
+        return firstMiss == -1 || firstMiss > groupBy.size();
+    }
+
+    private RelCollation buildGroupByCollation(VoltPhysicalHashAggregate aggr) {
+        // Build a collation that represents each GROUP BY expression.
+        // This collation implies that this serial aggregate requires its input
+        // to be sorted in an order that is one of permutations of the fields from this collation
+        ImmutableBitSet groupBy = aggr.getGroupSet();
+        List<RelDataTypeField> rowTypeList = aggr.getRowType().getFieldList();
+        List<RelFieldCollation> collationFields = new ArrayList<>();
+        for (int index = groupBy.nextSetBit(0); index != -1;
+             index = groupBy.nextSetBit(index + 1)) {
+            Preconditions.checkState(index < rowTypeList.size());
+            collationFields.add(new RelFieldCollation(index));
+        }
+        return RelCollations.of(collationFields.toArray(new RelFieldCollation[collationFields.size()]));
+    }
+
+    private void aggrSeqScan(RelOptRuleCall call) {
+        final VoltPhysicalHashAggregate hashAggregate = call.rel(0);
+        final ImmutableBitSet groupBy = hashAggregate.getGroupSet();
+        final VoltPhysicalTableSequentialScan scan;
+        final VoltPhysicalCalc calc;
+        if (maggrMatchType == AggrMatchType.AGGR_SEQ_SCAN) {
+            scan = call.rel(1);
+            calc = null;
+        } else {
+            scan = call.rel(2);
+            calc = call.rel(1);
+        }
+
+        RelNode equivRel = null;
+        final Map<RelNode, RelNode> equivMap = new HashMap<>();
+
+        final Table catTable = scan.getVoltTable().getCatalogTable();
+        for (Index index : catTable.getIndexes()) {
+            RelCollation indexCollation = null;
+            try {
+                indexCollation = VoltRexUtil.createIndexCollation(index,
+                        catTable,
+                        scan.getCluster().getRexBuilder(),
+                        scan.getProgram());
+            } catch (JSONException ignored) { }
+            Preconditions.checkNotNull(indexCollation);
+            // Adjust index collation for a possible cacl
+            if (calc != null) {
+                indexCollation = VoltRexUtil.adjustCollationForProgram(
+                        calc.getCluster().getRexBuilder(), calc.getProgram(), indexCollation);
+            }
+            if (collationMatchesGroupBy(indexCollation, groupBy)) {
+                final AccessPath accessPath = new AccessPath(
+                        index,
+                        // With no index expression, the lookup type will be ignored and
+                        // the sort direction will determine the scan direction;
+                        IndexLookupType.EQ, SortDirectionType.INVALID, false);
+                final RelNode indexScan = new VoltPhysicalTableIndexScan(
+                        scan.getCluster(),
+                        scan.getTraitSet(),
+                        scan.getTable(), scan.getVoltTable(), scan.getProgram(),
+                        index, accessPath, scan.getLimitRexNode(), scan.getOffsetRexNode(),
+                        scan.getAggregateRelNode(),
+                        scan.getPreAggregateRowType(),
+                        scan.getPreAggregateProgram(),
+                        indexCollation,
+                        false);
+                final RelNode aggregateInput;
+                if (calc == null) {
+                    aggregateInput = indexScan;
+                } else {
+                    aggregateInput = calc.copy(calc.getTraitSet(), indexScan, calc.getProgram());
+                }
+                final RelNode serialAggregate = new VoltPhysicalSerialAggregate(
+                        hashAggregate.getCluster(),
+                        hashAggregate.getTraitSet(),
+                        aggregateInput,
+                        hashAggregate.indicator,
+                        hashAggregate.getGroupSet(),
+                        hashAggregate.getGroupSets(),hashAggregate.getAggCallList(),
+                        null,
+                        false);
+                if (equivRel == null) {
+                    equivRel = serialAggregate;
+                } else {
+                    equivMap.put(serialAggregate, hashAggregate);
+                }
+            }
+        }
+        if (equivRel != null) {
+            call.transformTo(equivRel, equivMap);
+        }
+    }
+
+}

--- a/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPHashToSerialAggregateRule.java
+++ b/src/frontend/org/voltdb/plannerv2/rules/physical/VoltPHashToSerialAggregateRule.java
@@ -17,7 +17,6 @@
 
 package org.voltdb.plannerv2.rules.physical;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -28,10 +27,8 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.json_voltpatches.JSONException;
 import org.voltdb.catalog.Index;
@@ -192,21 +189,6 @@ public class VoltPHashToSerialAggregateRule extends RelOptRule {
         Preconditions.checkState(groupBy.asList().size() <= targets.length);
         int firstMiss = Arrays.asList(targets).indexOf(-1);
         return firstMiss == -1 || firstMiss > groupBy.size();
-    }
-
-    private RelCollation buildGroupByCollation(VoltPhysicalHashAggregate aggr) {
-        // Build a collation that represents each GROUP BY expression.
-        // This collation implies that this serial aggregate requires its input
-        // to be sorted in an order that is one of permutations of the fields from this collation
-        ImmutableBitSet groupBy = aggr.getGroupSet();
-        List<RelDataTypeField> rowTypeList = aggr.getRowType().getFieldList();
-        List<RelFieldCollation> collationFields = new ArrayList<>();
-        for (int index = groupBy.nextSetBit(0); index != -1;
-             index = groupBy.nextSetBit(index + 1)) {
-            Preconditions.checkState(index < rowTypeList.size());
-            collationFields.add(new RelFieldCollation(index));
-        }
-        return RelCollations.of(collationFields.toArray(new RelFieldCollation[collationFields.size()]));
     }
 
     private void aggrSeqScan(RelOptRuleCall call) {

--- a/tests/frontend/org/voltdb/plannerv2/TestPhysicalAggregate.java
+++ b/tests/frontend/org/voltdb/plannerv2/TestPhysicalAggregate.java
@@ -1,0 +1,128 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2020 VoltDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.voltdb.plannerv2;
+
+import org.voltdb.plannerv2.rules.PlannerRules;
+
+public class TestPhysicalAggregate extends Plannerv2TestCase {
+
+    private PhysicalConversionRulesTester m_tester = new PhysicalConversionRulesTester();
+
+    @Override
+    protected void setUp() throws Exception {
+        setupSchema(TestValidation.class.getResource(
+                "testcalcite-ddl.sql"), "testcalcite", false);
+        init();
+        m_tester.phase(PlannerRules.Phase.PHYSICAL_CONVERSION);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    // Single GROUB BY column I  matches index (I)
+    public void testSerailAggreagteNoGroupBy() {
+        m_tester.sql("SELECT avg(R1.si) FROM R1 ")
+                .transform("VoltPhysicalSerialAggregate(group=[{}], EXPR$0=[AVG($0)], coordinator=[false], type=[serial])\n" +
+                        "  VoltPhysicalCalc(expr#0..5=[{inputs}], SI=[$t1])\n" +
+                        "    VoltPhysicalTableSequentialScan(table=[[public, R1]], expr#0..5=[{inputs}], proj#0..5=[{exprs}])\n"
+                )
+                .pass();
+    }
+
+    // Single GROUB BY column I  matches index (I)
+    public void testSerailAggreagteWithSeqScan1() {
+        m_tester.sql("SELECT max(RI1.si), i FROM RI1 group by I")
+                .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], I=[$t0])\n" +
+                        "  VoltPhysicalSerialAggregate(group=[{0}], EXPR$0=[MAX($1)], coordinator=[false], type=[serial])\n" +
+                        "    VoltPhysicalCalc(expr#0..3=[{inputs}], proj#0..1=[{exprs}])\n" +
+                        "      VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], proj#0..3=[{exprs}], index=[VOLTDB_AUTOGEN_IDX_PK_RI1_I_INVALIDEQ0_0])\n"
+                )
+                .pass();
+    }
+
+    // HASH aggregate with IndexScan(I) wins over Serial Aggregate with IndexScan(BI, SI)??
+    public void testSerailAggreagteWithSeqScan2() {
+        m_tester.sql("SELECT max(RI1.si) FROM RI1 where I > 0 group by BI, SI")
+                .transform("VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1}], EXPR$0=[MAX($1)], coordinator=[false], type=[hash])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t0, $t4)], BI=[$t2], SI=[$t1], $condition=[$t5], index=[VOLTDB_AUTOGEN_IDX_PK_RI1_I_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+    // Single GROUB BY column I  matches index (I)
+    public void testSerailAggreagteWithIndexScan1() {
+        m_tester.sql("SELECT max(RI1.si), i FROM RI1 where I > 0 group by I")
+                .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1], I=[$t0])\n" +
+                        "  VoltPhysicalSerialAggregate(group=[{0}], EXPR$0=[MAX($1)], coordinator=[false], type=[serial])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t0, $t4)], proj#0..1=[{exprs}], $condition=[$t5], index=[VOLTDB_AUTOGEN_IDX_PK_RI1_I_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+    // GROUB BY columns (SI, BI) match index (BI, SI)
+    public void testSerailAggreagteWithIndexScan2() {
+        m_tester.sql("SELECT max(RI1.si) FROM RI1 where BI > 0 and SI > 0 group by SI, BI")
+                .transform("VoltPhysicalCalc(expr#0..2=[{inputs}], EXPR$0=[$t2])\n" +
+                        "  VoltPhysicalSerialAggregate(group=[{0, 1}], EXPR$0=[MAX($0)], coordinator=[false], type=[serial])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t2, $t4)], expr#6=[>($t1, $t4)], expr#7=[AND($t5, $t6)], SI=[$t1], BI=[$t2], $condition=[$t7], index=[RI1_IND2_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+    // GROUB BY column (SI) does not match index (BI, SI) -
+    // The first index column BI is not part of GROUP BY columns
+    public void testHashAggreagteWithIndexScan3() {
+        m_tester.sql("SELECT max(RI1.si) FROM RI1 where BI > 0 and SI > 0 group by SI")
+                .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0}], EXPR$0=[MAX($0)], coordinator=[false], type=[hash])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t2, $t4)], expr#6=[>($t1, $t4)], expr#7=[AND($t5, $t6)], SI=[$t1], $condition=[$t7], index=[RI1_IND2_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+    // GROUB BY columns (BI) matches index (BI, SI) -
+    public void testSerialAggreagteWithIndexScan4() {
+        m_tester.sql("SELECT max(RI1.si) FROM RI1 where BI > 0 and SI > 0 group by BI")
+                .transform("VoltPhysicalCalc(expr#0..1=[{inputs}], EXPR$0=[$t1])\n" +
+                        "  VoltPhysicalSerialAggregate(group=[{0}], EXPR$0=[MAX($1)], coordinator=[false], type=[serial])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t2, $t4)], expr#6=[>($t1, $t4)], expr#7=[AND($t5, $t6)], BI=[$t2], SI=[$t1], $condition=[$t7], index=[RI1_IND2_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+    // GROUB BY columns (SI, BI, I) does not match index (BI, SI) -
+    // Column I is not part of the (BI, SI) index
+    public void testHashAggreagteWithIndexScan5() {
+        m_tester.sql("SELECT max(RI1.si) FROM RI1 where BI > 0 and SI > 0 group by SI, BI, I")
+                .transform("VoltPhysicalCalc(expr#0..3=[{inputs}], EXPR$0=[$t3])\n" +
+                        "  VoltPhysicalHashAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($0)], coordinator=[false], type=[hash])\n" +
+                        "    VoltPhysicalTableIndexScan(table=[[public, RI1]], expr#0..3=[{inputs}], expr#4=[0], expr#5=[>($t2, $t4)], expr#6=[>($t1, $t4)], expr#7=[AND($t5, $t6)], SI=[$t1], BI=[$t2], I=[$t0], $condition=[$t7], index=[RI1_IND2_INVALIDGT1_0])\n"
+                )
+                .pass();
+    }
+
+}


### PR DESCRIPTION
Convert a Hash Aggregate to a Serial one if there is an index which collation matches a set of GROUP BY columns if it covers all GROUP BY columns starting from collations index 0 without gaps.

 Given a table T with indexes (A, B),  (A, B, C), (A, C, B) and (C, A, B) and a query
      select max(B), a, b from T group by b ,a;
 The first index (A,B) would provide a right ordering for the SerialAggregate -
       GROUP BY columns (B,A) match the all index columns
 The second index (A, B, C) also works because ORDER BY columns again match the first two index columns
 The (A, C, B) index won't because the GROUP BY columns B and A  match the first and the third index columns
 The (C, A, B) index is also in-eligible because the first index column is not part of the CROUP BY columns.
