### PR TITLE
Add message type in repair log dump.

### DIFF
--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -359,7 +359,26 @@ public class RepairLog
             sb.append(indentStr);
             for(int i = 0; i < txnIdsPerLine; i++) {
                 if (itemator.hasNext()) {
-                    sb.append(" ").append(TxnEgo.txnIdSeqToString(itemator.next().getTxnId()));
+                    Item item = itemator.next();
+                    long txnId = item.getTxnId();
+                    String msgType = "U"; // Stands for unknown
+                    if (item.getMessage() instanceof FragmentTaskMessage) {
+                        msgType = "F";
+                    } else if (item.getMessage() instanceof Iv2InitiateTaskMessage) {
+                        msgType = "I";
+                    } else if (item.getMessage() instanceof CompleteTransactionMessage) {
+                        CompleteTransactionMessage ctm = (CompleteTransactionMessage)item.getMessage();
+                        if (ctm.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP) {
+                            msgType = "C(I)";
+                        } else if (ctm.isRollback()) {
+                            msgType = "C(R)";
+                        } else {
+                            msgType = "C";
+                        }
+                    } else if (item.getMessage() instanceof DummyTransactionTaskMessage) {
+                        msgType = "D";
+                    }
+                    sb.append(" ").append(TxnEgo.txnIdSeqToString(txnId)).append(msgType);
                 }
             }
         }

--- a/src/frontend/org/voltdb/iv2/RepairLog.java
+++ b/src/frontend/org/voltdb/iv2/RepairLog.java
@@ -362,12 +362,13 @@ public class RepairLog
                     Item item = itemator.next();
                     long txnId = item.getTxnId();
                     String msgType = "U"; // Stands for unknown
-                    if (item.getMessage() instanceof FragmentTaskMessage) {
+                    VoltMessage msg = item.getMessage();
+                    if (msg instanceof FragmentTaskMessage) {
                         msgType = "F";
-                    } else if (item.getMessage() instanceof Iv2InitiateTaskMessage) {
+                    } else if (msg instanceof Iv2InitiateTaskMessage) {
                         msgType = "I";
-                    } else if (item.getMessage() instanceof CompleteTransactionMessage) {
-                        CompleteTransactionMessage ctm = (CompleteTransactionMessage)item.getMessage();
+                    } else if (msg instanceof CompleteTransactionMessage) {
+                        CompleteTransactionMessage ctm = (CompleteTransactionMessage)msg;
                         if (ctm.getTimestamp() == CompleteTransactionMessage.INITIAL_TIMESTAMP) {
                             msgType = "C(I)";
                         } else if (ctm.isRollback()) {
@@ -375,7 +376,7 @@ public class RepairLog
                         } else {
                             msgType = "C";
                         }
-                    } else if (item.getMessage() instanceof DummyTransactionTaskMessage) {
+                    } else if (msg instanceof DummyTransactionTaskMessage) {
                         msgType = "D";
                     }
                     sb.append(" ").append(TxnEgo.txnIdSeqToString(txnId)).append(msgType);

--- a/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
+++ b/src/frontend/org/voltdb/messaging/CompleteTransactionMessage.java
@@ -31,11 +31,35 @@ public class CompleteTransactionMessage extends TransactionInfoBaseMessage
     long m_timestamp = INITIAL_TIMESTAMP;
     int m_hash;
     int m_flags = 0;
+
+    // Note: flags below are not mutual exclusive, a CompleteTransactionMessage
+    // may have one or more flags, e.g. rollback and restart.
+    /**
+     * Indicate the current MP transaction needs to be rollback.
+     */
     static final int ISROLLBACK = 0;
+    /**
+     *  Not in use.
+     */
     static final int REQUIRESACK = 1;
+    /**
+     *  MPI sends it when in progress MP transaction is interrupted by
+     *  leader changes, don't apply to non-restartable sysproc.
+     */
     static final int ISRESTART = 2;
+    /**
+     * Indicate whether the message deliver needs to be coordinated by the scoreboard.
+     */
     static final int ISNPARTTXN = 3;
+    /**
+     *  A special type of completion that sends from MpPromoteAlgo to clean up
+     *  transaction task queue, transaction state and the scoreboard of SP site.
+     *  Only non-restartable sysproc fragment in the repair set can trigger it.
+     */
     static final int ISABORTDURINGREPAIR = 4;
+    /**
+     * Indicate whether this is for an empty DR transaction.
+     */
     static final int ISEMPTYDRTXN = 5;
 
     private void setBit(int position, boolean value)


### PR DESCRIPTION
'I' = InitiateTaskMessage,
'F' = FragmentTaskMessage,
'C' = CompleteTransactionMessage,
'C(I)' = The regular CompleteTransactionMessage, no restart or rollback,
'C(R)' = The rollback CompleteTransactionMessage, send during MP repair,
'D' = DummyTransactionMessage
'U' = Unknown

Change-Id: I0023fb9ee9d8cfe4e238e522625ee5cc6efd3719