### PR TITLE
ENG-18744:

### DIFF
--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -108,7 +108,7 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
                            (int)targetTable->allocatedTupleCount());
 
                 // empty the table either by table swap or iteratively deleting tuple-by-tuple
-                targetTable->truncateTable(m_engine, m_replicatedTableOperation);
+                targetTable->truncateTable(m_engine, targetTable->isReplicatedTable());
             } else {
                 vassert(m_inputTable);
                 vassert(m_inputTuple.columnCount() == m_inputTable->columnCount());

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -893,8 +893,6 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         localServer.start();
         localServer.waitForRejoin();
 
-        Thread.sleep(10000);
-
         // Run a transaction through the HTTP interface to make sure the
         // internal adapter is correctly setup after rejoin
         final TestJSONInterface.Response httpResp =
@@ -999,7 +997,6 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
             Thread.sleep(100);
         }
 
-        Thread.sleep(10000);
         client = ClientFactory.createClient(m_cconfig);
         client.createConnection("localhost", cluster.port(0));
 

--- a/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
+++ b/tests/frontend/org/voltdb/TestRejoinEndToEnd.java
@@ -67,6 +67,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     public void testRejoinWithMultipartLoad() throws Exception {
         System.out.println("testRejoinWithMultipartLoad");
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
         builder.setSecurityEnabled(true, true);
 
         LocalCluster cluster = new LocalCluster("rejoin.jar", 2, 3, 1,
@@ -251,6 +254,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     @Test
     public void testLocalClusterRecoveringMode() throws Exception {
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         LocalCluster cluster = new LocalCluster("rejoin.jar", 2, 2, 1,
                 BackendTarget.NATIVE_EE_JNI,
@@ -288,6 +294,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     @Test
     public void testRejoinInlineStringBug() throws Exception {
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         LocalCluster cluster = new LocalCluster("rejoin.jar", 1, 2, 1, BackendTarget.NATIVE_EE_JNI);
         cluster.setMaxHeap(768);
@@ -349,6 +358,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         VoltProjectBuilder builder = getBuilderForTest();
         builder.setSecurityEnabled(true, true);
         builder.setHTTPDPort(0);
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
         int sitesPerHost = 4;
         int hostCount = 3;
         int kFactor = 2;
@@ -471,6 +483,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         org.voltdb.utils.VoltFile.resetSubrootForThisProcess();
         VoltProjectBuilder builder = getBuilderForTest();
         builder.setSecurityEnabled(true, true);
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         LocalCluster cluster = new LocalCluster("rejoin.jar", 2, 3, 1, BackendTarget.NATIVE_EE_JNI);
         cluster.overrideAnyRequestForValgrind();
@@ -530,6 +545,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         System.out.println("testRejoinDataTransfer");
         VoltProjectBuilder builder = getBuilderForTest();
         builder.setSecurityEnabled(true, true);
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.export.ExportTestClient");
         String dexportClientClassName = System.getProperty("exportclass", "");
@@ -705,6 +723,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         //Reset the VoltFile prefix that may have been set by previous tests in this suite
         org.voltdb.utils.VoltFile.resetSubrootForThisProcess();
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.export.ExportTestClient");
         String dexportClientClassName = System.getProperty("exportclass", "");
@@ -911,6 +932,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         //builder.setTableAsExportOnly("PARTITIONED", false);
         //builder.setTableAsExportOnly("PARTITIONED_LARGE", false);
         builder.addExport(true, ServerExportEnum.FILE, null);  // authGroups (off)
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         System.setProperty(ExportDataProcessor.EXPORT_TO_TYPE, "org.voltdb.export.ExportTestClient");
         String dexportClientClassName = System.getProperty("exportclass", "");
@@ -926,7 +950,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         boolean success = cluster.compile(builder);
         assertTrue(success);
         MiscUtils.copyFile(builder.getPathToDeployment(), Configuration.getPathToCatalogForTest("rejoin.xml"));
-        cluster.setHasLocalServer(false);
+        cluster.setHasLocalServer(true);
 
         cluster.startUp();
 
@@ -967,16 +991,15 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         }
         config.m_leader = ":" + cluster.internalPort(1);
         config.m_coordinators = cluster.coordinators(1);
-
         config.m_isRejoinTest = true;
         cluster.setPortsFromConfig(0, config);
         cluster.recoverOne(0, 1, "");
 
-        Thread.sleep(1000);
         while (VoltDB.instance().rejoining()) {
             Thread.sleep(100);
         }
 
+        Thread.sleep(10000);
         client = ClientFactory.createClient(m_cconfig);
         client.createConnection("localhost", cluster.port(0));
 
@@ -1002,6 +1025,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     @Test
     public void testRejoinWithExportWithActuallyExportedTables() throws Exception {
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
 
         builder.addExport(true, ServerExportEnum.FILE, null);  // authGroups (off)
 
@@ -1019,7 +1045,7 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         boolean success = cluster.compile(builder);
         assertTrue(success);
         MiscUtils.copyFile(builder.getPathToDeployment(), Configuration.getPathToCatalogForTest("rejoin.xml"));
-        cluster.setHasLocalServer(false);
+        cluster.setHasLocalServer(true);
 
         cluster.startUp();
 
@@ -1066,7 +1092,6 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
 
         cluster.recoverOne(0, 1, "");
 
-        Thread.sleep(1000);
         while (VoltDB.instance().rejoining()) {
             Thread.sleep(100);
         }
@@ -1110,6 +1135,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
         lc.overrideAnyRequestForValgrind();
         VoltProjectBuilder vpb = new VoltProjectBuilder();
         vpb.setUseDDLSchema(true);
+        if (MiscUtils.isPro()) {
+            vpb.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
         vpb.addExport(true, ServerExportEnum.CUSTOM, exportClassName, new Properties(),
                 "exporter");
         assertTrue(lc.compile(vpb));
@@ -1149,6 +1177,9 @@ public class TestRejoinEndToEnd extends RejoinTestBase {
     @Test
     public void testTimeoutWaitingForInitialDataFromSnapshot() throws Exception {
         VoltProjectBuilder builder = getBuilderForTest();
+        if (MiscUtils.isPro()) {
+            builder.configureLogging(null, null, false, true, 200, 20000, 300);
+        }
         LocalCluster lc = new LocalCluster("rejoin.jar", 3, 2, 1, BackendTarget.NATIVE_EE_JNI);
         lc.overrideAnyRequestForValgrind();
         lc.setJavaProperty("REJOIN_INITIAL_DATA_TIMEOUT_MS", "2");

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -598,10 +598,10 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     private void startLocalServer(int hostId, boolean clearLocalDataDirectories) throws IOException {
-        startLocalServer(hostId, clearLocalDataDirectories, templateCmdLine.m_startAction);
+        startLocalServer(hostId, templateCmdLine.internalPort(), clearLocalDataDirectories, templateCmdLine.m_startAction);
     }
 
-    private void startLocalServer(int hostId, boolean clearLocalDataDirectories, StartAction action) {
+    private void startLocalServer(int hostId, int leaderPort, boolean clearLocalDataDirectories, StartAction action) {
         // Generate a new root for the in-process server if clearing directories.
         File subroot = null;
         if (!isNewCli) {
@@ -623,8 +623,25 @@ public class LocalCluster extends VoltServerConfig {
             }
         }
 
-        // Make the local Configuration object...
-        CommandLine cmdln = (templateCmdLine.makeCopy());
+        CommandLine cmdln;
+        if (hostId >= m_cmdLines.size()) {
+            // Make the local Configuration object...
+            cmdln = (templateCmdLine.makeCopy());
+            cmdln.internalPort(internalPortGenerator.nextInternalPort(hostId));
+            cmdln.port(portGenerator.nextClient());
+            cmdln.adminPort(portGenerator.nextAdmin());
+            cmdln.zkport(portGenerator.nextZkPort());
+            cmdln.httpPort(portGenerator.nextHttp());
+            // replication port and its two automatic followers.
+            cmdln.drAgentStartPort(m_replicationPort != -1 ? m_replicationPort : portGenerator.nextReplicationPort());
+            setDrPublicInterface(cmdln);
+            portGenerator.nextReplicationPort();
+            portGenerator.nextReplicationPort();
+        }
+        else {
+            cmdln = m_cmdLines.get(hostId);
+        }
+        cmdln.leaderPort(leaderPort);
         cmdln.startCommand(action);
         cmdln.setJavaProperty(clusterHostIdProperty, String.valueOf(hostId));
         if (this.m_additionalProcessEnv != null) {
@@ -635,16 +652,6 @@ public class LocalCluster extends VoltServerConfig {
         if (!isNewCli) {
             cmdln.voltFilePrefix(subroot.getPath());
         }
-        cmdln.internalPort(internalPortGenerator.nextInternalPort(hostId));
-        cmdln.port(portGenerator.nextClient());
-        cmdln.adminPort(portGenerator.nextAdmin());
-        cmdln.zkport(portGenerator.nextZkPort());
-        cmdln.httpPort(portGenerator.nextHttp());
-        // replication port and its two automatic followers.
-        cmdln.drAgentStartPort(m_replicationPort != -1 ? m_replicationPort : portGenerator.nextReplicationPort());
-        setDrPublicInterface(cmdln);
-        portGenerator.nextReplicationPort();
-        portGenerator.nextReplicationPort();
         if (m_target == BackendTarget.NATIVE_EE_VALGRIND_IPC) {
             EEProcess proc = m_eeProcs.get(hostId);
             assert(proc != null);
@@ -1428,8 +1435,7 @@ public class LocalCluster extends VoltServerConfig {
         int portNoToRejoin = m_cmdLines.get(rejoinHostId).internalPort();
 
         if (hostId == 0 && m_hasLocalServer) {
-            templateCmdLine.leaderPort(portNoToRejoin);
-            startLocalServer(rejoinHostId, false, startAction);
+            startLocalServer(hostId, portNoToRejoin, false, startAction);
             m_localServer.waitForRejoin();
             return true;
         }
@@ -1535,14 +1541,14 @@ public class LocalCluster extends VoltServerConfig {
                               ".rejoined.txt";
 
             if (m_logMessageMatchPatterns == null) {
-                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_initToken, false, proc);
+                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_rejoinCompleteToken, false, proc);
             } else {
                 if (m_logMessageMatchResults.containsKey(hostId)) {
                     resetLogMessageMatchResults(hostId);
                 } else {
                     m_logMessageMatchResults.put(hostId, Collections.newSetFromMap(new ConcurrentHashMap<>()));
                 }
-                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_initToken, false,
+                ptf = new PipeToFile(filePath, proc.getInputStream(), PipeToFile.m_rejoinCompleteToken, false,
                         proc, m_logMessageMatchPatterns, m_logMessageMatchResults.get(hostId));
                 ptf.setHostId(hostId);
             }
@@ -2021,7 +2027,7 @@ public class LocalCluster extends VoltServerConfig {
         assert(cl != null);
         cl.m_port = config.m_port;
         cl.m_adminPort = config.m_adminPort;
-        cl.m_zkInterface = config.m_zkInterface;
+        cl.zkport(config.getZKPort());
         cl.m_internalPort = config.m_internalPort;
         cl.m_leader = config.m_leader;
         cl.m_coordinators = ImmutableSortedSet.copyOf(config.m_coordinators);

--- a/tests/frontend/org/voltdb/regressionsuites/PipeToFile.java
+++ b/tests/frontend/org/voltdb/regressionsuites/PipeToFile.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
     public class PipeToFile extends Thread {
         final static String m_initToken = "Server completed init";
         final static String m_hostID = "Host id of this node is: ";
+        final static String m_rejoinCompleteToken = "Node rejoin completed";
 
         FileWriter m_writer ;
         BufferedReader m_input;


### PR DESCRIPTION
Fix up RecoverOne path when LocalServerThread is being used on Host 0.
Make sure that Truncate correctly cleans up replicated tables (and their views) even when called from the limit path.