### PR TITLE
ENG-19126, exit the repair message forwarding loop when zombie connec…

### DIFF
--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -217,11 +217,9 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
                     m_logger.debug( "PicoNetwork died, probably of natural causes", e);
                 }
             } else {
-                e.printStackTrace();
                 networkLog.error( "PicoNetwork died due to an unexpected exception", e);
             }
         } catch (Throwable ex) {
-            ex.printStackTrace();
             m_logger.error(null, ex);
             m_shouldStop = true;
         } finally {
@@ -230,7 +228,6 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
                 p_shutdown();
             } catch (Throwable t) {
                 m_logger.error("Error shutting down Volt Network", t);
-                t.printStackTrace();
             }
         }
     }

--- a/src/frontend/org/voltcore/network/PicoNetwork.java
+++ b/src/frontend/org/voltcore/network/PicoNetwork.java
@@ -213,10 +213,12 @@ public class PicoNetwork implements Runnable, Connection, IOStatsIntf
                     e instanceof AsynchronousCloseException ||
                     e instanceof ClosedChannelException ||
                     e instanceof ClosedByInterruptException) {
-                m_logger.debug( "VoltPort died, probably of natural causes", e);
+                if (m_logger.isDebugEnabled()) {
+                    m_logger.debug( "PicoNetwork died, probably of natural causes", e);
+                }
             } else {
                 e.printStackTrace();
-                networkLog.error( "VoltPort died due to an unexpected exception", e);
+                networkLog.error( "PicoNetwork died due to an unexpected exception", e);
             }
         } catch (Throwable ex) {
             ex.printStackTrace();

--- a/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/InitiatorMailbox.java
@@ -591,6 +591,11 @@ public class InitiatorMailbox implements Mailbox
                 if (req.getRepairRetryCount() > 100 && req.getRepairRetryCount() % 100 == 0) {
                     hostLog.warn("Repair Request for dead host " + deadHostId +
                             " has not been processed yet because connection has not closed");
+                    if (req.getRepairRetryCount() == 60 * 100) {
+                        hostLog.warn("Connection to dead host " + deadHostId +
+                                " has not been closed for 60 seconds, stop blocking repair request.");
+                        m_messenger.markPicoZombieHost(deadHostId);
+                    }
                 }
                 Runnable retryRepair = new Runnable() {
                     @Override


### PR DESCRIPTION
…tion has not closed for 60 seconds.

In busy and (often) resource-limited environment, we've observed extremely long delay to close the connection to dead host. This may leads to MP deadlock because the SP leader promotion is blocked, in progress MP transaction couldn't proceed on partitions without leader. We introduce a timeout as a last resort to break the loop.

