### PR TITLE
Eng 19180 snapshot reads duplicate values

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1326,11 +1326,7 @@ inline bool IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>:
 template<typename Chunks, typename Tag, typename E>
 template<iterator_permission_type perm, iterator_view_type view> inline
 IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>::operator position_type() const noexcept {
-    if (m_iter != storage().cend()) {
-        return {m_cursor, m_iter};
-    } else {
-        return {};
-    }
+    return {m_cursor, m_iter};
 }
 
 /**
@@ -1429,7 +1425,8 @@ struct ChunkDeleter<ChunkList, Iter, iterator_permission_type::rw, iterator_view
                     vassert(l.front().range_begin() == l.front().range_next());
                     l.pop_front();
                 }
-                vassert(! l.empty() && l.front().id() == id);
+                vassert(! l.empty() && l.front().id() == id &&
+                        l.front().range_begin() == l.front().range_next());
                 l.pop_front();
             } else {                               // snapshot iterator drained
                 vassert(all_of(l.cbegin(), l.cend(),

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1361,6 +1361,8 @@ struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, true_type> {
                 // needs to use the next() position.
                 vassert((iter->range_begin() == iter->range_next()) == (next(iter) != l.end()));
                 return iter->range_begin() == iter->range_next() ? iter->range_end() : iter->range_next();
+            } else if (leftId == iterId) {      // in the left boundary of frozen state
+                return frozenBoundaries.left().address();
             } else if(less_rolling(iterId, txnBeginChunkId)) {  // in chunk visible to frozen iterator only
                 if (less_rolling(iterId, rightId)) {
                     return iter->range_end();
@@ -1368,8 +1370,6 @@ struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, true_type> {
                     vassert(iterId == rightId);
                     return frozenBoundaries.right().address();
                 }
-            } else if (leftId == iterId) {      // in the left boundary of frozen state
-                return hasTxnInvisibleChunks ? iter->range_end() : frozenBoundaries.left().address();
             } else if (rightId == iterId) {     // in the right boundary
                 return frozenBoundaries.right().address();
             } else if (txnBeginChunkId == iterId) {

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -1245,28 +1245,12 @@ struct iterator_begin<Cont, perm, iterator_view_type::txn, true_type> {
     }
 };
 
-template<typename Chunks, iterator_view_type view, typename = typename Chunks::Compact>
-struct HasTxnInvisibleChunks {
-    inline constexpr bool operator()(Chunks const&) const noexcept {
-        return false;
-    }
-};
-
-template<typename Chunks>
-struct HasTxnInvisibleChunks<Chunks, iterator_view_type::snapshot, true_type> {
-    inline bool operator()(Chunks const& c) const noexcept {
-        return c.frozen() && (c.empty() ||
-                less_rolling(c.frozenBoundaries().left().chunkId(), c.begin()->id()));
-    }
-};
-
 template<typename Chunks, typename Tag, typename E>
 template<iterator_permission_type perm, iterator_view_type view>
 inline IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>::iterator_type(
         typename IterableTableTupleChunks<Chunks, Tag, E>::template iterator_type<perm, view>::container_type src) :
     m_offset(src.tupleSize()), m_storage(src),
     m_iter(iterator_begin<typename remove_reference<container_type>::type, perm, view>()(src)),
-    m_hasTxnInvisibleChunks(HasTxnInvisibleChunks<Chunks, view>()(src)),
     m_cursor(const_cast<value_type>(m_iter == m_storage.end() ? nullptr : m_iter->range_begin())) {
     // paranoid type check
     static_assert(is_lvalue_reference<container_type>::value,
@@ -1337,14 +1321,14 @@ IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>::operator po
  */
 template<typename ChunkList, typename Iter, iterator_view_type view, typename Comp>
 struct ChunkBoundary {
-    inline void const* operator()(ChunkList const&, Iter const& iter, bool) const noexcept {
+    inline void const* operator()(ChunkList const&, Iter const& iter) const noexcept {
         return iter->range_next();
     }
 };
 
 template<typename ChunkList, typename Iter>
 struct ChunkBoundary<ChunkList, Iter, iterator_view_type::snapshot, true_type> {
-    inline void const* operator()(ChunkList const& l, Iter const& iter, bool hasTxnInvisibleChunks) const noexcept {
+    inline void const* operator()(ChunkList const& l, Iter const& iter) const noexcept {
         auto const& frozenBoundaries = reinterpret_cast<CompactingChunks const&>(l).frozenBoundaries();
         if (frozenBoundaries.left().empty()) {        // not frozen
             return iter->range_next();
@@ -1453,7 +1437,7 @@ void IterableTableTupleChunks<Chunks, Tag, E>::iterator_type<perm, view>::advanc
         if (! m_storage.empty() && m_iter != m_storage.end()) {
             const_cast<void*&>(m_cursor) =
                 reinterpret_cast<char*>(const_cast<void*>(m_cursor)) + m_offset;
-            if (m_cursor < boundary(m_storage, m_iter, m_hasTxnInvisibleChunks)) {
+            if (m_cursor < boundary(m_storage, m_iter)) {
                 finished = false;              // within chunk
             } else {
                 advance_iter(m_storage, m_iter); // cross chunk

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -929,8 +929,6 @@ namespace voltdb {
                 using list_iterator_type = typename conditional<perm == iterator_permission_type::ro,
                       typename Chunks::list_type::const_iterator, typename Chunks::list_type::iterator>::type;
                 list_iterator_type m_iter;
-                bool const m_hasTxnInvisibleChunks;    // can be true only if in snapshot view, is frozen, and contains chunks
-                // only visible to snapshot
             protected:
                 using value_type = typename super::value_type;
                 // ctor arg type

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -2205,24 +2205,108 @@ TEST_F(TableTupleAllocatorTest, TestSimulateDuplicateSnapshotRead_mt) {
     alloc.template thaw<truth>();
 }
 
-TEST_F(TableTupleAllocatorTest, TestSnapIterBug) {
+TEST_F(TableTupleAllocatorTest, TestSnapIterBug_rep1) {
     // test finalizer on iterator
     using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    Alloc alloc(TupleSize);
     using Gen = StringGen<TupleSize>;
     Gen gen;
-    array<void*, AllocsPerChunk * 2> addresses;
-    for (size_t i = 0; i < AllocsPerChunk * 2 ; ++i) {
+    array<void*, AllocsPerChunk * 3> addresses;
+    size_t i;
+    for (i = 0; i < AllocsPerChunk * 3 ; ++i) {
         addresses[i] = gen.fill(alloc.allocate());
     }
+    // delete last 2 tuples from last chunk
     alloc.remove_reserve(2);
-    alloc.template remove_add<truth>(addresses[AllocsPerChunk - 1]);
-    alloc.template remove_add<truth>(addresses[AllocsPerChunk - 2]);
-    // delete last 2 tuples from 1st chunk
-    ASSERT_EQ(2, alloc.template remove_force<truth>());
-    // then, freeze, and remove 2 more tuples
+    alloc.template remove_add<truth>(
+            const_cast<void*>(addresses[AllocsPerChunk * 3 - 1]));
+    alloc.template remove_add<truth>(
+            const_cast<void*>(addresses[AllocsPerChunk * 3 - 2]));
+    ASSERT_EQ(2,
+            alloc.remove_force([](vector<pair<void*, void*>> const& entries) noexcept{
+                for_each(entries.begin(), entries.end(),
+                        [](pair<void*, void*> const& entry) {memcpy(entry.first, entry.second, TupleSize);});
+                }));
+    // then, freeze, and remove 1 full chunk worth of tuples
     auto const& iter = alloc.template freeze<truth>();
+    alloc.remove_reserve(AllocsPerChunk);
+    for (i = 0; i < AllocsPerChunk - 2; ++i) {
+        alloc.template remove_add<truth>(const_cast<void*>(addresses[i]));
+    }
+    for (i = 0; i < 2; ++i) {
+        alloc.template remove_add<truth>(const_cast<void*>(addresses[i + AllocsPerChunk]));
+    }
+    ASSERT_EQ(AllocsPerChunk,
+            alloc.remove_force([](vector<pair<void*, void*>> const& entries) noexcept{
+                for_each(entries.begin(), entries.end(),
+                        [](pair<void*, void*> const& entry) {memcpy(entry.first, entry.second, TupleSize);});
+                }));
+    // verify that snapshot should not see values deleted in the
+    // 1st batch
+    i = 0;
+    while (! iter->drained()) {
+        auto const val = Gen::of(reinterpret_cast<unsigned char*>(**iter));
+        // should not see deleted values before freeze;
+        ASSERT_NE(AllocsPerChunk * 3 - 1, val);
+        ASSERT_NE(AllocsPerChunk * 3 - 2, val);
+        ++(*iter);
+        ++i;
+    }
+    ASSERT_EQ(AllocsPerChunk * 3 - 2, i);
     alloc.template thaw<truth>();
 }
+
+TEST_F(TableTupleAllocatorTest, TestSnapIterBug_rep2) {
+    // test finalizer on iterator
+    using Alloc = HookedCompactingChunks<TxnPreHook<NonCompactingChunks<EagerNonCompactingChunk>, HistoryRetainTrait<gc_policy::always>>>;
+    Alloc alloc(TupleSize);
+    using Gen = StringGen<TupleSize>;
+    Gen gen;
+    array<void*, AllocsPerChunk * 3> addresses;
+    size_t i;
+    for (i = 0; i < AllocsPerChunk * 3 ; ++i) {
+        addresses[i] = gen.fill(alloc.allocate());
+    }
+    // delete last 2 tuples from 1st chunk
+    alloc.remove_reserve(2);
+    alloc.template remove_add<truth>(
+            const_cast<void*>(addresses[AllocsPerChunk - 1]));
+    alloc.template remove_add<truth>(
+            const_cast<void*>(addresses[AllocsPerChunk - 2]));
+    ASSERT_EQ(2,
+            alloc.remove_force([](vector<pair<void*, void*>> const& entries) noexcept{
+                for_each(entries.begin(), entries.end(),
+                        [](pair<void*, void*> const& entry) {memcpy(entry.first, entry.second, TupleSize);});
+                }));
+    // then, freeze, and remove 1 full chunk worth of tuples
+    auto const& iter = alloc.template freeze<truth>();
+    alloc.remove_reserve(AllocsPerChunk);
+    for (i = 0; i < AllocsPerChunk - 2; ++i) {
+        alloc.template remove_add<truth>(const_cast<void*>(addresses[i]));
+    }
+    for (i = 0; i < 2; ++i) {
+        alloc.template remove_add<truth>(const_cast<void*>(addresses[i + AllocsPerChunk]));
+    }
+    ASSERT_EQ(AllocsPerChunk,
+            alloc.remove_force([](vector<pair<void*, void*>> const& entries) noexcept{
+                for_each(entries.begin(), entries.end(),
+                        [](pair<void*, void*> const& entry) {memcpy(entry.first, entry.second, TupleSize);});
+                }));
+    // verify that snapshot should not see values deleted in the
+    // 1st batch
+    i = 0;
+    while (! iter->drained()) {
+        auto const val = Gen::of(reinterpret_cast<unsigned char*>(**iter));
+        // should not see holes created due to deletion before freeze;
+        ASSERT_NE(AllocsPerChunk - 1, val);
+        ASSERT_NE(AllocsPerChunk - 2, val);
+        ++(*iter);
+        ++i;
+    }
+    ASSERT_EQ(AllocsPerChunk * 3 - 2, i);
+    alloc.template thaw<truth>();
+}
+
 
 #endif
 


### PR DESCRIPTION
Fixed the bug on snapshot iterator chunk boundary calculation, when current chunk is on the left frozen boundary, causing snapshot to read extra false values.