### PR TITLE
Eng 15712 scov misc

### DIFF
--- a/tests/sqlcoverage/SQLCoverageReport.py
+++ b/tests/sqlcoverage/SQLCoverageReport.py
@@ -75,7 +75,10 @@ FatalExceptionTypes = ['NullPointerException',
 NonfatalExceptionTypes = ['ClassCastException',
                           'SAXParseException',
                           'VoltTypeException',
-                          'ERROR: IN: NodeSchema'
+                          'ERROR: IN: NodeSchema',
+                          # this is actually a PostgreSQL error message, not,
+                          # strictly speaking, an exception:
+                          'timeout: procedure call took longer than 5 seconds'
                           ]
 # Rejected idea (happens frequently in advanced-scalar-set-subquery):
 #                        'VOLTDB ERROR: UNEXPECTED FAILURE',
@@ -96,7 +99,7 @@ AllExceptionTypes.extend(NonfatalExceptionTypes)
 def highlight(s, flag):
     if not isinstance(s, basestring):
         s = str(s)
-    return flag and "<span style=\"color: red\">%s</span>" % (s) or s
+    return flag and '<span style="color:red">%s*</span>' % (s) or s
 
 def as_html_unicode_string(s):
     if isinstance(s, list):
@@ -498,7 +501,7 @@ def generate_html_reports(suite, seed, statements_path, cmpdb_path, jni_path,
             notFound = True
             jni = {'Status': -99, 'Exception': 'None', 'Result': None,
                    'Info': '<p style="color:red">RESULT NOT FOUND! Probably due to a VoltDB crash!</p>'}
-        cdb_status = 0
+
         cdb_info = ''
         while True:
             try:
@@ -509,14 +512,17 @@ def generate_html_reports(suite, seed, statements_path, cmpdb_path, jni_path,
                        'Info': '<p style="color:red">RESULT NOT FOUND! Probably due to a ' + cmpdb + ' backend crash!</p>'}
 
             if 'timeout: procedure call took longer than 5 seconds' in (cdb.get('Info') or ''):
-                cdb_status = cdb_status | cdb.get('Status', -97)
-                cdb_info += cdb.get('Info', '') + ';\n'
-                next_cdb = cPickle.load(cmpdb_file)
-            else:
-                if cdb_status:
-                    cdb['Status'] = cdb_status | cdb.get('Status', 0)
                 if cdb_info:
-                    cdb['Info'] = cdb_info + cdb.get('Info', '')
+                    cdb_info += ';\n' + cdb.get('Info')
+                else:
+                    cdb_info = cdb.get('Info')
+                print "WARNING: found %s error '%s'; ignoring Status '%s'" % (cmpdb, cdb.get('Info'), cdb.get('Status'))
+            else:
+                if cdb_info:
+                    if cdb.get('Info'):
+                        cdb['Info'] = cdb_info + ';\n' + cdb.get('Info')
+                    else:
+                        cdb['Info'] = cdb_info
                 break
 
         # VoltDB usually produces this error message, for the first couple
@@ -807,7 +813,7 @@ h2 {text-transform: uppercase}
                                                    against VoltDB.</td></tr>
 <tr><td colspan=2>Exceptions/VN: number of 'Non-fatal' Exceptions (those deemed NOT worth failing the test, e.g., VoltTypeException's) while running
                                                    against VoltDB.</td></tr>
-<tr><td colspan=2>Exceptions/%s: number of (any) Exceptions while running against %s (likely in VoltDB's %s backend code).</td></tr>
+<tr><td colspan=2>Exceptions/%s: number of (any) Exceptions (or timeouts) while running against %s (likely in VoltDB's %s backend code).</td></tr>
 <tr><td colspan=2>Crashes/V: number of VoltDB crashes.</td></tr>
 <tr><td colspan=2>Crashes/%s: number of %s crashes.</td></tr>
 <tr><td colspan=2>Crashes/C: number of crashes while comparing VoltDB and %s results.</td></tr>

--- a/tests/sqlcoverage/SQLCoverageReport.py
+++ b/tests/sqlcoverage/SQLCoverageReport.py
@@ -99,7 +99,7 @@ AllExceptionTypes.extend(NonfatalExceptionTypes)
 def highlight(s, flag):
     if not isinstance(s, basestring):
         s = str(s)
-    return flag and '<span style="color:red">%s*</span>' % (s) or s
+    return flag and '<span style="color:red">%s**</span>' % (s) or s
 
 def as_html_unicode_string(s):
     if isinstance(s, list):

--- a/tests/sqlcoverage/SQLGenerator.py
+++ b/tests/sqlcoverage/SQLGenerator.py
@@ -511,7 +511,7 @@ class BaseGenerator:
     __GEO_COLUMN_NAMES    = ['POINT', 'PT1', 'PT2', 'PT3', 'POLYGON', 'POLY1', 'POLY2', 'POLY3']
     # List of possible prefixes for those column names, i.e., either a table name alias with '.',
     # or nothing at all; the empty one (no table name prefix) must be last
-    __GEO_COLUMN_PREFIXES = ['A.', 'B.', 'LHS.', '']
+    __GEO_COLUMN_PREFIXES = ['A.', 'B.', 'LHS.', 'SUBQ.', '']
     # List of Geo functions, which indicate that the Geo column is already appropriately
     # wrapped, so you don't need to add AsText(...)
     __GEO_FUNCTION_NAMES  = ['AREA', 'ASTEXT', 'CAST', 'CENTROID', 'CONTAINS', 'COUNT',

--- a/tests/sqlcoverage/sql_coverage_test.py
+++ b/tests/sqlcoverage/sql_coverage_test.py
@@ -241,6 +241,9 @@ def get_max_mismatches(comparison_database, suite_name):
         # Failures in joined-matview-int due to ENG-11086
         elif config_name == 'joined-matview-int':
             max_mismatches = 46440
+        # Failures in geo-functions due to ENG-19236
+        elif config_name == 'geo-functions':
+            max_mismatches = 3
 
     return max_mismatches
 
@@ -754,7 +757,7 @@ if __name__ == "__main__":
     parser.add_option("-G", "--postgis", action="store_true",
                       dest="postgis", default=False,
                       help="compare VoltDB results to PostgreSQL, with the PostGIS extension")
-    parser.add_option("-d", "--maxdetailfiles", dest="max_detail_files", default="10",
+    parser.add_option("-d", "--maxdetailfiles", dest="max_detail_files", default="6",
                       help="maximum number of detail files, per test suite, per failure category "
                          + "(e.g. mismatches vs crashes vs various types of exceptions)")
     parser.add_option("-R", "--reproduce", dest="reproduce", default="DML",
@@ -852,15 +855,6 @@ if __name__ == "__main__":
         # for certain rare cases involving known errors in PostgreSQL
         if result["mis"] > get_max_mismatches(comparison_database, config_name):
             success = False
-        # If the number of mismatches is nonzero but less than (or equal to) the
-        # acceptable maximum, then we don't need to save the detailed results,
-        # so delete them
-        elif result["mis"] > 0:
-            print "Deleting unneeded result files, for expected mismatches:\n    " + \
-                report_dir + "/*.html"
-            for file in os.listdir(report_dir):
-                if file.endswith(".html") and not file.endswith("index.html"):
-                    os.remove(os.path.join(report_dir, file))
 
     # Write the summary
     time1 = time.time()

--- a/tests/sqlcoverage/template/include/advanced-select.sql
+++ b/tests/sqlcoverage/template/include/advanced-select.sql
@@ -157,10 +157,10 @@ SELECT __[#arg]               Q41,      CASE        A._variable[#arg @columntype
 -- Test simple sub-queries, with and without LIMIT (see ENG-18533)
 {_maybelimit |= ""}
 {_maybelimit |= "LIMIT 10"}
-SELECT SUB.COL1 FROM \
-    (SELECT _variable[@columntype] COL1, @idcol PARTCOL FROM @fromtables ORDER BY COL1, PARTCOL _maybelimit) SUB, \
+SELECT SUBQ.__[#col1] FROM \
+    (SELECT _variable[#col1 @columntype], @idcol PARTCOL FROM @fromtables ORDER BY __[#col1], PARTCOL _maybelimit) SUBQ, \
     @fromtables Q42 \
-    WHERE Q42.@idcol = SUB.PARTCOL ORDER BY PARTCOL
+    WHERE Q42.@idcol = SUBQ.PARTCOL ORDER BY PARTCOL
 
 -- Test GROUP BY and aggregate functions, with CAST function (like ENG-18549, but w/o ?)
 SELECT _variable[#GB], CAST('_value[byte]' AS INTEGER) + COUNT(_variable[@columntype]) FROM @fromtables Q43 GROUP BY __[#GB]

--- a/tests/sqlcoverage/template/include/advanced-select.sql
+++ b/tests/sqlcoverage/template/include/advanced-select.sql
@@ -157,10 +157,11 @@ SELECT __[#arg]               Q41,      CASE        A._variable[#arg @columntype
 -- Test simple sub-queries, with and without LIMIT (see ENG-18533)
 {_maybelimit |= ""}
 {_maybelimit |= "LIMIT 10"}
-SELECT SUBQ.__[#col1] FROM \
-    (SELECT _variable[#col1 @columntype], @idcol PARTCOL FROM @fromtables ORDER BY __[#col1], PARTCOL _maybelimit) SUBQ, \
-    @fromtables Q42 \
-    WHERE Q42.@idcol = SUBQ.PARTCOL ORDER BY PARTCOL
+-- Commented out for now, due to ENG-19229; uncomment once that is fixed:
+--SELECT SUBQ.__[#col1] FROM \
+--    (SELECT _variable[#col1 @columntype], @idcol PARTCOL FROM @fromtables ORDER BY __[#col1], PARTCOL _maybelimit) SUBQ, \
+--    @fromtables Q42 \
+--    WHERE Q42.@idcol = SUBQ.PARTCOL ORDER BY PARTCOL
 
 -- Test GROUP BY and aggregate functions, with CAST function (like ENG-18549, but w/o ?)
 SELECT _variable[#GB], CAST('_value[byte]' AS INTEGER) + COUNT(_variable[@columntype]) FROM @fromtables Q43 GROUP BY __[#GB]

--- a/tests/sqlcoverage/template/include/advanced-select.sql
+++ b/tests/sqlcoverage/template/include/advanced-select.sql
@@ -153,3 +153,14 @@ SELECT @star FROM @fromtables Q38 WHERE CASE      Q38._variable[#arg @columntype
 SELECT @star FROM @fromtables Q39 WHERE CASE      Q39._variable[#arg @columntype] WHEN @comparableconstant THEN Q39._variable[#numone @columntype] @aftermath                              END @cmp (@comparableconstant@plus10)
 SELECT __[#numone]            Q40,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath ELSE   A.__[#arg] @aftermath END FROM @fromtables A WHERE @columnpredicate
 SELECT __[#arg]               Q41,      CASE        A._variable[#arg @columntype] WHEN @comparableconstant THEN   A._variable[#numone @columntype] @aftermath                              END FROM @fromtables A WHERE @columnpredicate
+
+-- Test simple sub-queries, with and without LIMIT (see ENG-18533)
+{_maybelimit |= ""}
+{_maybelimit |= "LIMIT 10"}
+SELECT SUB.COL1 FROM \
+    (SELECT _variable[@columntype] COL1, @idcol PARTCOL FROM @fromtables ORDER BY COL1, PARTCOL _maybelimit) SUB, \
+    @fromtables Q42 \
+    WHERE Q42.@idcol = SUB.PARTCOL ORDER BY PARTCOL
+
+-- Test GROUP BY and aggregate functions, with CAST function (like ENG-18549, but w/o ?)
+SELECT _variable[#GB], CAST('_value[byte]' AS INTEGER) + COUNT(_variable[@columntype]) FROM @fromtables Q43 GROUP BY __[#GB]

--- a/tests/sqlcoverage/template/include/grammar.sql
+++ b/tests/sqlcoverage/template/include/grammar.sql
@@ -14,13 +14,15 @@
 --{_stringfun |= "LOWER"}
 --{_stringfun |= "UPPER"}
 
--- Aggregate functions that accept a string (or numeric) column and return the same type
+-- Aggregate functions that accept a string (or numeric, or other) column and return the same type
 {_stringagg |= "MIN"}
 {_stringagg |= "MAX"}
 
+-- Aggregate functions that are usable with all types
 {_genericagg |= "_stringagg"}
 {_genericagg |= "COUNT"}
 
+-- Aggregate functions that are usable with numeric types
 {_numagg |= "SUM"}
 {_numagg |= "AVG"}
 {_numagg |= "_genericagg"}
@@ -30,10 +32,8 @@
 --HSQL refuses to do AVG(DISTINCT) {_distinctableagg |= "AVG"}
 
 -- Aggregate functions when used as windowed analytic functions
-{_stringwinagg  |= "COUNT"}
-{_stringwinagg  |= "MIN"}
-{_stringwinagg  |= "MAX"}
-{_numwinagg     |= "_stringwinagg"}
+{_stringwinagg  |= "_genericagg"}
+{_numwinagg     |= "_genericagg"}
 {_numwinagg     |= "SUM"}
 
 {_geofun |= ""}

--- a/tests/sqlcoverage/template/int/advanced-ints.sql
+++ b/tests/sqlcoverage/template/int/advanced-ints.sql
@@ -1,2 +1,5 @@
 <configure-for-ints.sql>
 <advanced-template.sql>
+
+-- Additional test of GROUP BY and aggregate functions, with CAST function (like ENG-18549, but w/o ?)
+SELECT _variable[#GB], CAST(_value[byte] AS INTEGER) + @agg(_variable[@columntype]) FROM @fromtables Q44 GROUP BY __[#GB]


### PR DESCRIPTION
Several improvements:
1. A more complete fix for ENG-15712 ('timeout: procedure call took longer than 5 seconds'): slow PostgreSQL queries will no longer cause a failure;
2. A fix for ENG-19187, part 8 ('TypeError: cannot concatenate 'str' and 'NoneType' objects') [both in SQLCoverageReport.py];
3. Added test queries with GROUP BY, somewhat like ENG-18549, but without the '?' parameter, which SqlCoverage cannot handle [in advanced-select.sql, advanced-ints.sql];
4. Improved start_postgresql.sh to give better messages, especially when errors occur;
5. In SQLCoverageReport.py, just add 2 asterisks ('**') for mismatched data, so they are easier to find in long query results;
6. Trivial changes to grammar.sql;
7. Added test queries with (& without) LIMIT in sub-queries (named SUBQ), per ENG-18533 [in advanced-select.sql], but unfortunately these had to be commented out due to ENG-19229;
8.In SQLGenerator.py, add 'SUBQ' to the list of __GEO_COLUMN_PREFIXES, to avoid sending geo point/polygon values across the python client, which does not support them, causing a crash - which will be needed once ENG-19229 is fixed and those LIMIT sub-queries are uncommented.