### PR TITLE
ENG-19147, skip sending repair message *only* if leader change is caused by leader migration request, and no pending repair was cancelled previously

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpRepairTask.java
+++ b/src/frontend/org/voltdb/iv2/MpRepairTask.java
@@ -61,7 +61,8 @@ public class MpRepairTask extends SiteTasker
 
     // Indicate if the round of leader promotion has been completed
     private final boolean m_partitionLeaderPromotionComplete;
-    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean leaderMigration, boolean partitionLeaderPromotionComplete)
+    public MpRepairTask(InitiatorMailbox mailbox, List<Long> spMasters, boolean leaderMigration,
+            boolean partitionLeaderPromotionComplete, boolean skipRepair)
     {
         m_mailbox = mailbox;
         m_spMasters = new ArrayList<Long>(spMasters);
@@ -69,7 +70,7 @@ public class MpRepairTask extends SiteTasker
                 CoreUtils.hsIdToString(m_mailbox.getHSId()) + " ";
         m_leaderMigration = leaderMigration;
         m_partitionLeaderPromotionComplete = partitionLeaderPromotionComplete;
-        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, leaderMigration);
+        algo = mailbox.constructRepairAlgo(Suppliers.ofInstance(m_spMasters), Integer.MAX_VALUE, whoami, skipRepair);
     }
 
     @Override

--- a/src/frontend/org/voltdb/iv2/MpScheduler.java
+++ b/src/frontend/org/voltdb/iv2/MpScheduler.java
@@ -26,8 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.google_voltpatches.common.collect.ImmutableList;
-import com.google_voltpatches.errorprone.annotations.Immutable;
 import org.json_voltpatches.JSONException;
 import org.json_voltpatches.JSONObject;
 import org.voltcore.logging.VoltLogger;
@@ -58,6 +56,7 @@ import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.ProClass;
 import org.voltdb.utils.VoltTrace;
 
+import com.google_voltpatches.common.collect.ImmutableList;
 import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.collect.Sets;
 
@@ -145,11 +144,11 @@ public class MpScheduler extends Scheduler
     public long[] updateReplicas(final List<Long> replicas, final Map<Integer, Long> partitionMasters,
             TransactionState snapshotTransactionState)
     {
-        return updateReplicas(replicas, partitionMasters, false);
+        return updateReplicas(replicas, partitionMasters, false, false);
     }
 
     public long[] updateReplicas(final List<Long> replicas, final Map<Integer, Long> partitionMasters,
-            boolean balanceSPI)
+            boolean balanceSPI, boolean skipRepair)
     {
         applyLeaderMigration(replicas, balanceSPI);
 
@@ -201,8 +200,9 @@ public class MpScheduler extends Scheduler
         partitionLeaderHosts.removeAll(((MpInitiatorMailbox)m_mailbox).m_messenger.getLiveHostIds());
 
         // This is a non MPI Promotion (but SPI Promotion) path for repairing outstanding MP Txns
-        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI, partitionLeaderHosts.isEmpty());
-        m_pendingTasks.repair(repairTask, replicas, partitionMasters, balanceSPI);
+        MpRepairTask repairTask = new MpRepairTask((InitiatorMailbox)m_mailbox, replicas, balanceSPI,
+                partitionLeaderHosts.isEmpty(), skipRepair);
+        m_pendingTasks.repair(repairTask, replicas, partitionMasters, skipRepair);
         return new long[0];
     }
 


### PR DESCRIPTION
Mixed SP leader changes that caused by host down and leader migration request can have a side effect, that is when the last SP leader change was caused by leader migration request, because an optimization we put on leader migration the MPI won't send repair message. If there was a pending
repair needs to restart, all sites will miss the repair message which can cause other severe issues like cluster hang or deadlock. This commit addresses that issue.