### PR TITLE
ENG-19277, catch all throwables on both snapshot write service and sy…

### DIFF
--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -535,6 +535,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
                     }
                     SNAP_LOG.error("Unexpected error while attempting to write snapshot data to file " + m_file, t);
                     m_writeFailed = true;
+                    throw t;
                 } finally {
                     try {
                         tupleDataCont.discard();


### PR DESCRIPTION
…nc service thread.

Snapshot write and sync service are two threads that responsible for writing snapshot to disk.
They cordinatate through a semaphore on how many bytes the write thread can write before synced.
If there is any exception uncaught in those two threads, it may lead to permit leaking, or even
worse, deadlock in the write thread. Unfortunately the snapshot write thread is one of the vital
thread to kepp snapshot subsystem running, its deadlock would make snapshot unusable.

Change-Id: I94c25a38bdebe8b032790f9fa0f35dede409eb7a