### PR TITLE
CompoundErrors: Backport rename of error collector

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -600,9 +600,9 @@ DISTRIBUTION
             <include name="src/frontend/org/voltdb/task/Interval.java" />
             <include name="src/frontend/org/voltdb/task/IntervalGenerator.java" />
             <include name="src/frontend/org/voltdb/task/ScheduledAction.java" />
-            <include name="src/frontend/org/voltdb/task/TaskValidationErrors.java" />
             <include name="src/frontend/org/voltdb/task/TaskScope.java" />
             <include name="src/frontend/org/voltdb/task/TaskHelper.java" />
+            <include name="src/frontend/org/voltdb/utils/CompoundErrors.java" />
         </fileset>
     </javadoc>
 

--- a/src/frontend/org/voltdb/task/DurationIntervalGenerator.java
+++ b/src/frontend/org/voltdb/task/DurationIntervalGenerator.java
@@ -19,6 +19,8 @@ package org.voltdb.task;
 
 import java.util.concurrent.TimeUnit;
 
+import org.voltdb.utils.CompoundErrors;
+
 /**
  * Simple abstract class to handle the common duration parsing and validation of schedulers which use a static duration
  * in the form of &lt;interval&gt; &lt;timeUnit&gt;
@@ -28,7 +30,7 @@ abstract class DurationIntervalGenerator implements IntervalGenerator {
     long m_durationNs = -1;
 
     public static String validateParameters(TaskHelper helper, int interval, String timeUnit) {
-        TaskValidationErrors errors = new TaskValidationErrors();
+        CompoundErrors errors = new CompoundErrors();
         if (interval <= 0) {
             errors.addErrorMessage("Interval must be greater than 0: " + interval);
         }

--- a/src/frontend/org/voltdb/task/SingleProcGenerator.java
+++ b/src/frontend/org/voltdb/task/SingleProcGenerator.java
@@ -17,6 +17,8 @@
 
 package org.voltdb.task;
 
+import org.voltdb.utils.CompoundErrors;
+
 /**
  * Simple implementation of a {@link ActionGenerator} which always returns the same procedure to run with the same
  * parameters
@@ -26,7 +28,7 @@ public final class SingleProcGenerator implements ActionGenerator {
     private boolean m_isReadOnly;
 
     public static String validateParameters(TaskHelper helper, String procedure, Object... procedureParameters) {
-        TaskValidationErrors errors = new TaskValidationErrors();
+        CompoundErrors errors = new CompoundErrors();
         helper.validateProcedure(errors, true, procedure, procedureParameters);
         return errors.getErrorMessage();
     }

--- a/src/frontend/org/voltdb/task/TaskHelper.java
+++ b/src/frontend/org/voltdb/task/TaskHelper.java
@@ -17,6 +17,8 @@
 
 package org.voltdb.task;
 
+import org.voltdb.utils.CompoundErrors;
+
 /**
  * Helper interface passed to {@link IntervalGenerator}, {@link ActionGenerator} and {@link ActionScheduler} instances for
  * calling in to the volt system to perform logging, validation and other operations
@@ -113,13 +115,13 @@ public interface TaskHelper {
      * <p>
      * Note: parameter validation might not work for system procedures
      *
-     * @param errors                   {@link TaskValidationErrors} instance to collect errors
+     * @param errors                   {@link CompoundErrors} instance to collect errors
      * @param restrictProcedureByScope If true type of procedures will be restricted. See
      *                                 {@link ActionScheduler#restrictProcedureByScope()}
      * @param procedureName            Name of procedure to validate
      * @param parameters               that will be passed to {@code name}
      */
-    void validateProcedure(TaskValidationErrors errors, boolean restrictProcedureByScope, String procedureName,
+    void validateProcedure(CompoundErrors errors, boolean restrictProcedureByScope, String procedureName,
             Object[] parameters);
 
     /**

--- a/src/frontend/org/voltdb/task/TaskHelperImpl.java
+++ b/src/frontend/org/voltdb/task/TaskHelperImpl.java
@@ -30,6 +30,7 @@ import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Database;
 import org.voltdb.catalog.ProcParameter;
 import org.voltdb.catalog.Procedure;
+import org.voltdb.utils.CompoundErrors;
 
 /**
  * Helper class passed to {@link IntervalGenerator}, {@link ActionGenerator} and {@link ActionScheduler} instances for
@@ -198,14 +199,14 @@ final class TaskHelperImpl implements TaskHelper {
      * <p>
      * Note: parameter validation might not work for system procedures
      *
-     * @param errors                   {@link TaskValidationErrors} instance to collect errors
+     * @param errors                   {@link CompoundErrors} instance to collect errors
      * @param restrictProcedureByScope If true type of procedures will be restricted. See
      *                                 {@link ActionScheduler#restrictProcedureByScope()}
      * @param procedureName            Name of procedure to validate
      * @param parameters               that will be passed to {@code name}
      */
     @Override
-    public void validateProcedure(TaskValidationErrors errors, boolean restrictProcedureByScope,
+    public void validateProcedure(CompoundErrors errors, boolean restrictProcedureByScope,
             String procedureName, Object[] parameters) {
         if (m_procedureGetter == null) {
             return;

--- a/src/frontend/org/voltdb/task/TaskManager.java
+++ b/src/frontend/org/voltdb/task/TaskManager.java
@@ -68,6 +68,7 @@ import org.voltdb.client.ClientResponse;
 import org.voltdb.compiler.deploymentfile.TaskSettingsType;
 import org.voltdb.compiler.deploymentfile.TaskThreadPoolType;
 import org.voltdb.iv2.MpInitiator;
+import org.voltdb.utils.CompoundErrors;
 import org.voltdb.utils.InMemoryJarfile;
 
 import com.google_voltpatches.common.base.MoreObjects;
@@ -442,7 +443,7 @@ public final class TaskManager {
      * @return An error message or {@code null} if no errors were found
      */
     public static String validateTasks(Database database, ClassLoader classLoader) {
-        TaskValidationErrors errors = new TaskValidationErrors();
+        CompoundErrors errors = new CompoundErrors();
         for (Task task : database.getTasks()) {
             errors.addErrorMessage(
                     validateTask(task, TaskScope.fromId(task.getScope()), database, classLoader).getErrorMessage());

--- a/src/frontend/org/voltdb/utils/CompoundErrors.java
+++ b/src/frontend/org/voltdb/utils/CompoundErrors.java
@@ -15,18 +15,21 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.voltdb.task;
+package org.voltdb.utils;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.voltdb.task.Initializable;
+
 import com.google_voltpatches.common.base.Joiner;
 
 /**
- * Helper that can be used to collect errors that are encountered while validating the parameters of any
- * {@link Initializable} class.
+ * Helper that can be used to collect multiple errors that are encountered, e.g. while validating the parameters of any
+ * {@link Initializable} class. This enables implementing a validation logic that will not stop at the first error, and
+ * return a message compounding multiple error messages.
  */
-public final class TaskValidationErrors {
+public final class CompoundErrors {
     private List<String> m_errors = null;
 
     /**
@@ -54,13 +57,25 @@ public final class TaskValidationErrors {
     /**
      * Creates an error message comprised of all of the error messages added to this instance by calling
      * {@link #addErrorMessage(String)}. If no error messages were added then {@code null} is returned.
+     * <p>
+     * This method uses a newline ('\n') character to separate the different error messages.
      *
      * @return An error message or {@code null} if {@link #hasErrors()} returns {@code false}
      */
     public String getErrorMessage() {
+        return getErrorMessage("\n");
+    }
+
+    /**
+     * A specialized version of {@link #getErrorMessage()}, using a specific separator.
+     *
+     * @param separator String separating individual error messages in the final string.
+     * @return An error message or {@code null} if {@link #hasErrors()} returns {@code false}
+     */
+    public String getErrorMessage(String separator) {
         if (m_errors == null) {
             return null;
         }
-        return Joiner.on('\n').join(m_errors);
+        return Joiner.on(separator).join(m_errors);
     }
 }

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/OrphanedTuples.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/OrphanedTuples.java
@@ -41,7 +41,7 @@ import org.voltdb.task.Action;
 import org.voltdb.task.ActionGenerator;
 import org.voltdb.task.ActionResult;
 import org.voltdb.task.TaskHelper;
-import org.voltdb.task.TaskValidationErrors;
+import org.voltdb.utils.CompoundErrors;
 
 /**
  * Task for polling the EXPORT statistics and reporting when disabled export streams have pending tuple counts.


### PR DESCRIPTION
TaskValidationErrors is part of the public API for tasks and needs to be
renamed before tasks comes out of beta.