### PR TITLE
ENG 19130 use init --license or -l to stage license file before database starts

### DIFF
--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -43,7 +43,7 @@ def _listOfGlobsToFiles(pathGlobs):
                            'Specifies a list of schema files or paths with wildcards, comma separated, containing the data definition (as SQL statements) to be loaded when starting the database.'),
         VOLT.StringListOption('-j', '--classes', 'classes_jarfiles',
                           'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.'),
-        VOLT.StringListOption('-l', '--license', 'license', 'specify the location of the license file')
+        VOLT.StringOption('-l', '--license', 'license', 'specify the location of the license file')
     ),
     description = 'Initializes a new, empty database.'
 )

--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -42,7 +42,8 @@ def _listOfGlobsToFiles(pathGlobs):
         VOLT.StringListOption('-s', '--schema', 'schemas',
                            'Specifies a list of schema files or paths with wildcards, comma separated, containing the data definition (as SQL statements) to be loaded when starting the database.'),
         VOLT.StringListOption('-j', '--classes', 'classes_jarfiles',
-                          'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.')
+                          'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.'),
+        VOLT.StringListOption('-l', '--license', 'license', 'specify the location of the license file')
     ),
     description = 'Initializes a new, empty database.'
 )
@@ -61,6 +62,8 @@ def init(runner):
     if runner.opts.classes_jarfiles:
         runner.args.append('classes')
         runner.args.append(_listOfGlobsToFiles(runner.opts.classes_jarfiles))
+    if runner.opts.license:
+        runner.args.extend(['license', runner.opts.license])
 
     args = runner.args
     runner.java_execute(VoltDB, None, *args)

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -85,6 +85,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.aeonbits.owner.ConfigFactory;
 import org.apache.cassandra_voltpatches.GCInspector;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.DailyRollingFileAppender;
@@ -911,55 +912,53 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             // Check license availability
             // All above - not for init
             String edition = "Community Edition";
-            if (config.m_startAction != StartAction.INITIALIZE) {
-                consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_StartupString.name(), null);
-                // load license API
-                if (config.m_pathToLicense == null) {
-                    m_licenseApi = MiscUtils.licenseApiFactory();
-                    if (m_licenseApi == null) {
-                        hostLog.fatal("Unable to open license file in default directories");
-                    }
-                } else {
-                    m_licenseApi = MiscUtils.licenseApiFactory(config.m_pathToLicense);
-                    if (m_licenseApi == null) {
-                        hostLog.fatal("Unable to open license file in provided path: " + config.m_pathToLicense);
-                    }
-                }
-
+            consoleLog.l7dlog( Level.INFO, LogKeys.host_VoltDB_StartupString.name(), null);
+            // load license API
+            if (config.m_pathToLicense == null) {
+                m_licenseApi = MiscUtils.licenseApiFactory();
                 if (m_licenseApi == null) {
-                    hostLog.fatal("Please contact sales@voltdb.com to request a license.");
-                    VoltDB.crashLocalVoltDB(
-                            "Failed to initialize license verifier. " + "See previous log message for details.", false,
-                            null);
+                    hostLog.fatal("Unable to open license file in default directories");
                 }
-
-                if (config.m_isEnterprise) {
-                    if (m_licenseApi.isEnterprise()) {
-                        edition = "Enterprise Edition";
-                    }
-                    if (m_licenseApi.isPro()) {
-                        edition = "Pro Edition";
-                    }
-                    if (m_licenseApi.isEnterpriseTrial()) {
-                        edition = "Enterprise Edition";
-                    }
-                    if (m_licenseApi.isProTrial()) {
-                        edition = "Pro Edition";
-                    }
-                    if (m_licenseApi.isAWSMarketplace()) {
-                        edition = "AWS Marketplace Edition";
-                    }
+            } else {
+                m_licenseApi = MiscUtils.licenseApiFactory(config.m_pathToLicense);
+                if (m_licenseApi == null) {
+                    hostLog.fatal("Unable to open license file in provided path: " + config.m_pathToLicense);
                 }
+            }
 
-                // this also prints out the license type on the console
-                readBuildInfo(edition);
+            if (m_licenseApi == null) {
+                hostLog.fatal("Please contact sales@voltdb.com to request a license.");
+                VoltDB.crashLocalVoltDB(
+                        "Failed to initialize license verifier. " + "See previous log message for details.", false,
+                        null);
+            }
 
-                // print out the licensee on the license
-                if (config.m_isEnterprise) {
-                    String licensee = m_licenseApi.licensee();
-                    if ((licensee != null) && (licensee.length() > 0)) {
-                        consoleLog.info(String.format("Licensed to: %s", licensee));
-                    }
+            if (config.m_isEnterprise) {
+                if (m_licenseApi.isEnterprise()) {
+                    edition = "Enterprise Edition";
+                }
+                if (m_licenseApi.isPro()) {
+                    edition = "Pro Edition";
+                }
+                if (m_licenseApi.isEnterpriseTrial()) {
+                    edition = "Enterprise Edition";
+                }
+                if (m_licenseApi.isProTrial()) {
+                    edition = "Pro Edition";
+                }
+                if (m_licenseApi.isAWSMarketplace()) {
+                    edition = "AWS Marketplace Edition";
+                }
+            }
+
+            // this also prints out the license type on the console
+            readBuildInfo(edition);
+
+            // print out the licensee on the license
+            if (config.m_isEnterprise) {
+                String licensee = m_licenseApi.licensee();
+                if ((licensee != null) && (licensee.length() > 0)) {
+                    consoleLog.info(String.format("Licensed to: %s", licensee));
                 }
             }
 
@@ -1013,6 +1012,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                     CatalogUtil.addExportConfigToDRConflictsTable(readDepl.deployment.getExport());
                 }
                 stageDeploymentFileForInitialize(config, readDepl.deployment);
+                if (config.m_pathToLicense != null) {
+                    stageLicenseFile(config.m_voltdbRoot, config.m_pathToLicense);
+                }
                 stageSchemaFiles(config,
                         readDepl.deployment.getDr() != null &&
                                 DrRoleType.XDCR.equals(readDepl.deployment.getDr().getRole()));
@@ -2574,6 +2576,23 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         // Save cluster settings properties derived from the deployment file
         ClusterSettings.create(CatalogUtil.asClusterSettingsMap(dt)).store();
     }
+
+    private void stageLicenseFile(File vdbroot, String pathToLicense) {
+        File licenseF = new VoltFile(pathToLicense);
+        String path = null;
+        try {
+            path = vdbroot.getCanonicalPath();
+        } catch (IOException e) {
+            VoltDB.crashLocalVoltDB("Unable to get voltdbroot path", false, e);
+        }
+        File destF = new VoltFile(path + File.separator + licenseF.getName());
+        try {
+            FileUtils.copyFile(licenseF, destF);
+        } catch (IOException e) {
+            VoltDB.crashLocalVoltDB("Unable to stage license file to " + vdbroot, false, e);
+        }
+    }
+
 
     private void stageSchemaFiles(Configuration config, boolean isXCDR) {
         if (config.m_userSchemas == null && config.m_stagedClassesPaths == null) {

--- a/src/frontend/org/voltdb/ServerThread.java
+++ b/src/frontend/org/voltdb/ServerThread.java
@@ -190,6 +190,12 @@ public class ServerThread extends Thread {
         }
     }
 
+    // For TestStartActionWithLicenseOption only, that test want to validate given
+    // license file instead of the default file.
+    public void ignoreDefaultLicense() {
+        m_config.m_pathToLicense = null;
+    }
+
     /**
      * For tests only, mostly with ServerThread or LocalCluster:
      *

--- a/src/frontend/org/voltdb/common/Constants.java
+++ b/src/frontend/org/voltdb/common/Constants.java
@@ -85,4 +85,5 @@ public class Constants
 
     public static final String DBROOT = "voltdbroot";
     public static final String CONFIG_DIR = "config";
+    public static final String LICENSE_FILE_NAME = "license.xml";
 }

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -53,6 +53,7 @@ public interface NodeSettings extends Settings {
     public final static String LARGE_QUERY_SWAP_PATH_KEY = "org.voltdb.path.large_query_swap";
     public final static String LOCAL_SITES_COUNT_KEY = "org.voltdb.local_sites_count";
     public final static String LOCAL_ACTIVE_SITES_COUNT_KEY = "org.voltdb.local_active_sites_count";
+    public final static String LICENSE_PATH_KEY = "org.voltdb.path.license";
 
     @Key(VOLTDBROOT_PATH_KEY)
     public VoltFile getVoltDBRoot();
@@ -88,6 +89,9 @@ public interface NodeSettings extends Settings {
     @DefaultValue("8")
     public int getLocalActiveSitesCount();
 
+    @Key(LICENSE_PATH_KEY)
+    public File getLicense();
+
     public static NodeSettings create(Map<?, ?>...imports) {
         return ConfigFactory.create(NodeSettings.class, imports);
     }
@@ -117,6 +121,7 @@ public interface NodeSettings extends Settings {
                 .put(DR_OVERFLOW_PATH_KEY, resolve(getDROverflow()))
                 .put(LARGE_QUERY_SWAP_PATH_KEY, resolve(getLargeQuerySwap()))
                 .put(EXPORT_CURSOR_PATH_KEY, resolve(getExportCursor()))
+                .put(LICENSE_PATH_KEY, resolve(getLicense()))
                 .build();
     }
 

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -53,7 +53,6 @@ public interface NodeSettings extends Settings {
     public final static String LARGE_QUERY_SWAP_PATH_KEY = "org.voltdb.path.large_query_swap";
     public final static String LOCAL_SITES_COUNT_KEY = "org.voltdb.local_sites_count";
     public final static String LOCAL_ACTIVE_SITES_COUNT_KEY = "org.voltdb.local_active_sites_count";
-    public final static String LICENSE_PATH_KEY = "org.voltdb.path.license";
 
     @Key(VOLTDBROOT_PATH_KEY)
     public VoltFile getVoltDBRoot();
@@ -89,9 +88,6 @@ public interface NodeSettings extends Settings {
     @DefaultValue("8")
     public int getLocalActiveSitesCount();
 
-    @Key(LICENSE_PATH_KEY)
-    public File getLicense();
-
     public static NodeSettings create(Map<?, ?>...imports) {
         return ConfigFactory.create(NodeSettings.class, imports);
     }
@@ -121,7 +117,6 @@ public interface NodeSettings extends Settings {
                 .put(DR_OVERFLOW_PATH_KEY, resolve(getDROverflow()))
                 .put(LARGE_QUERY_SWAP_PATH_KEY, resolve(getLargeQuerySwap()))
                 .put(EXPORT_CURSOR_PATH_KEY, resolve(getExportCursor()))
-                .put(LICENSE_PATH_KEY, resolve(getLicense()))
                 .build();
     }
 

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -55,6 +55,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
 import org.voltdb.client.Client;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.common.Constants;
 import org.voltdb.compiler.deploymentfile.DrRoleType;
 import org.voltdb.iv2.TxnEgo;
 import org.voltdb.licensetool.LicenseApi;
@@ -72,7 +73,7 @@ import com.google_voltpatches.common.net.HostAndPort;
 public class MiscUtils {
     private static final VoltLogger hostLog = new VoltLogger("HOST");
     private static final VoltLogger consoleLog = new VoltLogger("CONSOLE");
-    private static final String licenseFileName = "license.xml";
+
     private static final boolean assertsEnabled;
 
     static {
@@ -306,30 +307,42 @@ public class MiscUtils {
      * For enterprise edition, look in default locations ./, ~/, jar file directory
      * @return a valid API for community and pro editions, or null on error.
      */
-    public static LicenseApi licenseApiFactory()
+    public static LicenseApi licenseApiFactory(File voltdbRoot)
     {
-        String licensePath = System.getProperty("user.dir") + "/" + licenseFileName;
-        LicenseApi licenseApi = MiscUtils.licenseApiFactory(licensePath);
+        String licensePath = null;
+        LicenseApi licenseApi = null;
+        // search database root directory as first priority
+        File licenseF = new VoltFile(voltdbRoot, Constants.LICENSE_FILE_NAME);
+        licensePath = licenseF.getAbsolutePath();
+        hostLog.info("Searching for license file located " + licensePath);
+        licenseApi = MiscUtils.licenseApiFactory(licensePath);
+        if (licenseApi != null) {
+            return licenseApi;
+        }
+        // then search current directory
+        licensePath = System.getProperty("user.dir") + File.separator + Constants.LICENSE_FILE_NAME;
+        licenseApi = MiscUtils.licenseApiFactory(licensePath);
         if (licenseApi == null) {
             try {
                 // Get location of jar file
                 String jarLoc = VoltDB.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
                 // Strip of file name
-                int lastSlashOff = jarLoc.lastIndexOf("/");
+                int lastSlashOff = jarLoc.lastIndexOf(File.separator);
                 if (lastSlashOff == -1) {
                     // Jar is at root directory
-                    licensePath = "/" + licenseFileName;
+                    licensePath = File.separator + Constants.LICENSE_FILE_NAME;
                 }
                 else {
-                    licensePath = jarLoc.substring(0, lastSlashOff+1) + licenseFileName;
+                    licensePath = jarLoc.substring(0, lastSlashOff+1) + Constants.LICENSE_FILE_NAME;
                 }
                 licenseApi = MiscUtils.licenseApiFactory(licensePath);
             }
             catch (URISyntaxException e) {
             }
         }
+        // then search user home directory
         if (licenseApi == null) {
-            licensePath = System.getProperty("user.home") + "/" + licenseFileName;
+            licensePath = System.getProperty("user.home") + File.separator + Constants.LICENSE_FILE_NAME;
             licenseApi = MiscUtils.licenseApiFactory(licensePath);
         }
         if (licenseApi != null) {

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -304,7 +304,8 @@ public class MiscUtils {
 
     /**
      * Instantiate the license api impl based on enterprise/community editions
-     * For enterprise edition, look in default locations ./, ~/, jar file directory
+     * For enterprise edition, look in default locations voltdbroot, ./, ~/ and
+     * jar file directory.
      * @return a valid API for community and pro editions, or null on error.
      */
     public static LicenseApi licenseApiFactory(File voltdbRoot)

--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -57,12 +57,12 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.InMemoryJarfile;
 import org.voltdb.utils.VoltFile;
+import org.voltdb_testprocs.fakeusecase.greetings.GetGreetingBase;
 
 import com.google_voltpatches.common.base.Joiner;
 import com.google_voltpatches.common.io.CharStreams;
 import com.google_voltpatches.common.reflect.ClassPath;
 import com.google_voltpatches.common.reflect.ClassPath.ClassInfo;
-import org.voltdb_testprocs.fakeusecase.greetings.GetGreetingBase;
 
 /** Tests starting the server with init + start without a schema,
  * and 'init --schema --classes'.


### PR DESCRIPTION
1. add a --license argument to the voltdb init command. The specified license file is copied into the database root directory.
2. Deprecate the use of --license on the voltdb start command.(For v10.0 release?)
3. Add the database root directory as the first location searched for the license at startup (but continue to look in the existing list of directories: working directory, home directory, and voltdb software root).

Unit tests in https://github.com/VoltDB/pro/pull/3043