### PR TITLE
SystemProcedureCatalog: Readonly transactions cannot be durable

### DIFF
--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -118,6 +118,7 @@ public class SystemProcedureCatalog {
                 throw new IllegalArgumentException("RO not supported for MP transactions");
             }
             readOnly = true;
+            durable = Durability.NOT_APPLICABLE;
             return this;
         }
 
@@ -230,7 +231,7 @@ public class SystemProcedureCatalog {
         }
 
         public boolean isDurable() {
-            return durable == Durability.DURABLE;
+            return !readOnly && durable == Durability.DURABLE;
         }
 
         public boolean isRestartable() {


### PR DESCRIPTION
Readonly tranasacations do not modify any data and durability is only
for transactions which modify data. It is impossible to have a
readonly transaction which requires durability so make them mutually
exclusive.