### PR TITLE
ENG-19165-scv-num-files:

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2191,6 +2191,9 @@ TEST CASES
     <condition property="config_verbose" value="-r" else="">
         <isset property="sql_coverage_verbose"/>
     </condition>
+    <condition property="config_maxdetailfiles" value="-d ${maxdetailfiles}" else="">
+        <isset property="maxdetailfiles"/>
+    </condition>
     <condition property="config_reproduce" value="-R ${reproduce}" else="">
         <isset property="reproduce"/>
     </condition>
@@ -2255,6 +2258,7 @@ TEST CASES
         <arg line="${config_invalid}" />
         <arg line="${config_verbose}" />
         <arg file="${config_suite}" />
+        <arg line="${config_maxdetailfiles}" />
         <arg line="${config_reproduce}" />
         <arg file="${sqlcov.dir}" />
         <arg line='"${simpleserver.command}"' />

--- a/tests/sqlcoverage/normalizer/normalizer.py
+++ b/tests/sqlcoverage/normalizer/normalizer.py
@@ -51,12 +51,12 @@ def safecmp(x, y):
 def compare_results(suite, seed, statements_path, hsql_path, jni_path,
                     output_dir, report_invalid, report_all, extra_stats,
                     comparison_database, modified_sql_path,
-                    max_mismatches=0, within_minutes=0, reproducer=0,
-                    ddl_file=None):
+                    max_mismatches=0, max_detail_files=-1, within_minutes=0,
+                    reproducer=0, ddl_file=None):
     """Just calls SQLCoverageReport.generate_html_reports(...).
     """
     return generate_html_reports(suite, seed, statements_path, hsql_path, jni_path,
                                  output_dir, report_invalid, report_all, extra_stats,
                                  comparison_database, modified_sql_path,
-                                 max_mismatches, within_minutes, reproducer,
-                                 ddl_file)
+                                 max_mismatches, max_detail_files, within_minutes,
+                                 reproducer, ddl_file)

--- a/tests/sqlcoverage/normalizer/not-a-normalizer.py
+++ b/tests/sqlcoverage/normalizer/not-a-normalizer.py
@@ -41,12 +41,12 @@ def normalize(table, sql):
 def compare_results(suite, seed, statements_path, hsql_path, jni_path,
                     output_dir, report_invalid, report_all, extra_stats,
                     comparison_database, modified_sql_path,
-                    max_mismatches=0, within_minutes=0, reproducer=0,
-                    ddl_file=None):
+                    max_mismatches=0, max_detail_files=-1, within_minutes=0,
+                    reproducer=0, ddl_file=None):
     """Just calls SQLCoverageReport.generate_html_reports(...).
     """
     return generate_html_reports(suite, seed, statements_path, hsql_path, jni_path,
                                  output_dir, report_invalid, report_all, extra_stats,
                                  comparison_database, modified_sql_path,
-                                 max_mismatches, within_minutes, reproducer,
-                                 ddl_file=None, cntonly=True)
+                                 max_mismatches, max_detail_files, within_minutes,
+                                 reproducer, ddl_file=None, cntonly=True)

--- a/tests/sqlcoverage/normalizer/nulls-lowest-normalizer.py
+++ b/tests/sqlcoverage/normalizer/nulls-lowest-normalizer.py
@@ -44,13 +44,13 @@ def safecmp(x, y):
 def compare_results(suite, seed, statements_path, hsql_path, jni_path,
                     output_dir, report_invalid, report_all, extra_stats,
                     comparison_database, modified_sql_path,
-                    max_mismatches=0, within_minutes=0, reproducer=0,
-                    ddl_file=None):
+                    max_mismatches=0, max_detail_files=-1, within_minutes=0,
+                    reproducer=0, ddl_file=None):
     """Just calls SQLCoverageReport.generate_html_reports(...).
     """
     return generate_html_reports(suite, seed, statements_path, hsql_path, jni_path,
                                  output_dir, report_invalid, report_all, extra_stats,
                                  comparison_database, modified_sql_path,
-                                 max_mismatches, within_minutes, reproducer,
-                                 ddl_file)
+                                 max_mismatches, max_detail_files, within_minutes,
+                                 reproducer, ddl_file)
 


### PR DESCRIPTION
Added new SqlCoverage argument '--maxdetailfiles' (default value 10),
and pass it down to print_section & generate_detail (in
SQLCoverageReport.py), where it is used to limit the number of detail
files (& corresponding reproducer files) created, for each category of
failure (e.g. mismatches vs crashes vs various exception types), for
each test suite. Also, updated generate_html_reports (also in
SQLCoverageReport.py), to better handle 'Connection broken' errors,
which are now considered crashes (not mismatches), and 'timeout:
procedure call took longer than 5 seconds' errors, which should no
longer cause all subsequent results to get out of sync. And removed the
ignore_known_mismatches function (in sql_coverage_test.py), since that
is no longer needed (the maximum number of detail and reproducer files
is small for all test suites now, so no need to take special measures
for the ones that produce known failures).