### PR TITLE
Micro optimization of chunklist search by chunk id

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -345,12 +345,9 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front(
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
-        vassert(m_byAddr.count(super::cbegin()->begin()));
-        vassert(m_byId.count(super::cbegin()->id()));
-        m_byAddr.erase(super::cbegin()->begin());
-        m_byId.erase(super::cbegin()->id());
-        --m_size;
+        remove(super::begin());
         super::pop_front();
+        --m_size;
     }
 }
 
@@ -374,10 +371,7 @@ template<typename Chunk, typename E>
 template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
-            vassert(m_byAddr.count(iter->begin()));
-            vassert(m_byId.count(iter->id()));
-            m_byAddr.erase(iter->begin());
-            m_byId.erase(iter->id());
+            remove(iter);
             --m_size;
         } else {                           // since the last node could be invalidated, recalculate it
             m_back = iter;

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -256,8 +256,61 @@ pair<typename StxCollections::map<K, V, Cmp>::iterator, bool> StxCollections::ma
     return super::insert(value_type{forward<Args>(args)...});
 }
 
-template<typename Chunk, typename E>
-inline pair<bool, typename ChunkList<Chunk, E>::iterator> ChunkList<Chunk, E>::find(void const* k) const {
+template<typename Iter> inline typename ChunkListIdSeeker<Iter, true_type>::iterator
+ChunkListIdSeeker<Iter, true_type>::emplace(id_type id, Iter const& iter) {        // add to rear
+    vassert(super::empty() || (iter->id() == super::back()->id() + 1 && id == iter->id()));
+    super::emplace_back(iter);
+    return prev(end());
+}
+
+template<typename Iter> inline bool ChunkListIdSeeker<Iter, true_type>::contains(id_type id) const noexcept {
+    return ! super::empty() && ! less_rolling(id, super::front()->id()) &&
+        ! less_rolling(super::back()->id(), id);
+}
+
+template<typename Iter> inline typename ChunkListIdSeeker<Iter, true_type>::iterator
+ChunkListIdSeeker<Iter, true_type>::find(id_type id) {
+    if (contains(id)) {
+        vassert(super::at(id - super::front()->id())->id() == id);
+        return next(super::begin(), id - super::front()->id());
+    } else {
+        return end();
+    }
+}
+
+template<typename Iter> inline size_t ChunkListIdSeeker<Iter, true_type>::erase(id_type id) {
+    if (super::empty()) {
+        throw underflow_error("empty deque");
+    } else if (id == super::front()->id()) {
+        super::pop_front();
+    } else if (id == super::back()->id()) {
+        super::pop_back();
+    } else {
+        throw logic_error("ChunkListIdSeeker cannot be used to erase middle node");
+    }
+    return 1;
+}
+
+template<typename Iter> inline Iter&
+ChunkListIdSeeker<Iter, true_type>::get(typename ChunkListIdSeeker<Iter, true_type>::iterator const& iter) {
+    if (iter == super::end()) {
+        throw range_error("ChunkListIdSeeker::get(): iterator out of range");
+    } else {
+        return *iter;
+    }
+}
+
+template<typename Iter> inline Iter&
+ChunkListIdSeeker<Iter, false_type>::get(typename ChunkListIdSeeker<Iter, false_type>::iterator const& iter) {
+    if (iter == super::end()) {
+        throw range_error("ChunkListIdSeeker::get(): iterator out of range");
+    } else {
+        return iter->second;
+    }
+}
+
+template<typename Chunk, typename Compact, typename E>
+inline pair<bool, typename ChunkList<Chunk, Compact, E>::iterator> ChunkList<Chunk, Compact, E>::find(void const* k) const {
     // NOTE: this is a hacky method signature, and hacky way to
     // get around. Normally, we need to overload 2 versions of
     // find: one const-method that returns a const-iterator, and
@@ -266,7 +319,7 @@ inline pair<bool, typename ChunkList<Chunk, E>::iterator> ChunkList<Chunk, E>::f
     // (CompactingChunks::find), and a couple more places to do
     // the same, and TxnLeftBoundary, etc. to maintain two sets
     // of iterators.
-    auto* mutable_this = const_cast<ChunkList<Chunk, E>*>(this);
+    auto* mutable_this = const_cast<ChunkList<Chunk, Compact, E>*>(this);
     auto r = make_pair(! m_byAddr.empty(), mutable_this->end());
     if (r.first) {
         // find first entry whose begin() > k
@@ -278,58 +331,59 @@ inline pair<bool, typename ChunkList<Chunk, E>::iterator> ChunkList<Chunk, E>::f
     return r;
 }
 
-template<typename Chunk, typename E> inline pair<bool, typename ChunkList<Chunk, E>::iterator>
-ChunkList<Chunk, E>::find(id_type id) const {
-    auto* mutable_this = const_cast<ChunkList<Chunk, E>*>(this);
+template<typename Chunk, typename Compact, typename E> inline pair<bool, typename ChunkList<Chunk, Compact, E>::iterator>
+ChunkList<Chunk, Compact, E>::find(id_type id) const {
+    auto* mutable_this = const_cast<ChunkList<Chunk, Compact, E>*>(this);
     auto const& iter = mutable_this->m_byId.find(id);
     auto const found = iter != mutable_this->m_byId.end();
-    return {found, found ? iter->second : mutable_this->end()};
+    return {found, found ? mutable_this->m_byId.get(iter) : mutable_this->end()};
 }
 
-template<typename Chunk, typename E> inline ChunkList<Chunk, E>::ChunkList(size_t tsize) noexcept :
+template<typename Chunk, typename Compact, typename E> inline ChunkList<Chunk, Compact, E>::ChunkList(size_t tsize) noexcept :
 super(), m_tupleSize(tsize), m_chunkSize(::chunkSize(m_tupleSize)) {}
 
-template<typename Chunk, typename E> inline id_type& ChunkList<Chunk, E>::lastChunkId() {
+template<typename Chunk, typename Compact, typename E> inline id_type& ChunkList<Chunk, Compact, E>::lastChunkId() {
     return m_lastChunkId;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::tupleSize() const noexcept {
+template<typename Chunk, typename Compact, typename E> inline size_t ChunkList<Chunk, Compact, E>::tupleSize() const noexcept {
     return m_tupleSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::chunkSize() const noexcept {
+template<typename Chunk, typename Compact, typename E> inline size_t ChunkList<Chunk, Compact, E>::chunkSize() const noexcept {
     return m_chunkSize;
 }
 
-template<typename Chunk, typename E> inline size_t ChunkList<Chunk, E>::size() const noexcept {
+template<typename Chunk, typename Compact, typename E> inline size_t
+ChunkList<Chunk, Compact, E>::size() const noexcept {
     return m_size;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator const&
-ChunkList<Chunk, E>::last() const noexcept {
+template<typename Chunk, typename Compact, typename E> inline typename ChunkList<Chunk, Compact, E>::iterator const&
+ChunkList<Chunk, Compact, E>::last() const noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline typename ChunkList<Chunk, E>::iterator&
-ChunkList<Chunk, E>::last() noexcept {
+template<typename Chunk, typename Compact, typename E> inline typename ChunkList<Chunk, Compact, E>::iterator&
+ChunkList<Chunk, Compact, E>::last() noexcept {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void
-ChunkList<Chunk, E>::add(typename ChunkList<Chunk, E>::iterator const& iter) {
+template<typename Chunk, typename Compact, typename E> inline void
+ChunkList<Chunk, Compact, E>::add(typename ChunkList<Chunk, Compact, E>::iterator const& iter) {
     m_byAddr.emplace(iter->begin(), iter);
     m_byId.emplace(iter->id(), iter);
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::remove(
-        typename ChunkList<Chunk, E>::iterator const& iter) {
+template<typename Chunk, typename Compact, typename E> inline void
+ChunkList<Chunk, Compact, E>::remove(typename ChunkList<Chunk, Compact, E>::iterator const& iter) {
     m_byAddr.erase(iter->begin());
     m_byId.erase(iter->id());
 }
 
-template<typename Chunk, typename E>
-template<typename... Args> inline typename ChunkList<Chunk, E>::iterator
-ChunkList<Chunk, E>::emplace_back(Args&&... args) {
+template<typename Chunk, typename Compact, typename E>
+template<typename... Args> inline typename ChunkList<Chunk, Compact, E>::iterator
+ChunkList<Chunk, Compact, E>::emplace_back(Args&&... args) {
     if (super::empty()) {
         super::emplace_front(forward<Args>(args)...);
         m_back = super::begin();
@@ -341,23 +395,25 @@ ChunkList<Chunk, E>::emplace_back(Args&&... args) {
     return m_back;
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_front() {
+template<typename Chunk, typename Compact, typename E> inline void ChunkList<Chunk, Compact, E>::pop_front() {
     if (super::empty()) {
         throw underflow_error("pop_front() called on empty chunk list");
     } else {
-        remove(super::begin());
+        m_byId.erase(super::begin()->id());
+        m_byAddr.erase(super::begin()->begin());
         super::pop_front();
         --m_size;
     }
 }
 
-template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back() {
+template<typename Chunk, typename Compact, typename E> inline void ChunkList<Chunk, Compact, E>::pop_back() {
     if (super::empty()) {
         throw underflow_error("pop_back() called on empty chunk list");
     } else {
         auto const iter = find(m_back->id() - 1);
         if (iter.first) {            // original list contains more than 1 nodes
-            remove(m_back);
+            m_byId.erase(m_back->id());
+            m_byAddr.erase(m_back->begin());
             super::erase_after(m_back = iter.second);
             --lastChunkId();
             --m_size;
@@ -367,8 +423,8 @@ template<typename Chunk, typename E> inline void ChunkList<Chunk, E>::pop_back()
     }
 }
 
-template<typename Chunk, typename E>
-template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
+template<typename Chunk, typename Compact, typename E>
+template<typename Pred> inline void ChunkList<Chunk, Compact, E>::remove_if(Pred pred) {
     for(auto iter = begin(); iter != end(); ++iter) {
         if (pred(*iter)) {
             remove(iter);
@@ -380,8 +436,8 @@ template<typename Pred> inline void ChunkList<Chunk, E>::remove_if(Pred pred) {
     super::remove_if(pred);
 }
 
-template<typename Chunk, typename E> inline void
-ChunkList<Chunk, E>::clear() noexcept {
+template<typename Chunk, typename Compact, typename E> inline void
+ChunkList<Chunk, Compact, E>::clear() noexcept {
     m_byId.clear();
     m_byAddr.clear();
     super::clear();
@@ -394,7 +450,7 @@ template<typename C, typename E> inline
 NonCompactingChunks<C, E>::NonCompactingChunks(size_t tupleSize) noexcept : list_type(tupleSize) {}
 
 template<typename C, typename E> inline size_t NonCompactingChunks<C, E>::chunks() const noexcept {
-    return ChunkList<C>::size();
+    return ChunkList<C, false_type>::size();
 }
 
 template<typename C, typename E> inline bool NonCompactingChunks<C, E>::empty() const noexcept {
@@ -523,21 +579,21 @@ inline typename CompactingStorageTrait::list_type::iterator CompactingStorageTra
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(this), m_txnFirstChunk(*this), m_batched(*this) {}
 
-inline CompactingChunks::TxnLeftBoundary::TxnLeftBoundary(ChunkList<CompactingChunk>& chunks) noexcept :
+inline CompactingChunks::TxnLeftBoundary::TxnLeftBoundary(ChunkList<CompactingChunk, true_type>& chunks) noexcept :
     m_chunks(chunks), m_iter(chunks.end()), m_next(nullptr) {
     vassert(m_chunks.empty());
 }
 
-inline typename ChunkList<CompactingChunk>::iterator const& CompactingChunks::TxnLeftBoundary::iterator() const noexcept {
+inline typename ChunkList<CompactingChunk, true_type>::iterator const& CompactingChunks::TxnLeftBoundary::iterator() const noexcept {
     return m_iter;
 }
 
-inline typename ChunkList<CompactingChunk>::iterator& CompactingChunks::TxnLeftBoundary::iterator() noexcept {
+inline typename ChunkList<CompactingChunk, true_type>::iterator& CompactingChunks::TxnLeftBoundary::iterator() noexcept {
     return m_iter;
 }
 
-inline typename ChunkList<CompactingChunk>::iterator const& CompactingChunks::TxnLeftBoundary::iterator(
-        typename ChunkList<CompactingChunk>::iterator const& iter) noexcept {
+inline typename ChunkList<CompactingChunk, true_type>::iterator const& CompactingChunks::TxnLeftBoundary::iterator(
+        typename ChunkList<CompactingChunk, true_type>::iterator const& iter) noexcept {
     m_next = m_chunks.end() == iter ? nullptr : iter->next();
     return m_iter = iter;
 }
@@ -833,7 +889,7 @@ inline typename CompactingChunks::TxnLeftBoundary& CompactingChunks::beginTxn() 
     return m_txnFirstChunk;
 }
 
-inline CompactingChunks::FrozenTxnBoundaries::FrozenTxnBoundaries(ChunkList<CompactingChunk> const& l) noexcept {
+inline CompactingChunks::FrozenTxnBoundaries::FrozenTxnBoundaries(ChunkList<CompactingChunk, true_type> const& l) noexcept {
     if (! l.empty()) {
         m_left = *l.begin();
         m_right = *l.last();
@@ -1364,7 +1420,7 @@ struct ElasticIterator_refresh<I, ElasticIterator, true_type> {
     inline void operator()(ElasticIterator& iter, bool& isEmpty, id_type& chunkId,
             typename I::chunk_type const& storage,
             typename I::chunk_type::iterator const& last, position_type const& boundary,
-            ChunkList<CompactingChunk>::const_iterator& chunkIter,
+            ChunkList<CompactingChunk, true_type>::const_iterator& chunkIter,
             void const*& cursor) const {
         if (isEmpty) {                             // last time checked, allocator was empty
             isEmpty = storage.empty();             // check again,

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -82,6 +82,15 @@ namespace voltdb {
         };
 
         /**
+         * Data structure backing up id map in chunk list, used
+         * for finding chunk id => chunk list iterator. Can be
+         * either std::map (by default), or std::deque.
+         */
+        enum class id_map_type : char {
+            std_map, std_deque
+        };
+
+        /**
          * Global switch of collections type
          */
         constexpr static collections_enum_type const
@@ -293,6 +302,44 @@ namespace voltdb {
             }
         };
 
+        template<typename Iter, typename Compact> class ChunkListIdSeeker {};
+        template<typename Iter> class ChunkListIdSeeker<Iter, false_type> :
+            private Collections<collections_type>::template map<id_type, Iter, less_rolling_type<id_type>> {
+            using super = typename Collections<collections_type>::template map<id_type, Iter, less_rolling_type<id_type>>;
+        public:
+            using iterator = typename super::iterator;
+            ChunkListIdSeeker() noexcept = default;
+            Iter& get(iterator const&);
+            using super::emplace;
+            using super::erase;
+            using super::find;
+            using super::clear;
+            using super::end;
+        };
+
+        template<typename Iter> class ChunkListIdSeeker<Iter, true_type> : private deque<Iter> {
+            using super = deque<Iter>;
+            using iterator = typename super::iterator;
+            bool contains(id_type) const noexcept;
+        public:
+            ChunkListIdSeeker() = default;
+            iterator emplace(id_type, Iter const&);
+            size_t erase(id_type);
+            iterator find(id_type);
+            Iter& get(iterator const&);
+            using super::end; using super::clear;
+        };
+
+        /**
+         * Global switch of id_map type
+         */
+        constexpr static bool using_std_map_for_id_map_type = true;
+
+        template<typename Iter, typename Compact>
+        using id_seeker_type = ChunkListIdSeeker<Iter, integral_constant<bool, using_std_map_for_id_map_type ?
+                  false :                              // always using std::map<id_type, iterator>
+                  Compact::value>>;                    // using std::deque<iterator> when the chunk list is compacting
+
         /**
          * Homogeneous-sized singly-linked list of memory holders
          * (i.e. ChunkHolder).
@@ -301,7 +348,7 @@ namespace voltdb {
          * std::forward_list<ChunkHolder>, search by void* and by chunk id;
          * and limit insertion to tail and erase to front.
          */
-        template<typename Chunk,
+        template<typename Chunk, typename Compact,
             typename = typename enable_if<is_base_of<ChunkHolder<>, Chunk>::value>::type>
         class ChunkList : private forward_list<Chunk> {
             using super = forward_list<Chunk>;
@@ -310,10 +357,9 @@ namespace voltdb {
             size_t m_size = 0;
             id_type m_lastChunkId = 0;
             typename super::iterator m_back = super::end();
-            typename Collections<collections_type>::template
-                map<void const*, typename super::iterator> m_byAddr{};
-            typename Collections<collections_type>::template
-                map<id_type, typename super::iterator, less_rolling_type<id_type>> m_byId{};
+            typename Collections<collections_type>::template map<void const*, typename super::iterator>
+                m_byAddr{};
+            id_seeker_type<typename super::iterator, Compact> m_byId{};
             void add(typename super::iterator const&);
             void remove(typename super::iterator const&);
         protected:
@@ -370,7 +416,7 @@ namespace voltdb {
          */
         template<typename Chunk,
             typename = typename enable_if<is_base_of<ChunkHolder<>, Chunk>::value>::type>
-        class NonCompactingChunks final : private ChunkList<Chunk> {
+        class NonCompactingChunks final : private ChunkList<Chunk, false_type> {
             template<typename Chunks, typename Tag, typename E> friend class IterableTableTupleChunks;
             static auto constexpr CHUNK_REMOVAL_THRESHOLD = 64lu;    // iterate list and remove empty chunks when there are so many
             size_t m_emptyChunks = 0;                  // amortize chunk removal
@@ -390,7 +436,7 @@ namespace voltdb {
             void free(void*);
             bool empty() const noexcept;               // NOTE: with batched lazy chunk removal (CHUNK_REMOVAL_THRESHOLD), this cannot check on ChunkList emptiness
             id_type id() const noexcept { return 0; }  // dummy function
-            using list_type = ChunkList<Chunk>;
+            using list_type = ChunkList<Chunk, false_type>;
             using typename list_type::iterator; using typename list_type::const_iterator;
             using list_type::clear; using list_type::begin;
             using list_type::tupleSize; using list_type::chunkSize;
@@ -417,7 +463,7 @@ namespace voltdb {
          * Shrink-directional-dependent book-keeping
          */
         class CompactingStorageTrait {
-            using list_type = ChunkList<CompactingChunk>;
+            using list_type = ChunkList<CompactingChunk, true_type>;
             /**
              * Linearized access order depending on shrink
              * direction, to ensure that chunks are accessed in
@@ -452,10 +498,10 @@ namespace voltdb {
  * Needed for maps keyed on iterator, or chunk.
  * Of course, compared items must belong to the same list.
  */
-namespace std {
+namespace std {                                        // TODO: needed?
     using namespace voltdb::storage;
-    template<> struct less<typename ChunkList<CompactingChunk>::iterator> {
-        using value_type = typename ChunkList<CompactingChunk>::iterator;
+    template<> struct less<typename ChunkList<CompactingChunk, true_type>::iterator> {
+        using value_type = typename ChunkList<CompactingChunk, true_type>::iterator;
         inline bool operator()(value_type const& lhs, value_type const& rhs) const noexcept {
             // Rolling number comparison, assuming that neither is end().
             return less_rolling(lhs->id(), rhs->id());
@@ -529,18 +575,19 @@ namespace voltdb {
          * (creates new chunk if necessary); all free operations move
          * the non-empty allocation from the head to freed space.
          */
-        class CompactingChunks : private ChunkList<CompactingChunk>, private CompactingStorageTrait {
+        class CompactingChunks : private ChunkList<CompactingChunk, true_type>, private CompactingStorageTrait {
         public:
+            using Compact = true_type;
             class TxnLeftBoundary final {
-                ChunkList<CompactingChunk> const& m_chunks;
-                typename ChunkList<CompactingChunk>::iterator m_iter;
+                ChunkList<CompactingChunk, Compact> const& m_chunks;
+                typename ChunkList<CompactingChunk, Compact>::iterator m_iter;
                 void const* m_next;
             public:
-                TxnLeftBoundary(ChunkList<CompactingChunk>&) noexcept;
-                typename ChunkList<CompactingChunk>::iterator const& iterator() const noexcept;
-                typename ChunkList<CompactingChunk>::iterator& iterator() noexcept;
-                typename ChunkList<CompactingChunk>::iterator const&
-                    iterator(ChunkList<CompactingChunk>::iterator const&) noexcept;
+                TxnLeftBoundary(ChunkList<CompactingChunk, Compact>&) noexcept;
+                typename ChunkList<CompactingChunk, Compact>::iterator const& iterator() const noexcept;
+                typename ChunkList<CompactingChunk, Compact>::iterator& iterator() noexcept;
+                typename ChunkList<CompactingChunk, Compact>::iterator const&
+                    iterator(ChunkList<CompactingChunk, Compact>::iterator const&) noexcept;
                 void const*& next() noexcept;
                 bool empty() const noexcept;
             };
@@ -548,14 +595,14 @@ namespace voltdb {
                 position_type m_left{}, m_right{};
             public:
                 FrozenTxnBoundaries() noexcept = default;
-                FrozenTxnBoundaries(ChunkList<CompactingChunk> const&) noexcept;
+                FrozenTxnBoundaries(ChunkList<CompactingChunk, Compact> const&) noexcept;
                 position_type const& left() const noexcept;
                 position_type const& right() const noexcept;
                 void clear();
             };
         private:
             template<typename, typename, typename> friend struct IterableTableTupleChunks;
-            using list_type = ChunkList<CompactingChunk>;
+            using list_type = ChunkList<CompactingChunk, Compact>;
             // equivalent to "table id", to ensure injection relation to rw iterator
             id_type const m_id = ChunksIdValidator::instance().id();
             char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
@@ -607,7 +654,6 @@ namespace voltdb {
             using list_type::last;
             template<typename Remove_cb> void clear(Remove_cb const&);
         public:
-            using Compact = true_type;
             // for use in HookedCompactingChunks::remove() [batch mode]:
             using DelayedRemover_movments_type = typename list_type::collections::map<void*, void*> const&;
             CompactingChunks(size_t tupleSize) noexcept;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1426,6 +1426,23 @@ void testRemovesFromEnds(size_t batch) {
                     return ++i >= NumTuples - batch;
                 });
         assert(i == NumTuples - batch);
+        // remove everything, add something back
+        if (! alloc.empty()) {
+            for (--i; i > 0; --i) {
+                alloc.remove(dir, addresses[i]);
+            }
+            alloc.remove(dir, addresses[0]);
+            assert(alloc.empty());
+        }
+        for (i = 0; i < NumTuples; ++i) {
+            memcpy(alloc.allocate(), gen.get(), TupleSize);
+        }
+        fold<typename IterableTableTupleChunks<Alloc, truth>::const_iterator>(
+                static_cast<Alloc const&>(alloc),
+                [&i](void const* p) {
+                    assert(Gen::same(p, i++));
+                });
+        assert(i == NumTuples * 2);
     }
 }
 


### PR DESCRIPTION
Micro-optimization on the map type from chunk id to chunk list's iterator on compacting chunk only, by replacing `std::map` to `std::deque`, so that its search operation decreases from O(log(n)) to O(1).

Added a switch to enable this micro-optimization (disabled by default).