### PR TITLE
ENG-18628: Add a seperate path entry for topic data

### DIFF
--- a/lib/python/voltcli/voltadmin.d/resize.py
+++ b/lib/python/voltcli/voltadmin.d/resize.py
@@ -42,7 +42,7 @@ def hostIdsToNames(hostId, hosts):
                                   disabled_export -- ignore pending export data for targets that are disabled''',
                                   default = ''),
             VOLT.IntegerOption(None, '--delay', 'shutdown_delay', 'Delay the shutdown of the hosts which are being removed. '
-                               + 'This needs to be specified if topics are being used. Unit is seconds.', default=-1),
+                               + 'This needs to be specified if topics are being used. Unit is minutes.', default=-1),
             VOLT.StringOption(None, '--test', 'opt', 'Check the feasibility of current resizing plan.', action='store_const', const=Option.TEST, default=Option.START),
             VOLT.StringOption(None, '--restart', 'opt', 'Restart the previous failed resizing operation.', action='store_const', const=Option.RESTART),
             VOLT.StringOption(None, '--status', 'opt', 'Check the resizing progress.', action='store_const', const=Option.STATUS),

--- a/src/frontend/org/voltdb/DiskResourceChecker.java
+++ b/src/frontend/org/voltdb/DiskResourceChecker.java
@@ -172,6 +172,7 @@ public class DiskResourceChecker
             return licenseApi.isDrReplicationAllowed();
         case SNAPSHOTS:
         case EXPORTOVERFLOW:
+        case TOPICSDATA:
             return true;
         default: return false;
         }
@@ -239,7 +240,7 @@ public class DiskResourceChecker
         }
     }
 
-    private static VoltFile getPathForFeature(FeatureNameType featureName)
+    private static File getPathForFeature(FeatureNameType featureName)
     {
         switch(featureName) {
         case COMMANDLOG :
@@ -249,9 +250,11 @@ public class DiskResourceChecker
         case DROVERFLOW:
             return new VoltFile(VoltDB.instance().getDROverflowPath());
         case EXPORTOVERFLOW:
-            return new VoltFile(VoltDB.instance().getExportOverflowPath());
+            return VoltDB.instance().getExportOverflowPath();
         case SNAPSHOTS:
             return new VoltFile(VoltDB.instance().getSnapshotPath());
+        case TOPICSDATA:
+            return VoltDB.instance().getTopicsDataPath();
         default: // Not a valid feature or one that is supported for disk limit monitoring.
                  // Should not happen unless we forget to add a newly supported feature here.
             return null;
@@ -262,7 +265,7 @@ public class DiskResourceChecker
     private static class FeatureDiskLimitConfig
     {
         final FeatureNameType m_featureName;
-        final VoltFile m_path;
+        final File m_path;
         final double m_diskSizeLimit;
         final int m_diskSizeLimitPerc;
         final double m_diskSizeLimitSnmp;

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -614,8 +614,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     @Override
-    public String getExportOverflowPath() {
-        return m_nodeSettings.resolveToAbsolutePath(m_nodeSettings.getExportOverflow()).getPath();
+    public File getExportOverflowPath() {
+        return m_nodeSettings.resolveToAbsolutePath(m_nodeSettings.getExportOverflow());
     }
 
     @Override
@@ -631,6 +631,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     @Override
     public String getExportCursorPath() {
         return m_nodeSettings.resolveToAbsolutePath(m_nodeSettings.getExportCursor()).getPath();
+    }
+
+    @Override
+    public File getTopicsDataPath() {
+        return m_nodeSettings.resolveToAbsolutePath(m_nodeSettings.getTopicsData());
     }
 
     public static String getStagedCatalogPath(String voltDbRoot) {
@@ -691,6 +696,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             nonEmptyPaths.add(path);
         }
         if ((path = managedPathEmptyCheck(voltDbRoot, getCommandLogSnapshotPath(paths.getCommandlogsnapshot()))) != null) {
+            nonEmptyPaths.add(path);
+        }
+        if ((path = managedPathEmptyCheck(voltDbRoot, getTopicsDataPath().getPath())) != null) {
             nonEmptyPaths.add(path);
         }
         return nonEmptyPaths.build();

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -71,10 +71,11 @@ public interface VoltDBInterface
     public String getCommandLogSnapshotPath();
     public String getCommandLogPath();
     public String getSnapshotPath();
-    public String getExportOverflowPath();
+    public File getExportOverflowPath();
     public String getDROverflowPath();
     public String getLargeQuerySwapPath();
     public String getExportCursorPath();
+    public File getTopicsDataPath();
 
     public boolean isBare();
     public boolean isClusterComplete();

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -175,6 +175,7 @@
       <xs:enumeration value="droverflow"/>
       <xs:enumeration value="commandlog"/>
       <xs:enumeration value="commandlogsnapshot"/>
+      <xs:enumeration value="topicsdata"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -233,11 +233,11 @@ public class ExportManager implements ExportManagerInterface
 
     @Override
     public void clearOverflowData() throws ExportManagerInterface.SetupException {
-        String overflowDir = VoltDB.instance().getExportOverflowPath();
+        File overflowDir = VoltDB.instance().getExportOverflowPath();
         try {
             exportLog.info(
                 String.format("Cleaning out contents of export overflow directory %s for create with force", overflowDir));
-            VoltFile.recursivelyDelete(new File(overflowDir), false);
+            VoltFile.recursivelyDelete(overflowDir, false);
         } catch(IOException e) {
             String msg = String.format("Error cleaning out export overflow directory %s: %s",
                     overflowDir, e.getMessage());
@@ -344,7 +344,7 @@ public class ExportManager implements ExportManagerInterface
             ExportDataProcessor newProcessor = getNewProcessorWithProcessConfigSet(m_processorConfig);
             m_processor.set(newProcessor);
 
-            File exportOverflowDirectory = new File(VoltDB.instance().getExportOverflowPath());
+            File exportOverflowDirectory = VoltDB.instance().getExportOverflowPath();
             ExportGeneration generation = new ExportGeneration(exportOverflowDirectory, m_messenger);
             generation.initialize(m_hostId, catalogContext,
                     connectors, newProcessor, localPartitionsToSites, exportOverflowDirectory);
@@ -398,7 +398,7 @@ public class ExportManager implements ExportManagerInterface
             return;
         }
         if (m_generation.get() == null) {
-            File exportOverflowDirectory = new File(VoltDB.instance().getExportOverflowPath());
+            File exportOverflowDirectory = VoltDB.instance().getExportOverflowPath();
             try {
                 ExportGeneration gen = new ExportGeneration(exportOverflowDirectory, m_messenger);
                 m_generation.set(gen);

--- a/src/frontend/org/voltdb/settings/NodeSettings.java
+++ b/src/frontend/org/voltdb/settings/NodeSettings.java
@@ -49,6 +49,7 @@ public interface NodeSettings extends Settings {
     public final static String VOLTDBROOT_PATH_KEY = "org.voltdb.path.voltdbroot";
     public final static String EXPORT_CURSOR_PATH_KEY = "org.voltdb.path.export_cursor";
     public final static String EXPORT_OVERFLOW_PATH_KEY = "org.voltdb.path.export_overflow";
+    public final static String TOPICS_DATA_PATH_KEY = "org.voltdb.path.topics_data";
     public final static String DR_OVERFLOW_PATH_KEY = "org.voltdb.path.dr_overflow";
     public final static String LARGE_QUERY_SWAP_PATH_KEY = "org.voltdb.path.large_query_swap";
     public final static String LOCAL_SITES_COUNT_KEY = "org.voltdb.local_sites_count";
@@ -72,6 +73,10 @@ public interface NodeSettings extends Settings {
     @Key(EXPORT_CURSOR_PATH_KEY)
     @DefaultValue("export_cursor") // must match value in voltdb/compiler/DeploymentFileSchema.xsd
     public File getExportCursor();
+
+    @Key(TOPICS_DATA_PATH_KEY)
+    @DefaultValue("topics_data")
+    public File getTopicsData();
 
     @Key(DR_OVERFLOW_PATH_KEY)
     public File getDROverflow();
@@ -117,6 +122,7 @@ public interface NodeSettings extends Settings {
                 .put(DR_OVERFLOW_PATH_KEY, resolve(getDROverflow()))
                 .put(LARGE_QUERY_SWAP_PATH_KEY, resolve(getLargeQuerySwap()))
                 .put(EXPORT_CURSOR_PATH_KEY, resolve(getExportCursor()))
+                .put(TOPICS_DATA_PATH_KEY, resolve(getTopicsData()))
                 .build();
     }
 
@@ -199,7 +205,9 @@ public interface NodeSettings extends Settings {
         boolean archivedSnapshots = archiveSnapshotDirectory();
         for (File path: getManagedArtifactPaths().values()) {
             File [] children = path.listFiles();
-            if (children == null) continue;
+            if (children == null) {
+                continue;
+            }
             for (File child: children) {
                 MiscUtils.deleteRecursively(child);
             }
@@ -264,6 +272,8 @@ public interface NodeSettings extends Settings {
         }
 
         File deprectedConfigFH = new File(getVoltDBRoot(),".paths");
-        if (deprectedConfigFH.exists()) deprectedConfigFH.delete();
+        if (deprectedConfigFH.exists()) {
+            deprectedConfigFH.delete();
+        }
     }
 }

--- a/src/frontend/org/voltdb/sysprocs/SystemInformation.java
+++ b/src/frontend/org/voltdb/sysprocs/SystemInformation.java
@@ -516,7 +516,7 @@ public class SystemInformation extends VoltSystemProcedure
         for (Connector export_conn : database.getConnectors()) {
             if (export_conn != null && export_conn.getEnabled())
             {
-                results.addRow("exportoverflowpath", VoltDB.instance().getExportOverflowPath());
+                results.addRow("exportoverflowpath", VoltDB.instance().getExportOverflowPath().getPath());
                 break;
             }
         }

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2376,6 +2376,7 @@ public abstract class CatalogUtil {
         setupCommandLogSnapshot(paths.getCommandlogsnapshot(), voltDbRoot);
         setupDROverflow(paths.getDroverflow(), voltDbRoot);
         setupLargeQuerySwap(paths.getLargequeryswap(), voltDbRoot);
+        setupTopicData(voltDbRoot);
     }
 
     /**
@@ -2535,6 +2536,21 @@ public abstract class CatalogUtil {
         }
         validateDirectory("large query swap", largeQuerySwap);
         return largeQuerySwap;
+    }
+
+    public static File setupTopicData(File voltDbRoot) {
+        File topicsDataDir = VoltDB.instance().getTopicsDataPath();
+        if (!topicsDataDir.isAbsolute()) {
+            topicsDataDir = new VoltFile(voltDbRoot, topicsDataDir.getPath());
+        }
+        if (!topicsDataDir.exists()) {
+            hostLog.info("Creating topics data directory: " + topicsDataDir.getAbsolutePath());
+            if (!topicsDataDir.mkdirs()) {
+                hostLog.fatal("Failed to create topics data directory \"" + topicsDataDir + "\"");
+            }
+        }
+        validateDirectory("topics data", topicsDataDir);
+        return topicsDataDir;
     }
 
     /**

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -576,8 +576,8 @@ public class MockVoltDB implements VoltDBInterface
     }
 
     @Override
-    public String getExportOverflowPath() {
-        return "export_overflow";
+    public File getExportOverflowPath() {
+        return new File("export_overflow");
     }
 
     @Override
@@ -593,6 +593,11 @@ public class MockVoltDB implements VoltDBInterface
     @Override
     public String getExportCursorPath() {
         return  "export_cursor";
+    }
+
+    @Override
+    public File getTopicsDataPath() {
+        return new File("topic_data");
     }
 
     @Override


### PR DESCRIPTION
To easily separate the topic data from the export data topics are going to be put into a separate directory. This means that the check that export overflow is empty during restore can still behave the same and the topics will be left alone.

Related https://github.com/VoltDB/pro/pull/3073