### PR TITLE
Add debug info for allocator writes

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -320,15 +320,17 @@ inline pair<bool, typename ChunkList<Chunk, Compact, E>::iterator> ChunkList<Chu
     // the same, and TxnLeftBoundary, etc. to maintain two sets
     // of iterators.
     auto* mutable_this = const_cast<ChunkList<Chunk, Compact, E>*>(this);
-    auto const not_found = make_pair(false, mutable_this->end());
     if (! m_byAddr.empty()) {
         // find first entry whose begin() > k
-        auto iter = prev(mutable_this->m_byAddr.upper_bound(k));
-        if (iter != mutable_this->m_byAddr.end()) {
-            return {true, iter->second};
+        auto iter = mutable_this->m_byAddr.upper_bound(k);
+        if (iter != mutable_this->m_byAddr.begin()) {
+            iter = prev(iter);
+            if (iter != mutable_this->m_byAddr.end()) {
+                return {true, iter->second};
+            }
         }
     }
-    return not_found;
+    return {false, mutable_this->end()};
 }
 
 template<typename Chunk, typename Compact, typename E> inline pair<bool, typename ChunkList<Chunk, Compact, E>::iterator>

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -835,6 +835,8 @@ namespace voltdb {
             void remove_add(void*);
             size_t remove_force(function<void(vector<pair<void*, void*>> const&)> const&);
             void clear();
+            // Debugging aid, only prints in debug build
+            string info(void const*) const;
         };
 
         /**

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1788,7 +1788,7 @@ TEST_F(TableTupleAllocatorTest, TestDebugInfo) {
     for (i = 0; i < NumTuples; ++i) {
         addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
     }
-    ASSERT_EQ("Cannot find address (nil)\n", alloc.info(nullptr));
+    ASSERT_TRUE(alloc.info(nullptr).substr(0, 20) == "Cannot find address ");
     string expected_prefix("Address "),
            actual = alloc.info(addresses[0]);
     expected_prefix

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1771,6 +1771,41 @@ TEST_F(TableTupleAllocatorTest, TestClearFreeCompactingChunks) {
     ASSERT_EQ(NumTuples, i);
 }
 
+string address(void const* p) {
+    static ostringstream oss;
+    oss<<p;
+    return oss.str();
+}
+
+// test printing of debug info
+TEST_F(TableTupleAllocatorTest, TestDebugInfo) {
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    using Gen = StringGen<TupleSize>;
+    Alloc alloc(TupleSize);
+    array<void const*, NumTuples> addresses;
+    Gen gen;
+    size_t i;
+    for (i = 0; i < NumTuples; ++i) {
+        addresses[i] = memcpy(alloc.allocate(), gen.get(), TupleSize);
+    }
+    ASSERT_EQ("Cannot find address (nil)\n", alloc.info(nullptr));
+    string expected_prefix("Address "),
+           actual = alloc.info(addresses[0]);
+    expected_prefix
+        .append(address(addresses[0]))
+        .append(" found at chunk 0, offset 0, ");
+    ASSERT_EQ(expected_prefix, actual.substr(0, expected_prefix.length()));
+    // freeze, remove 1 + AllocsPerChunk tuples from head and
+    // tail each
+    alloc.template freeze<truth>();
+    for (i = 0; i <= AllocsPerChunk; ++i) {
+        alloc.remove(const_cast<void*>(addresses[i]));
+        alloc.remove(CompactingChunks::remove_direction::from_tail, addresses[NumTuples - i - 1]);
+    }
+    ASSERT_EQ(NumTuples - 2 * AllocsPerChunk - 2, alloc.size());
+    puts(alloc.info(addresses[0]).c_str());
+}
+
 #endif
 
 int main() {


### PR DESCRIPTION
to help debugging system tests.
Added a new method that returns the information related to a particular memory address and the allocator; and a bunch of `VOLT_TRACE` statements that prints all write-op to the terminal.
Tune which information you need, by changing the log level (`VOLT_DEBUG`), and/or project build option (`-DVOLT_LOG_LEVEL`).

*(And, accidentally, found & fixed a bug)*