### PR TITLE
ENG-19147, send repair only in necessary

### DIFF
--- a/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
+++ b/src/frontend/org/voltdb/iv2/MpInitiatorMailbox.java
@@ -252,11 +252,13 @@ public class MpInitiatorMailbox extends InitiatorMailbox
                 // and no pending repair was cancelled previously, the repair
                 // message is not necessarily needed
                 boolean skipRepair = balanceSPI;
+                if (m_algo != null && m_algo.isCancelled()) {
+                    skipRepair = false;
+                }
                 // If a replica set has been configured and it changed during
                 // promotion, must cancel the term
                 if (m_algo != null) {
                     m_algo.cancel();
-                    skipRepair = false;
                 }
                 ((MpScheduler)m_scheduler).updateReplicas(replicas, partitionMasters, balanceSPI, skipRepair);
             }

--- a/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/MpPromoteAlgo.java
@@ -153,6 +153,11 @@ public class MpPromoteAlgo implements RepairAlgo
         return m_promotionResult.cancel(false);
     }
 
+    @Override
+    public boolean isCancelled() {
+        return m_promotionResult.isCancelled();
+    }
+
     /** Start fixing survivors: setup scoreboard and request repair logs. */
     void prepareForFaultRecovery()
     {

--- a/src/frontend/org/voltdb/iv2/RepairAlgo.java
+++ b/src/frontend/org/voltdb/iv2/RepairAlgo.java
@@ -72,4 +72,7 @@ public interface RepairAlgo
 
     /** Process a new repair log response */
     public void deliver(VoltMessage message);
+
+    /** Was the future returned by start() cancelled*/
+    public boolean isCancelled();
 }

--- a/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
+++ b/src/frontend/org/voltdb/iv2/SpPromoteAlgo.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeSet;
 import java.util.concurrent.Future;
+
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.messaging.Iv2RepairLogRequestMessage;
@@ -135,6 +136,11 @@ public class SpPromoteAlgo implements RepairAlgo
     public boolean cancel()
     {
         return m_promotionResult.cancel(false);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return m_promotionResult.isCancelled();
     }
 
     /** Start fixing survivors: setup scoreboard and request repair logs. */
@@ -263,4 +269,5 @@ public class SpPromoteAlgo implements RepairAlgo
 
         m_promotionResult.set(new RepairResult(m_maxSeenTxnId, Long.MIN_VALUE));
     }
+
 }


### PR DESCRIPTION
The previous attempt to fix it isn't complete, partly because the m_algo is always not null. @MigratePartitionLeader sends repair even if it didn't cancel the previous repair.
