### PR TITLE
ENG-18628: Export and test cleanup

### DIFF
--- a/src/frontend/org/voltdb/Inits.java
+++ b/src/frontend/org/voltdb/Inits.java
@@ -736,7 +736,7 @@ public class Inits {
                         //If durability is off and we are told not to join but create by mesh clear overflow.
                         (m_config.m_startAction==StartAction.CREATE && (m_config.m_forceVoltdbCreate || !m_durable)),
                         m_rvdb.m_messenger,
-                        m_rvdb.m_partitionsToSitesAtStartupForExportInit
+                        m_rvdb.getPartitionToSiteMap()
                         );
             } catch (Throwable t) {
                 VoltDB.crashLocalVoltDB("Error setting up export", true, t);

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3108,9 +3108,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         if (null == keyStorePassword) {
             keyStorePassword = Constants.DEFAULT_KEYSTORE_PASSWD;
         }
-        if (keyStorePassword == null) {
-            throw new IllegalArgumentException("An SSL keystore password was not specified.");
-        }
         sslContextFactory.setKeyStorePassword(keyStorePassword);
 
         String trustStorePath = getKeyTrustStoreAttribute("javax.net.ssl.trustStore", sslType.getTruststore(), "path");
@@ -3126,9 +3123,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
         String trustStorePassword = getKeyTrustStoreAttribute("javax.net.ssl.trustStorePassword", sslType.getTruststore(), "password");
         if (null == trustStorePassword) {
             trustStorePassword = Constants.DEFAULT_TRUSTSTORE_PASSWD;
-        }
-        if (trustStorePassword == null) {
-            throw new IllegalArgumentException("An SSL truststore password was not specified.");
         }
         sslContextFactory.setTrustStorePassword(trustStorePassword);
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -381,8 +381,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     private final VoltSampler m_sampler = new VoltSampler(10, "sample" + String.valueOf(new Random().nextInt() % 10000) + ".txt");
     private final AtomicBoolean m_hasStartedSampler = new AtomicBoolean(false);
 
-    List<Pair<Integer, Integer>> m_partitionsToSitesAtStartupForExportInit;
-
     RestoreAgent m_restoreAgent = null;
 
     private final ListeningExecutorService m_es = CoreUtils.getCachedSingleThreadExecutor("StartAction ZK Watcher", 15000);
@@ -1306,7 +1304,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
              * is trying to rejoin, it should rely on the cartographer's view to pick the partitions to replace.
              */
             AbstractTopology topo = getTopology(config.m_startAction, hostInfos, m_joinCoordinator);
-            m_partitionsToSitesAtStartupForExportInit = new ArrayList<>();
             try {
                 // IV2 mailbox stuff
                 m_cartographer = new Cartographer(m_messenger, m_configuredReplicationFactor,
@@ -1361,8 +1358,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 }
                 m_iv2Initiators = createIv2Initiators(
                         partitions,
-                        m_config.m_startAction,
-                        m_partitionsToSitesAtStartupForExportInit);
+                        m_config.m_startAction);
                 m_iv2InitiatorStartingTxnIds.put(MpInitiator.MP_INIT_PID,
                         TxnEgo.makeZero(MpInitiator.MP_INIT_PID).getTxnId());
 
@@ -2298,8 +2294,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     private TreeMap<Integer, Initiator> createIv2Initiators(Collection<Integer> partitions,
-                                                StartAction startAction,
-                                                List<Pair<Integer, Integer>> partitionsToSitesAtStartupForExportInit)
+            StartAction startAction)
     {
         TreeMap<Integer, Initiator> initiators = new TreeMap<>();
         // Needed when static is reused by ServerThread
@@ -2309,8 +2304,6 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             Initiator initiator = new SpInitiator(m_messenger, partition, getStatsAgent(),
                     m_snapshotCompletionMonitor, startAction);
             initiators.put(partition, initiator);
-            partitionsToSitesAtStartupForExportInit.add(
-                    Pair.of(partition, CoreUtils.getSiteIdFromHSId(initiator.getInitiatorHSId())));
         }
         if (StartAction.JOIN.equals(startAction)) {
             TransactionTaskQueue.initBarrier(m_nodeSettings.getLocalSitesCount());
@@ -3987,19 +3980,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                                            m_messenger,
                                                            hasSchemaChange);
 
-                //Construct the list of partitions and sites because it simply doesn't exist anymore
-                SiteTracker siteTracker = VoltDB.instance().getSiteTrackerForSnapshot();
-                List<Long> sites = siteTracker.getSitesForHost(m_messenger.getHostId());
-
-                List<Pair<Integer, Integer>> partitions = new ArrayList<>();
-                for (Long site : sites) {
-                    Integer partition = siteTracker.getPartitionForSite(site);
-                    partitions.add(Pair.of(partition, CoreUtils.getSiteIdFromHSId(site)));
-                }
-
                 // 1. update the export manager.
                 ExportManagerInterface.instance().updateCatalog(m_catalogContext, requireCatalogDiffCmdsApplyToEE,
-                        requiresNewExportGeneration, partitions);
+                        requiresNewExportGeneration, getPartitionToSiteMap());
 
                 // 1.1 Update the elastic service throughput settings
                 if (m_elasticService != null) {
@@ -4107,6 +4090,17 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             //Set state back to UP
             m_statusTracker.set(NodeState.UP);
         }
+    }
+
+    Map<Integer, Integer> getPartitionToSiteMap() {
+        Map<Integer, Integer> partitions = new HashMap<>();
+        for (Initiator initiator : m_iv2Initiators.values()) {
+            int partition = initiator.getPartitionId();
+            if (partition != MpInitiator.MP_INIT_PID) {
+                partitions.put(partition, CoreUtils.getSiteIdFromHSId(initiator.getInitiatorHSId()));
+            }
+        }
+        return partitions;
     }
 
     @Override

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -27,7 +27,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
@@ -280,7 +280,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
     }
 
     public ExportDataSource(Generation generation, File adFile,
-            List<Pair<Integer, Integer>> localPartitionsToSites,
+            Map<Integer, Integer> localPartitionsToSites,
             final ExportDataProcessor processor,
             final long genId) throws IOException {
         m_generation = generation;
@@ -299,12 +299,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             // SiteId is outside the valid range if it is no longer local
             int partitionsLocalSite = MpInitiator.MP_INIT_PID + 1;
             if (localPartitionsToSites != null) {
-                for (Pair<Integer, Integer> partition : localPartitionsToSites) {
-                    if (partition.getFirst() == m_partitionId) {
-                        partitionsLocalSite = partition.getSecond();
-                        break;
-                    }
-                }
+                partitionsLocalSite = localPartitionsToSites.getOrDefault(m_partitionId, partitionsLocalSite);
             }
             m_siteId = partitionsLocalSite;
             m_tableName = jsObj.getString("tableName");

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -32,7 +32,6 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.apache.zookeeper_voltpatches.AsyncCallback;
 import org.apache.zookeeper_voltpatches.CreateMode;
@@ -145,7 +144,7 @@ public class ExportGeneration implements Generation {
             CatalogContext catalogContext,
             final CatalogMap<Connector> connectors,
             final ExportDataProcessor processor,
-            List<Pair<Integer, Integer>> localPartitionsToSites,
+            Map<Integer, Integer> localPartitionsToSites,
             File exportOverflowDirectory)
     {
         File files[] = exportOverflowDirectory.listFiles();
@@ -168,7 +167,8 @@ public class ExportGeneration implements Generation {
      */
     private void initializeGenerationFromDisk(final CatalogMap<Connector> connectors,
             final ExportDataProcessor processor,
-            File[] files, List<Pair<Integer, Integer>> localPartitionsToSites,
+            File[] files,
+            Map<Integer, Integer> localPartitionsToSites,
             long genId) {
 
         List<Integer> onDiskPartitions = new ArrayList<Integer>();
@@ -222,9 +222,7 @@ public class ExportGeneration implements Generation {
         }
 
         // Count unique partitions only
-        Set<Integer> allLocalPartitions = localPartitionsToSites.stream()
-                .map(p -> p.getFirst())
-                .collect(Collectors.toSet());
+        Set<Integer> allLocalPartitions = localPartitionsToSites.keySet();
         Set<Integer> onDIskPartitionsSet = new HashSet<Integer>(onDiskPartitions);
         onDIskPartitionsSet.removeAll(allLocalPartitions);
         // One export mailbox per node, since we only keep one generation
@@ -251,7 +249,7 @@ public class ExportGeneration implements Generation {
             final CatalogMap<Connector> connectors,
             final ExportDataProcessor processor,
             int hostId,
-            List<Pair<Integer, Integer>> localPartitionsToSites,
+            Map<Integer, Integer> localPartitionsToSites,
             boolean isCatalogUpdate)
     {
         // Update catalog version so that datasources use this version when propagating acks
@@ -275,8 +273,7 @@ public class ExportGeneration implements Generation {
         // Now create datasources based on the catalog (if already present will not be re-created).
         // Note that we create sources on disabled connectors.
 
-        Set<Integer> partitionsInUse =
-                localPartitionsToSites.stream().map(p -> p.getFirst()).collect(Collectors.toSet());
+        Set<Integer> partitionsInUse = localPartitionsToSites.keySet();
 
         boolean createdSources = false;
         NavigableSet<Table> streams = CatalogUtil.getExportTablesExcludeViewOnly(connectors);
@@ -620,7 +617,7 @@ public class ExportGeneration implements Generation {
      * Create a datasource based on an ad file
      */
     private void addDataSource(File adFile,
-            List<Pair<Integer, Integer>> localPartitionsToSites,
+            Map<Integer, Integer> localPartitionsToSites,
             List<Integer> adFilePartitions,
             final ExportDataProcessor processor,
             final long genId) throws IOException {
@@ -662,20 +659,20 @@ public class ExportGeneration implements Generation {
      * @param processor
      */
     private void addDataSources(Table table, int hostId,
-            List<Pair<Integer, Integer>> localPartitionsToSites,
+            Map<Integer, Integer> localPartitionsToSites,
             Set<Integer> partitionsInUse,
             final ExportDataProcessor processor,
             final long genId,
             boolean isCatalogUpdate)
     {
-        for (Pair<Integer, Integer> partitionAndSiteId : localPartitionsToSites) {
+        for (Map.Entry<Integer, Integer> partitionAndSiteId : localPartitionsToSites.entrySet()) {
 
             /*
              * IOException can occur if there is a problem
              * with the persistent aspects of the datasource storage
              */
-            int partition = partitionAndSiteId.getFirst();
-            int siteId = partitionAndSiteId.getSecond();
+            int partition = partitionAndSiteId.getKey();
+            int siteId = partitionAndSiteId.getValue();
             synchronized(m_dataSourcesByPartition) {
                 try {
                     Map<String, ExportDataSource> dataSourcesForPartition = m_dataSourcesByPartition.get(partition);

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -325,7 +325,8 @@ public class ExportManager implements ExportManagerInterface
 
     /** Creates the initial export processor if export is enabled */
     @Override
-    public void initialize(CatalogContext catalogContext, List<Pair<Integer, Integer>> localPartitionsToSites,
+    public void initialize(CatalogContext catalogContext,
+            Map<Integer, Integer> localPartitionsToSites,
             boolean isRejoin) {
         try {
             CatalogMap<Connector> connectors = CatalogUtil.getConnectors(catalogContext);
@@ -364,7 +365,7 @@ public class ExportManager implements ExportManagerInterface
 
     @Override
     public synchronized void updateCatalog(CatalogContext catalogContext, boolean requireCatalogDiffCmdsApplyToEE,
-            boolean requiresNewExportGeneration, List<Pair<Integer, Integer>> localPartitionsToSites)
+            boolean requiresNewExportGeneration, Map<Integer, Integer> localPartitionsToSites)
     {
         final CatalogMap<Connector> connectors = CatalogUtil.getConnectors(catalogContext);
 
@@ -464,7 +465,7 @@ public class ExportManager implements ExportManagerInterface
             final CatalogContext catalogContext,
             ExportGeneration generation,
             CatalogMap<Connector> connectors,
-            List<Pair<Integer, Integer>> partitions,
+            Map<Integer, Integer> partitions,
             Map<String, Pair<Properties, Set<String>>> config)
     {
         ExportDataProcessor oldProcessor = m_processor.get();
@@ -484,8 +485,8 @@ public class ExportManager implements ExportManagerInterface
             //Load any missing tables.
             generation.initializeGenerationFromCatalog(catalogContext, connectors, newProcessor,
                     m_hostId, partitions, true);
-            for (Pair<Integer, Integer> partition : partitions) {
-                generation.updateAckMailboxes(partition.getFirst(), null);
+            for (int partition : partitions.keySet()) {
+                generation.updateAckMailboxes(partition, null);
             }
             //We create processor even if we dont have any streams.
             newProcessor.setExportGeneration(generation);

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.voltcore.messaging.HostMessenger;
-import org.voltcore.utils.Pair;
 import org.voltcore.zk.SynchronizedStatesManager;
 import org.voltdb.CatalogContext;
 import org.voltdb.ClientInterface;
@@ -116,7 +115,7 @@ public interface ExportManagerInterface {
             boolean isRejoin,
             boolean forceCreate,
             HostMessenger messenger,
-            List<Pair<Integer, Integer>> partitions)
+            Map<Integer, Integer> partitions)
             throws ExportManagerInterface.SetupException, ReflectiveOperationException
     {
         ExportMode mode = getExportFeatureMode(deploymentFeatures);
@@ -163,7 +162,7 @@ public interface ExportManagerInterface {
 
     public List<ExportStatsRow> getStats(final boolean interval);
 
-    public void initialize(CatalogContext catalogContext, List<Pair<Integer, Integer>> localPartitionsToSites,
+    public void initialize(CatalogContext catalogContext, Map<Integer, Integer> localPartitionsToSites,
             boolean isRejoin);
 
     public void startListeners(ClientInterface cif);
@@ -173,7 +172,7 @@ public interface ExportManagerInterface {
     public void startPolling(CatalogContext catalogContext, StreamStartAction action);
 
     public void updateCatalog(CatalogContext catalogContext, boolean requireCatalogDiffCmdsApplyToEE,
-            boolean requiresNewExportGeneration, List<Pair<Integer, Integer>> localPartitionsToSites);
+            boolean requiresNewExportGeneration, Map<Integer, Integer> localPartitionsToSites);
 
     public void updateInitialExportStateToSeqNo(int partitionId, String streamName,
             StreamStartAction action,

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Properties;
@@ -175,6 +176,7 @@ import org.xml.sax.SAXException;
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
 import com.google_voltpatches.common.collect.ImmutableMap;
+import com.google_voltpatches.common.collect.ImmutableSortedMap;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
 import com.google_voltpatches.common.collect.Maps;
 
@@ -613,13 +615,14 @@ public abstract class CatalogUtil {
 
     // Return all the tables that are persistent streams, i.e. all tables creating PBDs,
     // regardless of whether a connector exists
-    public static NavigableSet<Table> getAllStreamsExcludingViews(Database db) {
-        ImmutableSortedSet.Builder<Table> exportTables = ImmutableSortedSet.naturalOrder();
+    public static NavigableMap<String, Table> getAllStreamsExcludingViews(Database db) {
+        ImmutableSortedMap.Builder<String, Table> exportTables = ImmutableSortedMap
+                .orderedBy(String.CASE_INSENSITIVE_ORDER);
         for (Table t : db.getTables()) {
             if (!TableType.needsExportDataSource(t.getTabletype())) {
                 continue;
             }
-            exportTables.add(t);
+            exportTables.put(t.getTypeName(), t);
         }
         return exportTables.build();
     }

--- a/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
+++ b/tests/frontend/org/voltdb/export/TestExportBaseSocketExport.java
@@ -103,15 +103,18 @@ public class TestExportBaseSocketExport extends RegressionSuite {
         }
 
         public void closeClient() {
-            for (ClientConnectionHandler s : m_clients) {
-                s.stopClient();
+            m_close = true;
+            synchronized (m_clients) {
+                for (ClientConnectionHandler s : m_clients) {
+                    s.stopClient();
+                }
             }
             m_clients.clear();
         }
 
         public void close() throws IOException {
-            ssocket.close();
             m_close = true;
+            ssocket.close();
             try {
                 this.join();
             }
@@ -128,6 +131,10 @@ public class TestExportBaseSocketExport extends RegressionSuite {
                     Socket clientSocket = ssocket.accept();
                     ClientConnectionHandler ch = new ClientConnectionHandler(clientSocket);
                     m_clients.add(ch);
+                    if (m_close) {
+                        ch.stopClient();
+                        break;
+                    }
                     ch.start();
                     System.out.println("Client :" + m_port + " # of connections: " + m_clients.size());
                 } catch (IOException ex) {

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -70,7 +70,7 @@ import org.voltdb.messaging.LocalMailbox;
 import org.voltdb.utils.MiscUtils;
 
 import com.google_voltpatches.common.base.Throwables;
-import com.google_voltpatches.common.collect.ImmutableList;
+import com.google_voltpatches.common.collect.ImmutableMap;
 
 public class TestExportGeneration {
 
@@ -176,7 +176,7 @@ public class TestExportGeneration {
 
         m_exportGeneration.initializeGenerationFromCatalog(m_mockVoltDB.getCatalogContext(),
                 m_connectors, getProcessor(), m_mockVoltDB.m_hostId,
-                ImmutableList.of(Pair.of(m_part, CoreUtils.getSiteIdFromHSId(m_site))), false);
+                ImmutableMap.of(m_part, CoreUtils.getSiteIdFromHSId(m_site)), false);
 
         m_mbox = new LocalMailbox(m_mockVoltDB.getHostMessenger()) {
             @Override
@@ -265,7 +265,7 @@ public class TestExportGeneration {
                     0L,
                     foo.duplicate()
                     );
-            AckingContainer cont = (AckingContainer)m_expDs.poll().get();
+            AckingContainer cont = m_expDs.poll().get();
             cont.updateStartTime(System.currentTimeMillis());
 
             m_mbxNotifyCdlRef.set( new CountDownLatch(1));


### PR DESCRIPTION
RealVoltDB: Remove unnecessary null checks
Export: Use a map to represent partition to site ID mapping
CatalogUtil: Return a map of streams rather than a set
TestExportBaseSocketExport: synchronize while iterating over clients
TestCSVLoader: Move test from sub class