### PR TITLE
Add clear api to allocator

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -483,8 +483,10 @@ inline void CompactingStorageTrait::freeze() {
 inline void CompactingStorageTrait::thaw() {
     if (m_frozen) {                        // release all chunks invisible to txn
         if (! m_storage->empty()) {
-            auto const stop = reinterpret_cast<CompactingChunks const*>(m_storage)->beginTxn().iterator()->id();
-            while (! m_storage->empty() && less_rolling(m_storage->front().id(), stop)) {
+            auto const& beginTxn = reinterpret_cast<CompactingChunks const*>(m_storage)->beginTxn();
+            bool const empty = beginTxn.empty();
+            auto const stop = empty ? 0 : beginTxn.iterator()->id();
+            while (! m_storage->empty() && (empty || less_rolling(m_storage->front().id(), stop))) {
                 m_storage->pop_front();
             }
         }
@@ -523,8 +525,7 @@ inline typename CompactingStorageTrait::list_type::iterator CompactingStorageTra
 }
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
-    list_type(tupleSize), CompactingStorageTrait(this),
-    m_txnFirstChunk(*this), m_batched(*this) {}
+    list_type(tupleSize), CompactingStorageTrait(this), m_txnFirstChunk(*this), m_batched(*this) {}
 
 inline CompactingChunks::TxnLeftBoundary::TxnLeftBoundary(ChunkList<CompactingChunk>& chunks) noexcept :
     m_chunks(chunks), m_iter(chunks.end()), m_next(nullptr) {
@@ -610,12 +611,41 @@ inline void CompactingChunks::thaw() {
     CompactingStorageTrait::thaw();
 }
 
+template<typename Remove_cb>
+inline void CompactingChunks::clear(Remove_cb const& cb) {
+    if (m_lastFreeFromHead != nullptr) {
+        throw logic_error("Unfinished free(remove_direction::from_head, ?)");
+    } else if (! m_batched.empty()) {
+        throw logic_error("Unfinished free_add(?)");
+    } else if (frozen()) {                        // slow clear path
+        // first, apply call back on all txn tuples (in order)
+        fold<IterableTableTupleChunks<CompactingChunks, truth>::const_iterator>(
+                static_cast<CompactingChunks const&>(*this),
+                [&cb] (void const* p) noexcept {cb(p);});
+        // then, release all chunks from txn view
+        while (! beginTxn().empty()) {
+            beginTxn().next() = beginTxn().iterator()->m_next = beginTxn().iterator()->begin();
+            releasable();
+        }
+        m_allocs = 0;
+    } else {                               // fast clear path
+        list_type::clear();
+        m_allocs = 0;
+        m_txnFirstChunk.iterator(list_type::begin());
+    }
+}
+
 inline void* CompactingChunks::allocate() {
     void* r;
     if (empty() || last()->full()) {
-        r = emplace_back(lastChunkId()++, list_type::tupleSize(), list_type::chunkSize())->allocate();
-        if (beginTxn().empty()) {
-            beginTxn().iterator(begin());
+        // Under some circumstances (e.g. truncation when frozen, followed by
+        // allocation (still frozen)), the inserted chunk is not
+        // the only chunk.
+        auto const& beg = emplace_back(lastChunkId()++,
+                list_type::tupleSize(), list_type::chunkSize());
+        r = beg->allocate();
+        if (empty()) {
+            beginTxn().iterator(beg);
         }
     } else {
         r = last()->allocate();
@@ -625,6 +655,10 @@ inline void* CompactingChunks::allocate() {
     }
     ++m_allocs;
     return r;
+}
+
+inline bool CompactingChunks::empty() const noexcept {
+    return beginTxn().empty();
 }
 
 void* CompactingChunks::free(void* dst) {
@@ -1033,10 +1067,14 @@ inline size_t CompactingChunks::DelayedRemover::clear() noexcept {
     return r;
 }
 
-size_t CompactingChunks::DelayedRemover::force() {
+inline size_t CompactingChunks::DelayedRemover::force() {
     validate();
     shift();
     return clear();
+}
+
+inline bool CompactingChunks::DelayedRemover::empty() const noexcept {
+    return m_size == 0;
 }
 
 template<typename Chunks, typename Tag, typename E> Tag IterableTableTupleChunks<Chunks, Tag, E>::s_tagger{};
@@ -1163,11 +1201,14 @@ struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, true_type> {
         if (frozenBoundaries.left().empty()) {        // not frozen
             return iter->next();
         } else {
+            auto const& beginTxn = reinterpret_cast<CompactingChunks const&>(l).beginTxn();
             auto const leftId = frozenBoundaries.left().chunkId(),
                  rightId = frozenBoundaries.right().chunkId(),
-                 txnBeginChunkId = reinterpret_cast<CompactingChunks const&>(l).beginTxn().iterator()->id(),
+                 txnBeginChunkId = beginTxn.empty() ? 0 : beginTxn.iterator()->id(),
                  iterId = iter->id();
-            if(less_rolling(iterId, txnBeginChunkId)) {  // in chunk visible to frozen iterator only
+            if (beginTxn.empty()) {                // txn view is empty
+                return iter->end();                // TODO: before txn goes empty, the last chunk may not be full
+            } else if(less_rolling(iterId, txnBeginChunkId)) {  // in chunk visible to frozen iterator only
                 if (less_rolling(iterId, rightId)) {
                     return iter->end();
                 } else {
@@ -1750,6 +1791,13 @@ template<typename Hook, typename E> inline size_t HookedCompactingChunks<Hook, E
                 memcpy(entry.first, entry.second, tupleSize());    // memcpy after remove_moves() call
             });
     return CompactingChunks::m_batched.force();
+}
+
+template<typename Hook, typename E> inline void HookedCompactingChunks<Hook, E>::clear() {
+    CompactingChunks::clear([this] (void const* s) noexcept {
+                Hook::copy(s);
+                Hook::add(*this, Hook::ChangeType::Deletion, s);
+            });
 }
 
 // # # # # # # # # # # # # # # # # # Codegen: begin # # # # # # # # # # # # # # # # # # # # # # #

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -787,8 +787,8 @@ namespace voltdb {
              */
             void remove_reserve(size_t);
             void remove_add(void*);
-            vector<pair<void*, void*>> const& remove_moves();
-            size_t remove_force();
+            size_t remove_force(function<void(vector<pair<void*, void*>> const&)> const& =
+                    [](vector<pair<void*, void*>> const&){});
             void clear();
         };
 

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -601,9 +601,11 @@ namespace voltdb {
                 vector<void*> const& removed() const;
                 // Actuate batch remove
                 size_t force();
+                bool empty() const noexcept;
             } m_batched;
             size_t m_allocs = 0;
             using list_type::last;
+            template<typename Remove_cb> void clear(Remove_cb const&);
         public:
             using Compact = true_type;
             // for use in HookedCompactingChunks::remove() [batch mode]:
@@ -614,9 +616,10 @@ namespace voltdb {
              */
             size_t chunks() const noexcept;            // number of chunks
             size_t size() const noexcept;              // number of allocation requested
+            bool empty() const noexcept;               // txn view emptiness
             id_type id() const noexcept;
             using list_type::tupleSize; using list_type::chunkSize;
-            using list_type::empty; using list_type::begin; using list_type::end;
+            using list_type::begin; using list_type::end;
             using CompactingStorageTrait::frozen;
 
             // search in txn memory region (i.e. excludes snapshot-related, front portion of list)
@@ -786,6 +789,7 @@ namespace voltdb {
             void remove_add(void*);
             vector<pair<void*, void*>> const& remove_moves();
             size_t remove_force();
+            void clear();
         };
 
         /**

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -787,8 +787,7 @@ namespace voltdb {
              */
             void remove_reserve(size_t);
             void remove_add(void*);
-            size_t remove_force(function<void(vector<pair<void*, void*>> const&)> const& =
-                    [](vector<pair<void*, void*>> const&){});
+            size_t remove_force(function<void(vector<pair<void*, void*>> const&)> const&);
             void clear();
         };
 

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -165,18 +165,18 @@ void testNonCompactingChunks(size_t outOfOrder) {
     assert(alloc.empty());                 // everything gone
 }
 
-TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
-    CompactingChunks alloc(TupleSize);
-    array<void*, 3 * AllocsPerChunk> addresses;
-    for(auto i = 0; i < addresses.size(); ++i) {
-        addresses[i] = alloc.allocate();
-    }
-    for(auto i = 0; i < addresses.size(); ++i) {
-        auto const iter = alloc.find(addresses[i]);
-        ASSERT_TRUE(iter.first);
-        ASSERT_TRUE(iter.second->contains(addresses[i]));
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
+//    CompactingChunks alloc(TupleSize);
+//    array<void*, 3 * AllocsPerChunk> addresses;
+//    for(auto i = 0; i < addresses.size(); ++i) {
+//        addresses[i] = alloc.allocate();
+//    }
+//    for(auto i = 0; i < addresses.size(); ++i) {
+//        auto const iter = alloc.find(addresses[i]);
+//        ASSERT_TRUE(iter.first);
+//        ASSERT_TRUE(iter.second->contains(addresses[i]));
+//    }
+//}
 
 template<typename Chunks>
 void testIteratorOfNonCompactingChunks() {
@@ -259,17 +259,17 @@ void testIteratorOfNonCompactingChunks() {
             alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });*/
 }
 
-TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
-    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
-        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
-        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
-    }
-}
-
-TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
-    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
-    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
-}
+//TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
+//    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
+//        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
+//        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
+//    }
+//}
+//
+//TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
+//    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
+//    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
+//}
 
 void testCompactingChunks() {
     using Gen = StringGen<TupleSize>;
@@ -452,15 +452,15 @@ void testCustomizedIterator(size_t skipped) {      // iterator that skips on eve
     }
 }
 
-TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
-    testCompactingChunks();
-    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
-        testCustomizedIterator<CompactingChunks, 3>(skipped);
-        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
-        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
-        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
+//    testCompactingChunks();
+//    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
+//        testCustomizedIterator<CompactingChunks, 3>(skipped);
+//        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
+//        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
+//        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
+//    }
+//}
 
 // expression template used to apply variadic NthBitChecker
 template<typename Tuple, size_t N> struct Apply {
@@ -708,9 +708,9 @@ struct TestTxnHook {
 TestTxnHook1<NonCompactingChunks<EagerNonCompactingChunk>> const TestTxnHook::sChain1{};
 TestTxnHook1<NonCompactingChunks<LazyNonCompactingChunk>> const TestTxnHook::sChain2{};
 
-TEST_F(TableTupleAllocatorTest, TestTxnHook) {
-    TestTxnHook()();
-}
+//TEST_F(TableTupleAllocatorTest, TestTxnHook) {
+//    TestTxnHook()();
+//}
 
 /**
  * Test of HookedCompactingChunks using its RW iterator that
@@ -1085,58 +1085,58 @@ void testHookedCompactingChunksBatchRemove_multi2() {
     alloc.thaw();
 }
 
-TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
-    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-    using Alloc = HookedCompactingChunks<Hook>;
-    using Gen = StringGen<TupleSize>;
-    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
-    Gen gen;
-    Alloc alloc(TupleSize);
-    addresses_type addresses;
-    assert(alloc.empty());
-    size_t i;
-    for(i = 0; i < addresses.size(); ++i) {
-        addresses[i] = alloc.allocate();
-        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
-    }
-    alloc.remove_reserve(AllocsPerChunk + 2);
-    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
-        alloc.remove_add(const_cast<void*>(addresses[i]));
-    }
-    alloc.remove_force();
-    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
-}
-
-TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
-    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-    using Alloc = HookedCompactingChunks<Hook>;
-    auto constexpr N = AllocsPerChunk * 3 + 2;
-    array<void const*, N> addresses;
-    Alloc alloc(TupleSize);
-    ASSERT_EQ(TupleSize, alloc.tupleSize());
-    ASSERT_EQ(0, alloc.chunks());
-    ASSERT_EQ(0, alloc.size());
-    size_t i;
-    for(i = 0; i < N; ++i) {
-        addresses[i] = alloc.allocate();
-    }
-    ASSERT_EQ(4, alloc.chunks());
-    ASSERT_EQ(N, alloc.size());
-    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
-    alloc.remove(const_cast<void*>(addresses[1]));
-    ASSERT_EQ(4, alloc.chunks());
-    ASSERT_EQ(N - 2, alloc.size());
-    // batch remove last 30 entries, compacts/removes head chunk
-    alloc.remove_reserve(AllocsPerChunk - 2);
-    for(i = 2; i < AllocsPerChunk; ++i) {
-        alloc.remove_add(const_cast<void*>(addresses[N - i + 1]));
-    }
-    alloc.remove_force();
-    ASSERT_EQ(3, alloc.chunks());
-    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
-}
+//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
+//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+//    using Alloc = HookedCompactingChunks<Hook>;
+//    using Gen = StringGen<TupleSize>;
+//    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
+//    Gen gen;
+//    Alloc alloc(TupleSize);
+//    addresses_type addresses;
+//    assert(alloc.empty());
+//    size_t i;
+//    for(i = 0; i < addresses.size(); ++i) {
+//        addresses[i] = alloc.allocate();
+//        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
+//    }
+//    alloc.remove_reserve(AllocsPerChunk + 2);
+//    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
+//        alloc.remove_add(const_cast<void*>(addresses[i]));
+//    }
+//    alloc.remove_force();
+//    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
+//}
+//
+//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
+//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+//    using Alloc = HookedCompactingChunks<Hook>;
+//    auto constexpr N = AllocsPerChunk * 3 + 2;
+//    array<void const*, N> addresses;
+//    Alloc alloc(TupleSize);
+//    ASSERT_EQ(TupleSize, alloc.tupleSize());
+//    ASSERT_EQ(0, alloc.chunks());
+//    ASSERT_EQ(0, alloc.size());
+//    size_t i;
+//    for(i = 0; i < N; ++i) {
+//        addresses[i] = alloc.allocate();
+//    }
+//    ASSERT_EQ(4, alloc.chunks());
+//    ASSERT_EQ(N, alloc.size());
+//    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
+//    alloc.remove(const_cast<void*>(addresses[1]));
+//    ASSERT_EQ(4, alloc.chunks());
+//    ASSERT_EQ(N - 2, alloc.size());
+//    // batch remove last 30 entries, compacts/removes head chunk
+//    alloc.remove_reserve(AllocsPerChunk - 2);
+//    for(i = 2; i < AllocsPerChunk; ++i) {
+//        alloc.remove_add(const_cast<void*>(addresses[N - i + 1]));
+//    }
+//    alloc.remove_force();
+//    ASSERT_EQ(3, alloc.chunks());
+//    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
+//}
 
 template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
     inline void operator()() const {
@@ -1178,9 +1178,9 @@ struct TestHookedCompactingChunks {
 TestHookedCompactingChunks1<EagerNonCompactingChunk> const TestHookedCompactingChunks::s1{};
 TestHookedCompactingChunks1<LazyNonCompactingChunk> const TestHookedCompactingChunks::s2{};
 
-TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
-    TestHookedCompactingChunks()();
-}
+//TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
+//    TestHookedCompactingChunks()();
+//}
 
 /**
  * Simulates how MP execution works: interleaved snapshot
@@ -1310,9 +1310,9 @@ struct TestInterleavedCompactingChunks {
 TestInterleavedCompactingChunks1<EagerNonCompactingChunk> const TestInterleavedCompactingChunks::s1{};
 TestInterleavedCompactingChunks1<LazyNonCompactingChunk> const TestInterleavedCompactingChunks::s2{};
 
-TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
-    TestInterleavedCompactingChunks()();
-}
+//TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
+//    TestInterleavedCompactingChunks()();
+//}
 
 template<typename Chunk, gc_policy pol>
 void testSingleChunkSnapshot() {
@@ -1376,9 +1376,9 @@ struct TestSingleChunkSnapshot {
 TestSingleChunkSnapshot1<EagerNonCompactingChunk> const TestSingleChunkSnapshot::s1{};
 TestSingleChunkSnapshot1<LazyNonCompactingChunk> const TestSingleChunkSnapshot::s2{};
 
-TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
-    TestSingleChunkSnapshot()();
-}
+//TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
+//    TestSingleChunkSnapshot()();
+//}
 
 template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 void testRemovesFromEnds(size_t batch) {
@@ -1475,199 +1475,225 @@ struct TestRemovesFromEnds {
     }
 };
 
-TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
-    TestRemovesFromEnds()();
-}
-
-TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    void* addr = alloc.allocate();
-    ASSERT_EQ(addr, alloc.remove(addr));
-    // empty: reallocate
-    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
-    size_t i = 0;
-    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
-                ASSERT_EQ(addr, p);
-                ASSERT_TRUE(Gen::same(p, i++));
-            });
-    ASSERT_EQ(1, i);
-}
+//TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
+//    TestRemovesFromEnds()();
+//}
+//
+//TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    void* addr = alloc.allocate();
+//    ASSERT_EQ(addr, alloc.remove(addr));
+//    // empty: reallocate
+//    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
+//    size_t i = 0;
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
+//                ASSERT_EQ(addr, p);
+//                ASSERT_TRUE(Gen::same(p, i++));
+//            });
+//    ASSERT_EQ(1, i);
+//}
 
 // Test that it should work without txn in progress
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    size_t i;
-    for(i = 0; i < NumTuples; ++i) {
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    i = 0;
-    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
-            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
-                ASSERT_TRUE(Gen::same(p, i++));
-            });
-    ASSERT_EQ(NumTuples, i);
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    size_t i;
+//    for(i = 0; i < NumTuples; ++i) {
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    i = 0;
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
+//            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
+//                ASSERT_TRUE(Gen::same(p, i++));
+//            });
+//    ASSERT_EQ(NumTuples, i);
+//}
 
 // Test that it should work with insertions
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    size_t i;
-    for(i = 0; i < NumTuples/ 2; ++i) {
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    while (! iter.drained()) {
-        ASSERT_TRUE(Gen::same(*iter++, i++));
-    }
-    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    size_t i;
+//    for(i = 0; i < NumTuples/ 2; ++i) {
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    while (! iter.drained()) {
+//        ASSERT_TRUE(Gen::same(*iter++, i++));
+//    }
+//    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
+//}
 
 // Test that it should work with normal, compacting removals that only eats what had
 // been iterated
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
-        // expensive O(n) check (actually almost O(AllocsPerChunk))
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        try {
-            alloc.remove(const_cast<void*>(addresses[i++]));
-        } catch (range_error const&) {                         // OK bc. compaction
-            continue;
-        }
-    }
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
+//        // expensive O(n) check (actually almost O(AllocsPerChunk))
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        try {
+//            alloc.remove(const_cast<void*>(addresses[i++]));
+//        } catch (range_error const&) {                         // OK bc. compaction
+//            continue;
+//        }
+//    }
+//}
 
 // Test that it should work with normal, compacting removals in
 // opposite direction of the/any iterator
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-    }
-    while (! iter.drained()) {
-        void const* pp = *iter;
-        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-        ASSERT_TRUE(matched);
-        ++iter;
-        ++i;
-    }
-//    ASSERT_EQ(NumTuples, i);
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+//    }
+//    while (! iter.drained()) {
+//        void const* pp = *iter;
+//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+//        ASSERT_TRUE(matched);
+//        ++iter;
+//        ++i;
+//    }
+//}
 
 // Test that it should work with lightweight, non-compacting removals that only eats
 // what had been iterated
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples; ++i) {
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        // Removing from head, unless forced by calling again
-        // with NULL next, would not have any effect except
-        // removing crosses boundary. This means that we are
-        // iterating over values that actually should *not* be
-        // visible (i.e. garbage). But that is ok, since we are
-        // not forcing it every time (in which case it becomes
-        // normal, compacting removal).
-        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
-    }
-    ASSERT_TRUE(iter.drained());
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples; ++i) {
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        // Removing from head, unless forced by calling again
+//        // with NULL next, would not have any effect except
+//        // removing crosses boundary. This means that we are
+//        // iterating over values that actually should *not* be
+//        // visible (i.e. garbage). But that is ok, since we are
+//        // not forcing it every time (in which case it becomes
+//        // normal, compacting removal).
+//        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
+//    }
+//    ASSERT_TRUE(iter.drained());
+//}
 
 // Test that it should work with lightweight, non-compacting removals from tail
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    Gen gen;
-    array<void const*, NumTuples> addresses;
-    size_t i;
-    for (i = 0; i < NumTuples; ++i) {
-        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
-        ASSERT_TRUE(Gen::same(*iter++, i));
-        // Removing from head, unless forced by calling again
-        // with NULL next, would not have any effect except
-        // removing crosses boundary. This means that we are
-        // iterating over values that actually should *not* be
-        // visible (i.e. garbage). But that is ok, since we are
-        // not forcing it every time (in which case it becomes
-        // normal, compacting removal). TODO: memcheck
-        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
-    }
-    ASSERT_TRUE(iter.drained());
-    ASSERT_EQ(NumTuples / 2, i);
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//        // Removing from head, unless forced by calling again
+//        // with NULL next, would not have any effect except
+//        // removing crosses boundary. This means that we are
+//        // iterating over values that actually should *not* be
+//        // visible (i.e. garbage). But that is ok, since we are
+//        // not forcing it every time (in which case it becomes
+//        // normal, compacting removal). TODO: memcheck
+//        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
+//    }
+//    ASSERT_TRUE(iter.drained());
+//    ASSERT_EQ(NumTuples / 2, i);
+//}
 
 // Test that it should work when iterator created when allocator
 // is empty
-TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic6) {
-    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-    using Gen = StringGen<TupleSize>;
-    Alloc alloc(TupleSize);
-    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-    Gen gen;
-    size_t i;
-    for (i = 0; i < AllocsPerChunk * 2; ++i) {
-        memcpy(alloc.allocate(), gen.get(), TupleSize);
-    }
-    for (i = 0; i < AllocsPerChunk * 2; ++i) {
-        ASSERT_TRUE(Gen::same(*iter++, i));
-    }
-    ASSERT_TRUE(iter.drained());
-    ASSERT_EQ(AllocsPerChunk * 2, i);
-}
+//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic6) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+//    Gen gen;
+//    size_t i;
+//    for (i = 0; i < AllocsPerChunk * 2; ++i) {
+//        memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    for (i = 0; i < AllocsPerChunk * 2; ++i) {
+//        ASSERT_TRUE(Gen::same(*iter++, i));
+//    }
+//    ASSERT_TRUE(iter.drained());
+//    ASSERT_EQ(AllocsPerChunk * 2, i);
+//}
+//
+//TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
+//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+//    using Gen = StringGen<TupleSize>;
+//    Alloc alloc(TupleSize);
+//    Gen gen;
+//    array<void const*, NumTuples> addresses;
+//    size_t i;
+//    for (i = 0; i < NumTuples; ++i) {
+//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+//    }
+//    // Remove last 10, making 1st chunk non-full
+//    for (i = 0; i < 10; ++i) {
+//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+//    }
+//    alloc.template freeze<truth>();
+//    i = 0;
+//    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
+//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
+//            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
+//                ASSERT_TRUE(end != find(beg, end, p) ||
+//                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
+//                ++i;
+//            });
+//    ASSERT_EQ(i, NumTuples - 10);
+//    alloc.thaw();
+//}
 
-TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
+TEST_F(TableTupleAllocatorTest, TestClearCompactingChunks) {
     using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
     using Gen = StringGen<TupleSize>;
     Alloc alloc(TupleSize);
@@ -1677,21 +1703,18 @@ TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
     for (i = 0; i < NumTuples; ++i) {
         addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
     }
-    // Remove last 10, making 1st chunk non-full
-    for (i = 0; i < 10; ++i) {
-        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-    }
     alloc.template freeze<truth>();
+    alloc.clear();
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+            static_cast<Alloc const&>(alloc),
+            [this] (void const*) { ASSERT_FALSE(true); });                             // txn should see nothing
     i = 0;
-    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
-    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
-            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
-                ASSERT_TRUE(end != find(beg, end, p) ||
-                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
-                ++i;
-            });
-    ASSERT_EQ(i, NumTuples - 10);
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(      // snapshot should see everything
+            static_cast<Alloc const&>(alloc),
+            [&i, this](void const* p) { ASSERT_TRUE(Gen::same(p, i++)); });
+    ASSERT_EQ(i, NumTuples);
     alloc.thaw();
+    ASSERT_TRUE(alloc.empty());
 }
 
 #endif

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -774,7 +774,7 @@ void testHookedCompactingChunks() {
     for (i = 909; i < 999; ++i) {
         alloc.remove_add(const_cast<void*>(addresses[i]));
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     verify_snapshot_const();
 
     // Step 4: insertion
@@ -851,7 +851,7 @@ void testHookedCompactingChunks() {
                 ii = 0;
                 for_each(tb_removed.cbegin(), tb_removed.cend(),
                         [&ii, &alloc](void* p) { ++ii; alloc.remove_add(p); });
-                assert(alloc.remove_force() == tb_removed.size());
+                assert(alloc.remove_force([](vector<pair<void*, void*>> const&){}) == tb_removed.size());
             default:;
         }
         ++i;
@@ -899,7 +899,7 @@ void testHookedCompactingChunksBatchRemove_single1() {
     for (i = AllocsPerChunk - 10; i < AllocsPerChunk; ++i) {       // batch remove last 10 entries
         alloc.remove_add(const_cast<void*>(addresses[i]));
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     verify_snapshot_const();
     alloc.thaw();
 }
@@ -944,7 +944,7 @@ void testHookedCompactingChunksBatchRemove_single2() {
     for (i = 0; i < 10; ++i) {       // inserts another 10 different entries
         memcpy(alloc.allocate(), gen.get(), TupleSize);
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     verify_snapshot_const();
     alloc.thaw();
 }
@@ -969,7 +969,7 @@ void testHookedCompactingChunksBatchRemove_single3() {         // correctness on
     alloc.template freeze<truth>();
     alloc.remove_reserve(1);
     alloc.remove_add(const_cast<void*>(addresses[4]));      // 9 => 4
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     i = 0;
     fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
             alloc_cref,
@@ -990,7 +990,7 @@ void testHookedCompactingChunksBatchRemove_single4() {         // correctness on
     void* p = alloc.allocate();
     alloc.remove_reserve(1);
     alloc.remove_add(p);
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     assert(alloc.empty());
 }
 
@@ -1036,7 +1036,7 @@ void testHookedCompactingChunksBatchRemove_multi1() {
         for_each(iter, next(iter, 10), [&alloc](void const* p) { alloc.remove_add(const_cast<void*>(p)); });
         advance(iter, 10);
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     verify_snapshot_const();
     alloc.thaw();
 }
@@ -1080,7 +1080,7 @@ void testHookedCompactingChunksBatchRemove_multi2() {
             ++iter;
         }
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     verify_snapshot_const();
     alloc.thaw();
 }
@@ -1104,7 +1104,7 @@ TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2c
     for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
         alloc.remove_add(const_cast<void*>(addresses[i]));
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
 }
 
@@ -1133,7 +1133,7 @@ TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
     for(i = 2; i < AllocsPerChunk; ++i) {
         alloc.remove_add(const_cast<void*>(addresses[N - i + 1]));
     }
-    alloc.remove_force();
+    alloc.remove_force([](vector<pair<void*, void*>> const&){});
     ASSERT_EQ(3, alloc.chunks());
     ASSERT_EQ(N - AllocsPerChunk, alloc.size());
 }

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -165,18 +165,18 @@ void testNonCompactingChunks(size_t outOfOrder) {
     assert(alloc.empty());                 // everything gone
 }
 
-//TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
-//    CompactingChunks alloc(TupleSize);
-//    array<void*, 3 * AllocsPerChunk> addresses;
-//    for(auto i = 0; i < addresses.size(); ++i) {
-//        addresses[i] = alloc.allocate();
-//    }
-//    for(auto i = 0; i < addresses.size(); ++i) {
-//        auto const iter = alloc.find(addresses[i]);
-//        ASSERT_TRUE(iter.first);
-//        ASSERT_TRUE(iter.second->contains(addresses[i]));
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestChunkListFind) {
+    CompactingChunks alloc(TupleSize);
+    array<void*, 3 * AllocsPerChunk> addresses;
+    for(auto i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.allocate();
+    }
+    for(auto i = 0; i < addresses.size(); ++i) {
+        auto const iter = alloc.find(addresses[i]);
+        ASSERT_TRUE(iter.first);
+        ASSERT_TRUE(iter.second->contains(addresses[i]));
+    }
+}
 
 template<typename Chunks>
 void testIteratorOfNonCompactingChunks() {
@@ -259,17 +259,17 @@ void testIteratorOfNonCompactingChunks() {
             alloc, [&alloc, &i](void* p) { alloc.free(p); ++i; });*/
 }
 
-//TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
-//    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
-//        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
-//        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
-//    }
-//}
-//
-//TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
-//    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
-//    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
-//}
+TEST_F(TableTupleAllocatorTest, TestNonCompactingChunks) {
+    for (size_t outOfOrder = 5; outOfOrder < 10; ++outOfOrder) {
+        testNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>(outOfOrder);
+        testNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>(outOfOrder);
+    }
+}
+
+TEST_F(TableTupleAllocatorTest, TestIteratorOfNonCompactingChunks) {
+    testIteratorOfNonCompactingChunks<NonCompactingChunks<EagerNonCompactingChunk>>();
+    testIteratorOfNonCompactingChunks<NonCompactingChunks<LazyNonCompactingChunk>>();
+}
 
 void testCompactingChunks() {
     using Gen = StringGen<TupleSize>;
@@ -452,15 +452,15 @@ void testCustomizedIterator(size_t skipped) {      // iterator that skips on eve
     }
 }
 
-//TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
-//    testCompactingChunks();
-//    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
-//        testCustomizedIterator<CompactingChunks, 3>(skipped);
-//        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
-//        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
-//        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestCompactingChunks) {
+    testCompactingChunks();
+    for (auto skipped = 8lu; skipped < 64; skipped += 8) {
+        testCustomizedIterator<CompactingChunks, 3>(skipped);
+        testCustomizedIterator<NonCompactingChunks<EagerNonCompactingChunk>, 3>(skipped);
+        testCustomizedIterator<NonCompactingChunks<LazyNonCompactingChunk>, 3>(skipped);
+        testCustomizedIterator<CompactingChunks, 6>(skipped);       // a different mask
+    }
+}
 
 // expression template used to apply variadic NthBitChecker
 template<typename Tuple, size_t N> struct Apply {
@@ -708,9 +708,9 @@ struct TestTxnHook {
 TestTxnHook1<NonCompactingChunks<EagerNonCompactingChunk>> const TestTxnHook::sChain1{};
 TestTxnHook1<NonCompactingChunks<LazyNonCompactingChunk>> const TestTxnHook::sChain2{};
 
-//TEST_F(TableTupleAllocatorTest, TestTxnHook) {
-//    TestTxnHook()();
-//}
+TEST_F(TableTupleAllocatorTest, TestTxnHook) {
+    TestTxnHook()();
+}
 
 /**
  * Test of HookedCompactingChunks using its RW iterator that
@@ -1085,58 +1085,58 @@ void testHookedCompactingChunksBatchRemove_multi2() {
     alloc.thaw();
 }
 
-//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
-//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-//    using Alloc = HookedCompactingChunks<Hook>;
-//    using Gen = StringGen<TupleSize>;
-//    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
-//    Gen gen;
-//    Alloc alloc(TupleSize);
-//    addresses_type addresses;
-//    assert(alloc.empty());
-//    size_t i;
-//    for(i = 0; i < addresses.size(); ++i) {
-//        addresses[i] = alloc.allocate();
-//        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
-//    }
-//    alloc.remove_reserve(AllocsPerChunk + 2);
-//    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
-//        alloc.remove_add(const_cast<void*>(addresses[i]));
-//    }
-//    alloc.remove_force();
-//    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
-//}
-//
-//TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
-//    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
-//    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
-//    using Alloc = HookedCompactingChunks<Hook>;
-//    auto constexpr N = AllocsPerChunk * 3 + 2;
-//    array<void const*, N> addresses;
-//    Alloc alloc(TupleSize);
-//    ASSERT_EQ(TupleSize, alloc.tupleSize());
-//    ASSERT_EQ(0, alloc.chunks());
-//    ASSERT_EQ(0, alloc.size());
-//    size_t i;
-//    for(i = 0; i < N; ++i) {
-//        addresses[i] = alloc.allocate();
-//    }
-//    ASSERT_EQ(4, alloc.chunks());
-//    ASSERT_EQ(N, alloc.size());
-//    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
-//    alloc.remove(const_cast<void*>(addresses[1]));
-//    ASSERT_EQ(4, alloc.chunks());
-//    ASSERT_EQ(N - 2, alloc.size());
-//    // batch remove last 30 entries, compacts/removes head chunk
-//    alloc.remove_reserve(AllocsPerChunk - 2);
-//    for(i = 2; i < AllocsPerChunk; ++i) {
-//        alloc.remove_add(const_cast<void*>(addresses[N - i + 1]));
-//    }
-//    alloc.remove_force();
-//    ASSERT_EQ(3, alloc.chunks());
-//    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
-//}
+TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksBatchRemove_nonfull_2chunks) {
+    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    using Gen = StringGen<TupleSize>;
+    using addresses_type = array<void const*, AllocsPerChunk * 2 - 2>;     // 2 chunks, 2nd 2 allocs from full
+    Gen gen;
+    Alloc alloc(TupleSize);
+    addresses_type addresses;
+    assert(alloc.empty());
+    size_t i;
+    for(i = 0; i < addresses.size(); ++i) {
+        addresses[i] = alloc.allocate();
+        memcpy(const_cast<void*>(addresses[i]), gen.get(), TupleSize);
+    }
+    alloc.remove_reserve(AllocsPerChunk + 2);
+    for(i = 0; i < AllocsPerChunk + 2; ++i) {                  // batch remove 1st chunk plus 2
+        alloc.remove_add(const_cast<void*>(addresses[i]));
+    }
+    alloc.remove_force();
+    ASSERT_EQ(AllocsPerChunk - 4, alloc.size());
+}
+
+TEST_F(TableTupleAllocatorTest, testHookedCompactingChunksStatistics) {
+    using HookAlloc = NonCompactingChunks<LazyNonCompactingChunk>;
+    using Hook = TxnPreHook<HookAlloc, HistoryRetainTrait<gc_policy::never>>;
+    using Alloc = HookedCompactingChunks<Hook>;
+    auto constexpr N = AllocsPerChunk * 3 + 2;
+    array<void const*, N> addresses;
+    Alloc alloc(TupleSize);
+    ASSERT_EQ(TupleSize, alloc.tupleSize());
+    ASSERT_EQ(0, alloc.chunks());
+    ASSERT_EQ(0, alloc.size());
+    size_t i;
+    for(i = 0; i < N; ++i) {
+        addresses[i] = alloc.allocate();
+    }
+    ASSERT_EQ(4, alloc.chunks());
+    ASSERT_EQ(N, alloc.size());
+    alloc.remove(const_cast<void*>(addresses[0]));             // single remove, twice
+    alloc.remove(const_cast<void*>(addresses[1]));
+    ASSERT_EQ(4, alloc.chunks());
+    ASSERT_EQ(N - 2, alloc.size());
+    // batch remove last 30 entries, compacts/removes head chunk
+    alloc.remove_reserve(AllocsPerChunk - 2);
+    for(i = 2; i < AllocsPerChunk; ++i) {
+        alloc.remove_add(const_cast<void*>(addresses[N - i + 1]));
+    }
+    alloc.remove_force();
+    ASSERT_EQ(3, alloc.chunks());
+    ASSERT_EQ(N - AllocsPerChunk, alloc.size());
+}
 
 template<typename Chunk, gc_policy pol> struct TestHookedCompactingChunks2 {
     inline void operator()() const {
@@ -1178,9 +1178,9 @@ struct TestHookedCompactingChunks {
 TestHookedCompactingChunks1<EagerNonCompactingChunk> const TestHookedCompactingChunks::s1{};
 TestHookedCompactingChunks1<LazyNonCompactingChunk> const TestHookedCompactingChunks::s2{};
 
-//TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
-//    TestHookedCompactingChunks()();
-//}
+TEST_F(TableTupleAllocatorTest, TestHookedCompactingChunks) {
+    TestHookedCompactingChunks()();
+}
 
 /**
  * Simulates how MP execution works: interleaved snapshot
@@ -1310,9 +1310,9 @@ struct TestInterleavedCompactingChunks {
 TestInterleavedCompactingChunks1<EagerNonCompactingChunk> const TestInterleavedCompactingChunks::s1{};
 TestInterleavedCompactingChunks1<LazyNonCompactingChunk> const TestInterleavedCompactingChunks::s2{};
 
-//TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
-//    TestInterleavedCompactingChunks()();
-//}
+TEST_F(TableTupleAllocatorTest, TestInterleavedOperations) {
+    TestInterleavedCompactingChunks()();
+}
 
 template<typename Chunk, gc_policy pol>
 void testSingleChunkSnapshot() {
@@ -1376,9 +1376,9 @@ struct TestSingleChunkSnapshot {
 TestSingleChunkSnapshot1<EagerNonCompactingChunk> const TestSingleChunkSnapshot::s1{};
 TestSingleChunkSnapshot1<LazyNonCompactingChunk> const TestSingleChunkSnapshot::s2{};
 
-//TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
-//    TestSingleChunkSnapshot()();
-//}
+TEST_F(TableTupleAllocatorTest, TestSingleChunkSnapshot) {
+    TestSingleChunkSnapshot()();
+}
 
 template<typename Chunk, gc_policy pol, CompactingChunks::remove_direction dir>
 void testRemovesFromEnds(size_t batch) {
@@ -1475,223 +1475,223 @@ struct TestRemovesFromEnds {
     }
 };
 
-//TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
-//    TestRemovesFromEnds()();
-//}
-//
-//TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    void* addr = alloc.allocate();
-//    ASSERT_EQ(addr, alloc.remove(addr));
-//    // empty: reallocate
-//    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
-//    size_t i = 0;
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
-//                ASSERT_EQ(addr, p);
-//                ASSERT_TRUE(Gen::same(p, i++));
-//            });
-//    ASSERT_EQ(1, i);
-//}
+TEST_F(TableTupleAllocatorTest, TestRemovesFromEnds) {
+    TestRemovesFromEnds()();
+}
+
+TEST_F(TableTupleAllocatorTest, TestClearReallocate) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    void* addr = alloc.allocate();
+    ASSERT_EQ(addr, alloc.remove(addr));
+    // empty: reallocate
+    memcpy(addr = alloc.allocate(), gen.get(), TupleSize);
+    size_t i = 0;
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+            static_cast<Alloc const&>(alloc), [addr, this, &i](void const* p) {
+                ASSERT_EQ(addr, p);
+                ASSERT_TRUE(Gen::same(p, i++));
+            });
+    ASSERT_EQ(1, i);
+}
 
 // Test that it should work without txn in progress
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    size_t i;
-//    for(i = 0; i < NumTuples; ++i) {
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    i = 0;
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
-//            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
-//                ASSERT_TRUE(Gen::same(p, i++));
-//            });
-//    ASSERT_EQ(NumTuples, i);
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic0) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    size_t i;
+    for(i = 0; i < NumTuples; ++i) {
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    i = 0;
+    fold<typename IterableTableTupleChunks<Alloc, truth>::elastic_iterator>(
+            static_cast<Alloc const&>(alloc), [&i, this](void const* p) {
+                ASSERT_TRUE(Gen::same(p, i++));
+            });
+    ASSERT_EQ(NumTuples, i);
+}
 
 // Test that it should work with insertions
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    size_t i;
-//    for(i = 0; i < NumTuples/ 2; ++i) {
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    while (! iter.drained()) {
-//        ASSERT_TRUE(Gen::same(*iter++, i++));
-//    }
-//    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic1) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    size_t i;
+    for(i = 0; i < NumTuples/ 2; ++i) {
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples / 2; ++i) {                      // iterator advance, then insertion in a loop
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    while (! iter.drained()) {
+        ASSERT_TRUE(Gen::same(*iter++, i++));
+    }
+    ASSERT_EQ(NumTuples / 2, i);                       // won't see any newly inserted values
+}
 
 // Test that it should work with normal, compacting removals that only eats what had
 // been iterated
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
-//        // expensive O(n) check (actually almost O(AllocsPerChunk))
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        try {
-//            alloc.remove(const_cast<void*>(addresses[i++]));
-//        } catch (range_error const&) {                         // OK bc. compaction
-//            continue;
-//        }
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic2) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples && ! iter.drained(); ++iter) {                      // iterator advance, then delete previous iterated tuple
+        // expensive O(n) check (actually almost O(AllocsPerChunk))
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        try {
+            alloc.remove(const_cast<void*>(addresses[i++]));
+        } catch (range_error const&) {                         // OK bc. compaction
+            continue;
+        }
+    }
+}
 
 // Test that it should work with normal, compacting removals in
 // opposite direction of the/any iterator
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-//    }
-//    while (! iter.drained()) {
-//        void const* pp = *iter;
-//        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
-//                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
-//        ASSERT_TRUE(matched);
-//        ++iter;
-//        ++i;
-//    }
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic3) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < (NumTuples - AllocsPerChunk) / 2 && ! iter.drained(); ++i, ++iter) {
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+    }
+    while (! iter.drained()) {
+        void const* pp = *iter;
+        bool const matched = until<IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc), [pp] (void const* p) { return ! memcmp(pp, p, TupleSize); });
+        ASSERT_TRUE(matched);
+        ++iter;
+        ++i;
+    }
+}
 
 // Test that it should work with lightweight, non-compacting removals that only eats
 // what had been iterated
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples; ++i) {
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        // Removing from head, unless forced by calling again
-//        // with NULL next, would not have any effect except
-//        // removing crosses boundary. This means that we are
-//        // iterating over values that actually should *not* be
-//        // visible (i.e. garbage). But that is ok, since we are
-//        // not forcing it every time (in which case it becomes
-//        // normal, compacting removal).
-//        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
-//    }
-//    ASSERT_TRUE(iter.drained());
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic4) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples; ++i) {
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        // Removing from head, unless forced by calling again
+        // with NULL next, would not have any effect except
+        // removing crosses boundary. This means that we are
+        // iterating over values that actually should *not* be
+        // visible (i.e. garbage). But that is ok, since we are
+        // not forcing it every time (in which case it becomes
+        // normal, compacting removal).
+        alloc.remove(CompactingChunks::remove_direction::from_head, addresses[i]);
+    }
+    ASSERT_TRUE(iter.drained());
+}
 
 // Test that it should work with lightweight, non-compacting removals from tail
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//        // Removing from head, unless forced by calling again
-//        // with NULL next, would not have any effect except
-//        // removing crosses boundary. This means that we are
-//        // iterating over values that actually should *not* be
-//        // visible (i.e. garbage). But that is ok, since we are
-//        // not forcing it every time (in which case it becomes
-//        // normal, compacting removal). TODO: memcheck
-//        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
-//    }
-//    ASSERT_TRUE(iter.drained());
-//    ASSERT_EQ(NumTuples / 2, i);
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic5) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    for (i = 0; i < NumTuples && ! iter.drained(); ++i) {
+        ASSERT_TRUE(Gen::same(*iter++, i));
+        // Removing from head, unless forced by calling again
+        // with NULL next, would not have any effect except
+        // removing crosses boundary. This means that we are
+        // iterating over values that actually should *not* be
+        // visible (i.e. garbage). But that is ok, since we are
+        // not forcing it every time (in which case it becomes
+        // normal, compacting removal). TODO: memcheck
+        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
+    }
+    ASSERT_TRUE(iter.drained());
+    ASSERT_EQ(NumTuples / 2, i);
+}
 
 // Test that it should work when iterator created when allocator
 // is empty
-//TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic6) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
-//    Gen gen;
-//    size_t i;
-//    for (i = 0; i < AllocsPerChunk * 2; ++i) {
-//        memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    for (i = 0; i < AllocsPerChunk * 2; ++i) {
-//        ASSERT_TRUE(Gen::same(*iter++, i));
-//    }
-//    ASSERT_TRUE(iter.drained());
-//    ASSERT_EQ(AllocsPerChunk * 2, i);
-//}
-//
-//TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
-//    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
-//    using Gen = StringGen<TupleSize>;
-//    Alloc alloc(TupleSize);
-//    Gen gen;
-//    array<void const*, NumTuples> addresses;
-//    size_t i;
-//    for (i = 0; i < NumTuples; ++i) {
-//        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
-//    }
-//    // Remove last 10, making 1st chunk non-full
-//    for (i = 0; i < 10; ++i) {
-//        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
-//    }
-//    alloc.template freeze<truth>();
-//    i = 0;
-//    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
-//    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
-//            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
-//                ASSERT_TRUE(end != find(beg, end, p) ||
-//                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
-//                ++i;
-//            });
-//    ASSERT_EQ(i, NumTuples - 10);
-//    alloc.thaw();
-//}
+TEST_F(TableTupleAllocatorTest, TestElasticIterator_basic6) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    auto iter = IterableTableTupleChunks<Alloc, truth>::elastic_iterator::begin(alloc);
+    Gen gen;
+    size_t i;
+    for (i = 0; i < AllocsPerChunk * 2; ++i) {
+        memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    for (i = 0; i < AllocsPerChunk * 2; ++i) {
+        ASSERT_TRUE(Gen::same(*iter++, i));
+    }
+    ASSERT_TRUE(iter.drained());
+    ASSERT_EQ(AllocsPerChunk * 2, i);
+}
+
+TEST_F(TableTupleAllocatorTest, TestSnapshotIteratorOnNonFull1stChunk) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    Gen gen;
+    array<void const*, NumTuples> addresses;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    // Remove last 10, making 1st chunk non-full
+    for (i = 0; i < 10; ++i) {
+        alloc.remove(const_cast<void*>(addresses[NumTuples - i - 1]));
+    }
+    alloc.template freeze<truth>();
+    i = 0;
+    auto const beg = addresses.begin(), end = prev(addresses.end(), 10);
+    fold<typename IterableTableTupleChunks<Alloc, truth>::const_hooked_iterator>(
+            static_cast<Alloc const&>(alloc), [this, &i, &beg, &end] (void const* p) {
+                ASSERT_TRUE(end != find(beg, end, p) ||
+                        end != find_if(beg, end, [p](void const* pp) { return ! memcmp(p, pp, TupleSize); }));
+                ++i;
+            });
+    ASSERT_EQ(i, NumTuples - 10);
+    alloc.thaw();
+}
 
 TEST_F(TableTupleAllocatorTest, TestClearCompactingChunks) {
     using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;


### PR DESCRIPTION
- Added `clear()` to the allocator which, depending on the frozen state, will get to the fastest route to clear out all contents from txn view
- Updates to batch removal API: removed function that returns a vector of pointers; and added a cb arg to `remove_force()`, which gets called *after* all memory movements
 - Found and fixed a couple of NPE bugs