### PR TITLE
Eng 18630 topic restore

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2768,30 +2768,14 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
     return remaining;
 }
 
-int64_t VoltDBEngine::exportAction(bool syncAction, int64_t uso,
+void VoltDBEngine::setExportStreamPositions(int64_t uso,
         int64_t seqNo, int64_t generationIdCreated, std::string streamName) {
     std::map<std::string, StreamedTable*>::iterator pos = m_exportingTables.find(streamName);
 
-    // return no data and polled offset for unavailable tables.
-    if (pos == m_exportingTables.end()) {
-        // ignore trying to sync a non-exported table
-        if (syncAction) {
-            return 0;
-        }
-
-        m_resultOutput.writeInt(0);
-        if (uso < 0) {
-            return 0;
-        } else {
-            return uso;
-        }
+    // ignore trying to sync a non-exported table
+    if (pos != m_exportingTables.end()) {
+        pos->second->setExportStreamPositions(seqNo, (size_t) uso, generationIdCreated);
     }
-
-    Table *table_for_el = pos->second;
-    if (syncAction) {
-        table_for_el->setExportStreamPositions(seqNo, (size_t) uso, generationIdCreated);
-    }
-    return 0;
 }
 
 bool VoltDBEngine::deleteMigratedRows(

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -526,18 +526,15 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                 ReferenceSerializeInputBE& serializeIn, std::vector<int>& retPositions);
 
         /**
-         * Perform an action on behalf of Export.
+         * Set the export stream positions for the given stream
          *
-         * @param syncAction if syncAction is true, the stream offset being set for a table
          * @param ackOffset the reference to the USO of the next row inserted in the stream
          * @param seqNo the reference to the sequenceNumber of the next inserted row
          * @param generationIdCreated the reference to the initial creation generation ID of the export stream
          * @param streamName the name of the stream we want to update the state for
-         * @return the universal offset for any poll results
-         * (results returned separately via QueryResults buffer)
          */
-        int64_t exportAction(bool syncAction, int64_t ackOffset, int64_t seqNo,
-                int64_t generationIdCreated, std::string streamName);
+        void setExportStreamPositions(int64_t ackOffset, int64_t seqNo, int64_t generationIdCreated,
+                std::string streamName);
 
         /**
          * Complete the deletion of the Migrated Table rows.

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1202,7 +1202,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeTabl
 
 /*
  * Class:     org_voltdb_jni_ExecutionEngine
- * Method:    nativeExportAction
+ * Method:    nativeSetExportStreamPositions
  *
  * @param ackAction  true if this call contains an ack
  * @param pollAction true if this call requests a poll
@@ -1210,16 +1210,11 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeTabl
  * @param ackOffset  if acking, the universal stream offset being acked/released
  * @param streamName    Name of the stream to which the Export action applies
  *
- * @return the universal stream offset for the last octet in any
- * returned poll results (returned via the query results buffer).  On
- * any error this will be less than 0.  For any call with no
- * pollAction, any value >= 0 may be ignored.
  */
-SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExportAction
+SHAREDLIB_JNIEXPORT void JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeSetExportStreamPositions
   (JNIEnv *env,
    jobject obj,
    jlong engine_ptr,
-   jboolean syncAction,
    jlong ackOffset,
    jlong seqNo,
    jlong genId,
@@ -1233,8 +1228,7 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
     try {
         try {
             engine->resetReusedResultOutputBuffer();
-            return engine->exportAction(syncAction,
-                                        static_cast<int64_t>(ackOffset),
+            engine->setExportStreamPositions(static_cast<int64_t>(ackOffset),
                                         static_cast<int64_t>(seqNo),
                                         static_cast<int64_t>(genId),
                                         streamNameStr);
@@ -1244,7 +1238,6 @@ SHAREDLIB_JNIEXPORT jlong JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeExpo
     } catch (const FatalException &e) {
         topend->crashVoltDB(e);
     }
-    return 0;
 }
 
 /**

--- a/src/frontend/org/voltdb/SiteProcedureConnection.java
+++ b/src/frontend/org/voltdb/SiteProcedureConnection.java
@@ -225,10 +225,9 @@ public interface SiteProcedureConnection {
 
     public void quiesce();
 
-    public void exportAction(boolean syncAction,
-                             ExportSnapshotTuple sequences,
-                             Integer partitionId,
-                             String tableSignature);
+    public void setExportStreamPositions(ExportSnapshotTuple sequences,
+                                         Integer partitionId,
+                                         String tableSignature);
 
     public boolean deleteMigratedRows(long txnid, long spHandle, long uniqueId,
             String tableName, long deletableTxnId);

--- a/src/frontend/org/voltdb/iv2/MpRoSite.java
+++ b/src/frontend/org/voltdb/iv2/MpRoSite.java
@@ -589,9 +589,7 @@ public class MpRoSite implements Runnable, SiteProcedureConnection
     }
 
     @Override
-    public void exportAction(boolean syncAction,
-                             ExportSnapshotTuple sequences,
-                             Integer partitionId, String tableSignature)
+    public void setExportStreamPositions(ExportSnapshotTuple sequences, Integer partitionId, String tableSignature)
     {
         throw new RuntimeException("RO MP Site doesn't do this, shouldn't be here.");
     }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1520,11 +1520,9 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public void exportAction(boolean syncAction,
-                             ExportSnapshotTuple sequences,
-                             Integer partitionId, String streamName)
+    public void setExportStreamPositions(ExportSnapshotTuple sequences, Integer partitionId, String streamName)
     {
-        m_ee.exportAction(syncAction, sequences, partitionId, streamName);
+        m_ee.setExportStreamPositions(sequences, partitionId, streamName);
     }
 
     @Override
@@ -1600,11 +1598,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                 }
             }
 
-            exportAction(
-                    true,
-                    sequenceNumbers,
-                    m_partitionId,
-                    catalogTable.getTypeName());
+            setExportStreamPositions(sequenceNumbers, m_partitionId, catalogTable.getTypeName());
             // assign the stats to the other partition's value
             ExportManagerInterface.instance().updateInitialExportStateToSeqNo(m_partitionId, catalogTable.getTypeName(),
                     StreamStartAction.REJOIN, tableEntry.getValue());

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -830,8 +830,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /**
      * Execute an Export action against the execution engine.
      */
-    public abstract void exportAction( boolean syncAction,
-            ExportSnapshotTuple sequences, int partitionId, String streamName);
+    public abstract void setExportStreamPositions(ExportSnapshotTuple sequences, int partitionId, String streamName);
 
     /**
      * Execute an Delete of migrated rows in the execution engine.
@@ -1292,9 +1291,8 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param mStreamName Name of the stream being acted against
      * @return
      */
-    protected native long nativeExportAction(
+    protected native void nativeSetExportStreamPositions(
             long pointer,
-            boolean syncAction,
             long mAckOffset,
             long seqNo,
             long generationId,

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1678,12 +1678,10 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
-    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
-            int partitionId, String mStreamName) {
+    public void setExportStreamPositions(ExportSnapshotTuple sequences, int partitionId, String mStreamName) {
         try {
             m_data.clear();
             m_data.putInt(Commands.ExportAction.m_id);
-            m_data.putInt(syncAction ? 1 : 0);
             m_data.putLong(sequences.getAckOffset());
             m_data.putLong(sequences.getSequenceNumber());
             m_data.putLong(sequences.getGenerationId());
@@ -1696,19 +1694,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             m_data.flip();
             m_connection.write();
 
-            ByteBuffer results = ByteBuffer.allocate(8);
-            while (results.remaining() > 0) {
-                m_connection.m_socketChannel.read(results);
-            }
-            results.flip();
-            long result_offset = results.getLong();
-            if (result_offset < 0) {
-                System.out.println("exportAction failed!  syncAction: " + syncAction + ", Uso: " +
-                    sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
-                    ", generationId: " + sequences.getGenerationId() +
-                    ", partitionId: " + partitionId +
-                    ", streamName: " + mStreamName);
-            }
+            m_connection.readStatusByte();
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -692,28 +692,21 @@ public class ExecutionEngineJNI extends ExecutionEngine {
      * data is returned in the usual results buffer, length preceded as usual.
      */
     @Override
-    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
-            int partitionId, String streamName)
+    public void setExportStreamPositions(ExportSnapshotTuple sequences, int partitionId, String streamName)
     {
         if (EXPORT_LOG.isDebugEnabled()) {
-            EXPORT_LOG.debug("exportAction on partition " + partitionId + " syncAction: " + syncAction + ", uso: " +
+            EXPORT_LOG.debug("exportAction on partition " + partitionId + ", uso: "
+                    +
                     sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
                     ", generationId:" + sequences.getGenerationId() + ", streamName: " + streamName);
         }
         //Clear is destructive, do it before the native call
         m_nextDeserializer.clear();
-        long retval = nativeExportAction(pointer,
-                                         syncAction,
-                                         sequences.getAckOffset(),
-                                         sequences.getSequenceNumber(),
-                                         sequences.getGenerationId(),
-                                         getStringBytes(streamName));
-        if (retval < 0) {
-            LOG.info("exportAction failed.  syncAction: " + syncAction + ", uso: " +
-                    sequences.getAckOffset() + ", seqNo: " + sequences.getSequenceNumber() +
-                    ", generationId:" + sequences.getGenerationId() + ", partitionId: " + partitionId +
-                    ", streamName: " + streamName);
-        }
+        nativeSetExportStreamPositions(pointer,
+                                       sequences.getAckOffset(),
+                                       sequences.getSequenceNumber(),
+                                       sequences.getGenerationId(),
+                                       getStringBytes(streamName));
     }
 
     @Override

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -209,8 +209,7 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public void exportAction(boolean syncAction, ExportSnapshotTuple sequences,
-            int partitionId, String mStreamName) {
+    public void setExportStreamPositions(ExportSnapshotTuple sequences, int partitionId, String mStreamName) {
     }
 
     @Override

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1351,7 +1351,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 continue;
             }
 
-            if (action == StreamStartAction.RECOVER) {
+            if (action == StreamStartAction.RECOVER || t.getIstopic()) {
                 ExportSnapshotTuple sequences =
                         sequenceNumberPerPartition.get(myPartitionId);
                 if (sequences == null) {

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1365,11 +1365,7 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 }
 
                 //Forward the sequence number to the EE
-                context.getSiteProcedureConnection().exportAction(
-                        true,
-                        sequences,
-                        myPartitionId,
-                        name);
+                context.getSiteProcedureConnection().setExportStreamPositions(sequences, myPartitionId, name);
 
             }
             // Truncate the PBD buffers and assign the stats to the restored value


### PR DESCRIPTION
Topic data is kept after a restore so it needs to be treated the same way an export stream is treated during recovery.

ExecutionEngine.exportAction was always called with true as the first argument. That means that it was only used to set the export stream positions. Remove the boolean argument and rename the method to setExportStreamPositions. Also, remove any extra code for old use including a return value.

Related https://github.com/VoltDB/pro/pull/3075