### PR TITLE
Rename GracefulXyz sysprocs to OpXyz

### DIFF
--- a/lib/python/voltcli/voltadmin.d/opshutdown.py
+++ b/lib/python/voltcli/voltadmin.d/opshutdown.py
@@ -22,7 +22,7 @@ from voltcli import utility
 from voltcli.hostinfo import Hosts
 
 ######################
-# Temporary command to exercise the new @GracefulShutdown sysproc.
+# Temporary command to exercise the new @OpShutdown sysproc.
 # No intention to ship this as-is.
 ######################
 
@@ -40,7 +40,7 @@ from voltcli.hostinfo import Hosts
     )
 )
 
-def gshutdown(runner):
+def opshutdown(runner):
     if runner.opts.forcing and runner.opts.save:
        runner.abort_with_help('You cannot specify both --force and --save options.')
     if runner.opts.cancel and runner.opts.save:
@@ -82,7 +82,7 @@ def gshutdown(runner):
             shutdown_options |= 1
         if runner.opts.xforce:
             shutdown_options |= 2
-        response = runner.call_proc('@GracefulShutdown',
+        response = runner.call_proc('@OpShutdown',
                                     [VOLT.FastSerializer.VOLTTYPE_INTEGER, VOLT.FastSerializer.VOLTTYPE_INTEGER, VOLT.FastSerializer.VOLTTYPE_INTEGER],
                                     [shutdown_options, runner.opts.timeout, runner.opts.waitlimit],
                                 check_status=False)

--- a/lib/python/voltcli/voltadmin.d/opstop.py
+++ b/lib/python/voltcli/voltadmin.d/opstop.py
@@ -15,7 +15,7 @@
 # along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
 
 ######################
-# Temporary command to exercise the new @GracefulStopNode sysproc.
+# Temporary command to exercise the new @OpStopNode sysproc.
 # No intention to ship this as-is.
 ######################
 
@@ -37,7 +37,7 @@ import sys
     ),
 )
 
-def gstop(runner):
+def opstop(runner):
 
     # Exec @SystemInformation to find out about the cluster.
     response = runner.call_proc('@SystemInformation',
@@ -85,7 +85,7 @@ def gstop(runner):
     # Not forcing
     try:
         runner.info('Stopping host %d: %s:%s' % (thost.id, thost.hostname, thost.internalport))
-        response = runner.call_proc('@GracefulStopNode',
+        response = runner.call_proc('@OpStopNode',
                                     [VOLT.FastSerializer.VOLTTYPE_INTEGER, VOLT.FastSerializer.VOLTTYPE_INTEGER, VOLT.FastSerializer.VOLTTYPE_INTEGER],
                                     [thost.id, runner.opts.timeout, runner.opts.waitlimit],
                                     check_status=False)

--- a/src/frontend/org/voltdb/CommandLog.java
+++ b/src/frontend/org/voltdb/CommandLog.java
@@ -202,7 +202,7 @@ public interface CommandLog {
     public void populateCommandLogStats(Map<String, Integer> columnNameToIndex, Object[] rowValues);
 
     /**
-     * Statistics-related interface, used by @GracefulShutdown
+     * Statistics-related interface, used by @OpShutdown.
      * Implementaton should return outstanding byte count
      * in out[0], outstanding txn count in out[1].
      * If counts are not available, ok to do nothing.

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -370,16 +370,6 @@ public class SystemProcedureCatalog {
                         false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.NOT_DURABLE,
                         true, true, Restartability.NOT_RESTARTABLE));
-        builder.put("@GracefulShutdown",
-                new Config("org.voltdb.sysprocs.GracefulShutdown",
-                        false, false, false, 0, VoltType.INVALID,
-                        false, false, true, Durability.NOT_APPLICABLE,
-                        true, false, Restartability.NOT_APPLICABLE));
-        builder.put("@GracefulShutdownWait",
-                new Config("org.voltdb.sysprocs.GracefulShutdownWait",
-                        false, false, false, 0, VoltType.INVALID,
-                        false, false, true, Durability.NOT_APPLICABLE,
-                        true, false, Restartability.NOT_APPLICABLE));
         builder.put("@ProfCtl",
                 new Config("org.voltdb.sysprocs.ProfCtl",
                         false, false, true, 0, VoltType.INVALID,
@@ -548,11 +538,6 @@ public class SystemProcedureCatalog {
                         true,  false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.NOT_APPLICABLE,
                         false, true, Restartability.NOT_APPLICABLE));
-        builder.put("@GracefulStopNode",
-                new Config("org.voltdb.sysprocs.GracefulStopNode",
-                        true, false, false, 0, VoltType.INVALID,
-                        false, false, true, Durability.NOT_APPLICABLE,
-                        false, false, Restartability.NOT_APPLICABLE));
         builder.put("@Explain",
                 new Config("org.voltdb.sysprocs.Explain",
                         false, true, false, 0, VoltType.INVALID,
@@ -689,7 +674,22 @@ public class SystemProcedureCatalog {
                         false, false, false,  0, VoltType.INVALID,
                         true, false, true, Durability.NOT_DURABLE,
                         false, true, Restartability.RESTARTABLE));
-
+        // Added for k8s operator support.
+        builder.put("@OpStopNode",
+                new Config("org.voltdb.sysprocs.OpStopNode",
+                        true, false, false, 0, VoltType.INVALID,
+                        false, false, true, Durability.NOT_APPLICABLE,
+                        false, false, Restartability.NOT_APPLICABLE));
+        builder.put("@OpShutdown",
+                new Config("org.voltdb.sysprocs.OpShutdown",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, Durability.NOT_APPLICABLE,
+                        true, false, Restartability.NOT_APPLICABLE));
+        builder.put("@OpShutdownWait",
+                new Config("org.voltdb.sysprocs.OpShutdownWait",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, Durability.NOT_APPLICABLE,
+                        true, false, Restartability.NOT_APPLICABLE)); 
         listing = builder.build();
     }
 

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -689,7 +689,7 @@ public class SystemProcedureCatalog {
                 new Config("org.voltdb.sysprocs.OpShutdownWait",
                         false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.NOT_APPLICABLE,
-                        true, false, Restartability.NOT_APPLICABLE)); 
+                        true, false, Restartability.NOT_APPLICABLE));
         listing = builder.build();
     }
 

--- a/src/frontend/org/voltdb/sysprocs/OpStopNode.java
+++ b/src/frontend/org/voltdb/sysprocs/OpStopNode.java
@@ -45,7 +45,7 @@ import org.voltdb.client.ClientResponse;
  * This procedure must be executed on some host which is not
  * the node that is being stopped.
  */
-public class GracefulStopNode extends VoltNTSystemProcedure {
+public class OpStopNode extends VoltNTSystemProcedure {
 
     private final static VoltLogger log = new VoltLogger("HOST");
     private final static int SYSPROC_CALL_TIMEOUT = 10 * 1000; // 10 seconds
@@ -55,7 +55,9 @@ public class GracefulStopNode extends VoltNTSystemProcedure {
 
     /**
      * Shut down a node gracefully. This is to be executed on
-     * a host that is not the one being shut down.
+     * a host that is not the one being shut down. The procedure
+     * is intended for use in operator automation scenarios, and
+     * is not currently exposed to end users.
      *
      * @param hostId the host that is to be stopped
      * @param progressTmo time limit on lack of progress on one source
@@ -67,10 +69,10 @@ public class GracefulStopNode extends VoltNTSystemProcedure {
      */
     public VoltTable[] run(Integer hostId, Integer progressTmo, Integer waitTmo) {
         if (hostId == null) {
-             throw new VoltAbortException("@GracefulStopNode requires a host id");
+             throw new VoltAbortException("@OpStopNode requires a host id");
         }
         if (!isAdminConnection()) {
-            throw new VoltAbortException("@GracefulStopNode requires an admin connection");
+            throw new VoltAbortException("@OpStopNode requires an admin connection");
         }
 
         info("Graceful stopping of host %d requested", hostId);


### PR DESCRIPTION
GracefulShutdown, GracefulShutdownWait, GracefulStopNode now have names starting with 'Op' rather that 'Graceful'.

This is in response to a suggestion from @ajgent to adopt common prefixing.  Not everything we need to add for k8s operator support will necessarily be graceful.  

