### PR TITLE
ENG-18744:

### DIFF
--- a/src/ee/storage/ConstraintFailureException.cpp
+++ b/src/ee/storage/ConstraintFailureException.cpp
@@ -74,7 +74,7 @@ ConstraintFailureException::~ConstraintFailureException() throw () {
     // do cleanup here
     VOLT_DEBUG("ConstraintFailureException has table surgeon %s", ((m_surgeon!=NULL) ? "true": "false"));
     if (m_surgeon && !m_tuple.isNullTuple()) {
-        m_surgeon->deleteTupleStorage(m_tuple);
+        m_surgeon->deleteTailTupleStorage(m_tuple);
     }
 }
 

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -1637,6 +1637,7 @@ void PersistentTable::processLoadedTuple(TableTuple& tuple,
         insertTupleCommon(tuple, tuple, true, shouldDRStreamRows, !uniqueViolationOutput);
     } catch (ConstraintFailureException& e) {
         if ( ! uniqueViolationOutput) {
+            // The exception will clean up the tableTuple that was being inserted into the storage
             throw;
         } else if (serializedTupleCount == 0) {
             serializeColumnHeaderTo(*uniqueViolationOutput);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -86,7 +86,7 @@ public:
     void deleteTuple(TableTuple& tuple, bool fallible = true, bool removeMigratingIndex = true);
     void deleteTupleForUndo(char* tupleData, bool skipLookup = false);
     void deleteTupleRelease(char* tuple);
-    void deleteTupleStorage(TableTuple& tuple);
+    void deleteTailTupleStorage(TableTuple& tuple);
 
     size_t getSnapshotPendingBlockCount() const;
     size_t getSnapshotPendingLoadBlockCount() const;
@@ -866,8 +866,8 @@ inline void PersistentTableSurgeon::deleteTupleRelease(char* tuple) {
     m_table.deleteTupleRelease(tuple);
 }
 
-inline void PersistentTableSurgeon::deleteTupleStorage(TableTuple& tuple) {
-    m_table.deleteTupleStorage(tuple);
+inline void PersistentTableSurgeon::deleteTailTupleStorage(TableTuple& tuple) {
+    m_table.deleteTailTupleStorage(tuple);
 }
 inline bool PersistentTableSurgeon::blockCountConsistent() const {
     return m_table.blockCountConsistent();


### PR DESCRIPTION
Use DeleteFromTail instead of deferred delete in the ConstraintFailureException, after the exception has been serialized for Java.