### PR TITLE
Eng 17214 app legacycompile4

### DIFF
--- a/tests/test_apps/matviewbenchmark/run.sh
+++ b/tests/test_apps/matviewbenchmark/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 APPNAME="matviewbenchmark"
+APPNAME2="-streamview"
 
 DDL=ddl.sql
 STREAMVIEW="false"
@@ -42,60 +43,51 @@ HOST="localhost"
 
 # remove build artifacts
 function clean() {
-    rm -rf obj debugoutput $APPNAME.jar $APPNAME-streamview.jar voltdbroot statement-plans catalog-report.html log
+    rm -rf obj debugoutput ${APPNAME}*.jar voltdbroot statement-plans catalog-report.html log
 }
 
+# compile the source code for the client
 function jars() {
-    ant all
+    mkdir -p obj
+    # compile java source
+    javac -classpath $APPCLASSPATH -d obj \
+        src/${APPNAME}/*.java
+    # stop if compilation fails
+    if [ $? != 0 ]; then exit 1; fi
+    # build the jar file
+    jar cf ${APPNAME}.jar -C obj ${APPNAME}
+    if [ $? != 0 ]; then exit 2; fi
+    # remove compiled .class files
+    rm -rf obj
 }
 
 # compile the source code for procedures and the client
-function srccompile() {
-    mkdir -p obj
-    javac -classpath $APPCLASSPATH -d obj \
-        src/matviewbenchmark/*.java
-    # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
+function jars-ifneeded() {
+    if [ ! -e ${APPNAME}.jar ]; then
+        jars
+    fi
 }
-
-# build an application catalog
-function catalog() {
-    srccompile
-    echo "Compiling the kvbenchmark application catalog."
-    echo "To perform this action manually, use the command line: "
-    echo
-    echo "voltdb legacycompile --classpath obj -o $APPNAME.jar ddl.sql"
-    echo
-    $VOLTDB legacycompile --classpath obj -o $APPNAME.jar ddl.sql
-    echo "voltdb legacycompile --classpath obj -o $APPNAME-streamview.jar ddl-streamview.sql"
-    echo
-    $VOLTDB legacycompile --classpath obj -o $APPNAME-streamview.jar ddl-streamview.sql
-
-    # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
-}
-
-# run the voltdb server locally
-function streamview() {
-    export APPNAME="$APPNAME-streamview"
-    STREAMVIEW="true"
-    server
-}
-
 
 # run the voltdb server locally
 function server() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
+    jars-ifneeded
     # truncate the voltdb log
-    [[ -d log && -w log ]] && > log/volt.log
+    [[ -d voltdbroot/log && -w voltdbroot/log ]] && > voltdbroot/log/volt.log
     # run the server
     echo "Starting the VoltDB server."
     echo "To perform this action manually, use the command line: "
     echo
-    echo "${VOLTDB} create -d deployment.xml -l ${LICENSE} -H ${HOST} ${APPNAME}$1.jar"
+    echo "${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl$1.sql --force"
+    echo "${VOLTDB} start -l ${LICENSE} -H ${HOST}"
     echo
-    ${VOLTDB} create -d deployment.xml -l ${LICENSE} -H ${HOST} ${APPNAME}$1.jar
+    ${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl$1.sql --force
+    ${VOLTDB} start -l ${LICENSE} -H ${HOST}
+}
+
+# run the voltdb server locally
+function streamview() {
+    STREAMVIEW="true"
+    server ${APPNAME2}
 }
 
 # run the client that drives the example
@@ -110,13 +102,13 @@ function streamview-client() {
 # Multi-threaded synchronous benchmark sample
 # Use this target for argument help
 function matviewbenchmark-help() {
-    srccompile
-    java -classpath obj:$APPCLASSPATH:obj matviewbenchmark.MaterializedViewBenchmark --help
+    jars-ifneeded
+    java -classpath ${APPCLASSPATH}:${APPNAME}.jar matviewbenchmark.MaterializedViewBenchmark --help
 }
 
 function matviewbenchmark() {
-    srccompile
-    java -classpath obj:$APPCLASSPATH:obj -Dlog4j.configuration=file://$LOG4J \
+    jars-ifneeded
+    java -classpath ${APPCLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$LOG4J \
         matviewbenchmark.MaterializedViewBenchmark \
         --displayinterval=5 \
         --servers=localhost \
@@ -128,7 +120,7 @@ function matviewbenchmark() {
 }
 
 function help() {
-    echo "Usage: ./run.sh {clean|srccompile|catalog|server|client|matviewbenchmark|matviewbenchmark-help}"
+    echo "Usage: ./run.sh {clean|jars[-ifneeded]|server|streamview|client|streamview-client|matviewbenchmark|matviewbenchmark-help}"
 }
 
 # Run the target passed as the first arg on the command line

--- a/tests/test_apps/oneshotkv/run.sh
+++ b/tests/test_apps/oneshotkv/run.sh
@@ -83,7 +83,7 @@ function client() {
 }
 
 function oneshot-benchmark() {
-    srccompile
+    jars-ifneeded
     java -classpath ${APPCLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$LOG4J \
         oneshotkv.OneShotBenchmark \
         --displayinterval=5 \

--- a/tests/test_apps/oneshotkv/run.sh
+++ b/tests/test_apps/oneshotkv/run.sh
@@ -35,38 +35,56 @@ HOST="localhost"
 
 # remove build artifacts
 function clean() {
-    rm -rf obj debugoutput $APPNAME.jar voltdbroot voltdbroot
+    rm -rf obj debugoutput ${APPNAME}.jar voltdbroot log
 }
 
-# compile the source code for procedures and the client
-function srccompile() {
+# compile the source code for procedures and the client into jarfiles
+function jars() {
     mkdir -p obj
+    # compile java source
     javac -classpath $APPCLASSPATH -d obj \
-        src/oneshotkv/*.java \
-        src/oneshotkv/procedures/*.java
+        src/${APPNAME}/*.java \
+        src/${APPNAME}/procedures/*.java
     # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
+    if [ $? != 0 ]; then exit 1; fi
+    # build the jar file
+    jar cf ${APPNAME}.jar -C obj ${APPNAME}
+    if [ $? != 0 ]; then exit 2; fi
+    # remove compiled .class files
+    rm -rf obj
 }
 
-# build an application catalog
-function catalog() {
-    srccompile
-    $VOLTDB legacycompile --classpath obj -o $APPNAME.jar ddl.sql
-    # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
+# compile the jar file, if it doesn't exist
+function jars-ifneeded() {
+    if [ ! -e ${APPNAME}.jar ]; then
+        jars;
+    fi
 }
 
 # run the voltdb server locally
 function server() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
+    jars-ifneeded
+    # truncate the voltdb log
+    [[ -d voltdbroot/log && -w voltdbroot/log ]] && > voltdbroot/log/volt.log
     # run the server
-    $VOLTDB create -d deployment.xml -l $LICENSE -H $HOST $APPNAME.jar
+    echo "Starting the VoltDB server."
+    echo "To perform this action manually, use the command line: "
+    echo
+    echo "${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl.sql --force"
+    echo "${VOLTDB} start -l ${LICENSE} -H ${HOST}"
+    echo
+    ${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl.sql --force
+    ${VOLTDB} start -l ${LICENSE} -H ${HOST}
+}
+
+# run the client that drives the example
+function client() {
+    oneshot-benchmark
 }
 
 function oneshot-benchmark() {
     srccompile
-    java -classpath obj:$APPCLASSPATH:obj -Dlog4j.configuration=file://$LOG4J \
+    java -classpath ${APPCLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$LOG4J \
         oneshotkv.OneShotBenchmark \
         --displayinterval=5 \
         --duration=60 \
@@ -82,9 +100,8 @@ function oneshot-benchmark() {
         --mpthreads=2
 }
 
-
 function help() {
-    echo "Usage: ./run.sh {clean|catalog|server|oneshot-benchmark|...}"
+    echo "Usage: ./run.sh {clean|jars[-ifneeded]|server|client|oneshot-benchmark|...}"
 }
 
 # Run the target passed as the first arg on the command line

--- a/tests/test_apps/scans/run.sh
+++ b/tests/test_apps/scans/run.sh
@@ -32,33 +32,46 @@ HOST="localhost"
 
 # remove build artifacts
 function clean() {
-    rm -rf obj debugoutput $APPNAME.jar voltdbroot voltdbroot
+    rm -rf obj debugoutput ${APPNAME}.jar voltdbroot log
 }
 
-# compile the source code for procedures and the client
-function srccompile() {
+# compile the source code for procedures and the client into jarfiles
+function jars() {
     mkdir -p obj
+    # compile java source
     javac -classpath $CLASSPATH -d obj \
-        src/scans/*.java \
-        src/scans/procedures/*.java
+        src/${APPNAME}/*.java \
+        src/${APPNAME}/procedures/*.java
     # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
+    if [ $? != 0 ]; then exit 1; fi
+    # build the jar file
+    jar cf ${APPNAME}.jar -C obj ${APPNAME}
+    if [ $? != 0 ]; then exit 2; fi
+    # remove compiled .class files
+    rm -rf obj
 }
 
-# build an application catalog
-function catalog() {
-    srccompile
-    $VOLTDB legacycompile --classpath obj -o $APPNAME.jar ddl.sql
-    # stop if compilation fails
-    if [ $? != 0 ]; then exit; fi
+# compile the jar file, if it doesn't exist
+function jars-ifneeded() {
+    if [ ! -e ${APPNAME}.jar ]; then
+        jars;
+    fi
 }
 
 # run the voltdb server locally
 function server() {
-    # if a catalog doesn't exist, build one
-    if [ ! -f $APPNAME.jar ]; then catalog; fi
+    jars-ifneeded
+    # truncate the voltdb log
+    [[ -d voltdbroot/log && -w voltdbroot/log ]] && > voltdbroot/log/volt.log
     # run the server
-    $VOLTDB create -d deployment.xml -l $LICENSE -H $HOST $APPNAME.jar
+    echo "Starting the VoltDB server."
+    echo "To perform this action manually, use the command line: "
+    echo
+    echo "${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl.sql --force"
+    echo "${VOLTDB} start -l ${LICENSE} -H ${HOST}"
+    echo
+    ${VOLTDB} init -C deployment.xml -j ${APPNAME}.jar -s ddl.sql --force
+    ${VOLTDB} start -l ${LICENSE} -H ${HOST}
 }
 
 # run the client that drives the example
@@ -68,7 +81,7 @@ function client() {
 
 function benchmark() {
     srccompile
-    java -classpath obj:$CLASSPATH:obj -Dlog4j.configuration=file://$CLIENTLOG4J \
+    java -classpath ${CLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$CLIENTLOG4J \
         scans.ScanBenchmark \
         --runs=20 \
         --rows=25000000 \
@@ -76,7 +89,7 @@ function benchmark() {
 }
 
 function help() {
-    echo "Usage: ./run.sh {clean|catalog|server|client|benchmark}"
+    echo "Usage: ./run.sh {clean|jars[-ifneeded]|server|client|benchmark}"
 }
 
 # Run the target passed as the first arg on the command line

--- a/tests/test_apps/schemachange/run.sh
+++ b/tests/test_apps/schemachange/run.sh
@@ -53,7 +53,7 @@ function server() {
 
 # run the client that drives the example
 function client() {
-    srccompile
+    jars-ifneeded
     java -ea -classpath ${CLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$CLIENTLOG4J \
         schemachange.SchemaChangeClient \
         --servers=localhost \
@@ -66,8 +66,7 @@ function client() {
 # sets a trap to kill the server before the script exits.
 function _auto_run() {
     local OPTIONS="$@"
-    srccompile || exit 1
-    catalog || exit 1
+    jars || exit 1
     voltdb_daemon_start $APPNAME.jar $HOST deployment.xml $LICENSE || exit 1
     java -ea -classpath ${CLASSPATH}:${APPNAME}.jar -Dlog4j.configuration=file://$CLIENTLOG4J \
         schemachange.SchemaChangeClient --servers=localhost $OPTIONS

--- a/tests/test_apps/txnid-selfcheck/run.sh
+++ b/tests/test_apps/txnid-selfcheck/run.sh
@@ -70,7 +70,7 @@ function client() {
 # Asynchronous benchmark sample
 # Use this target for argument help
 function async-benchmark-help() {
-    srccompile
+    jars-ifneeded
     java -classpath obj:$CLASSPATH:obj txnIdSelfCheck.AsyncBenchmark --help
 }
 

--- a/tests/test_apps/voter-selfcheck/ddl.sql
+++ b/tests/test_apps/voter-selfcheck/ddl.sql
@@ -76,6 +76,9 @@ CREATE ROLE dbuser WITH adhoc, defaultproc;
 CREATE ROLE adminuser WITH sysproc,adhoc;
 CREATE ROLE hockey WITH adhoc;
 
+-- make sure to load the Java code for the procedures, before creating them
+LOAD CLASSES voter.jar;
+
 CREATE PROCEDURE ALLOW dbuser FROM CLASS voter.procedures.Initialize;
 CREATE PROCEDURE ALLOW dbuser FROM CLASS voter.procedures.Results;
 CREATE PROCEDURE ALLOW dbuser PARTITION ON TABLE votes COLUMN phone_number FROM CLASS voter.procedures.Vote;

--- a/tests/test_apps/voter-selfcheck/deployment-secure.xml
+++ b/tests/test_apps/voter-selfcheck/deployment-secure.xml
@@ -7,6 +7,6 @@
     <security enabled="true" />
     <users>
       <user name="myuser" password="voltdbuser"  roles="dbuser" />
-      <user name="myadmin" password="voltdbadmin"  roles="adminuser" />
+      <user name="myadmin" password="voltdbadmin"  roles="ADMINISTRATOR" />
     </users>
 </deployment>


### PR DESCRIPTION
Remove legacycompile from test_apps run.sh:
Mostly a "rebase" of ENG-17214-app-legacycompile3 onto a recent (2/19)
version of master. On the 'voltdb' (community) side, modified run.sh
files, replacing the srccompile & catalog functions (and any calls to them) with jars &
jars-if-needed, and updating server & help functions accordingly (&
other minor changes, as needed), for the following 'test_apps', which
previously used the long-deprecated 'voltdb legacycompile' (in the
catalog function): aggbench, csvbenchmark, kvbenchmark,
matviewbenchmark, measure-overhead, oneshotkv, overhead, scans,
schemachange, voter-selfcheck (also needed a tweak in
deployment-secure.xml), and ycsb-zipfian.
Also added, to voter-selfcheck/ddl.sql, a 'LOAD CLASSES
voter.jar;' line, in order to avoid 'dbscript failed' errors.

[This time, unlike in ENG-17214-app-legacycompile3, I did NOT delete the
following obsolete 'test_apps': eng1969 and voter-daemons, which I think
are no longer used (they have have no references on the 'pro' side,
including in workloads.py), just in case that was causing some of the
earlier problems.]