### PR TITLE
ENG-19314: Additional ignoreOrder option for snapshot consitent checking

### DIFF
--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1891,24 +1891,10 @@ public final class VoltTable extends VoltTableRow implements JSONString {
      * @return Whether the tables have the same contents.
      */
     public boolean hasSameContents(VoltTable other) {
-        assert(verifyTableInvariants());
-        if (this == other) {
-            return true;
-        }
-
-        int mypos = m_buffer.position();
-        int theirpos = other.m_buffer.position();
-        if (mypos != theirpos) {
-            return false;
-        }
-        long checksum1 = ClientUtils.cheesyBufferCheckSum(m_buffer);
-        long checksum2 = ClientUtils.cheesyBufferCheckSum(other.m_buffer);
-        boolean checksum = (checksum1 == checksum2);
-        assert(verifyTableInvariants());
-        return checksum;
+        return hasSameContents(other, true);
     }
 
-    public boolean hasSameContentsWithOrder(VoltTable other) {
+    public boolean hasSameContents(VoltTable other, boolean ignoreOrder) {
         assert(verifyTableInvariants());
         if (this == other) {
             return true;
@@ -1919,8 +1905,14 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         if (mypos != theirpos) {
             return false;
         }
-        long checksum1 = ClientUtils.cheesyBufferCheckSumWithOrder(m_buffer);
-        long checksum2 = ClientUtils.cheesyBufferCheckSumWithOrder(other.m_buffer);
+        long checksum1, checksum2;
+        if (ignoreOrder) {
+            checksum1 = ClientUtils.cheesyBufferCheckSum(m_buffer);
+            checksum2 = ClientUtils.cheesyBufferCheckSum(other.m_buffer);
+        } else {
+            checksum1 = ClientUtils.cheesyBufferCheckSumWithOrder(m_buffer);
+            checksum2 = ClientUtils.cheesyBufferCheckSumWithOrder(other.m_buffer);
+        }
         boolean checksum = (checksum1 == checksum2);
         assert(verifyTableInvariants());
         return checksum;

--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1918,6 +1918,13 @@ public final class VoltTable extends VoltTableRow implements JSONString {
         return checksum;
     }
 
+    public long updateCheckSum(long preCheckSum) {
+        assert(verifyTableInvariants());
+        preCheckSum += ClientUtils.cheesyBufferCheckSum(m_buffer);
+        assert(verifyTableInvariants());
+        return preCheckSum;
+    }
+
     /**
      *  An unreliable version of {@link java.lang.Object#equals(Object)} that should not be used. Only
      *  present for unit testing.


### PR DESCRIPTION
Use --ignoreOrder for ignore all row order checking
Use -ignoreChunkOrder for only ignore row order with incorresponding chunk, but still assume rows within same chunk are same.

e.g.
| => ~/workspace/voltdb/tools/snapshotcomparer.sh --self --nonce MANUAL1581622336043 --dirs ./host0,./host1
Finished comparing table AREA_CODE_STATE.

Finished comparing table VOTES.

Finished comparing table V_VOTES_BY_PHONE_NUMBER.

Diffs between file ./host0/MANUAL1581622336043-CONTESTANTS.vpt and file ./host1/MANUAL1581622336043-CONTESTANTS.vpt
  1,Edwina Burnam
  2,Tabatha Gehling
  3,Kelly Clauss
 -4,Jessie Alloway
 +4,Jessie Eichman
  5,Alana Bregman
 -6,Jessie Eichman
 +6,Jessie Alloway

WARN: Replicated Table CONTESTANTS is inconsistent between host0 with host1 on partition 16383
Finished comparing table CONTESTANTS.

Finished comparing all tables.
The inconsistent tables are: [CONTESTANTS]
________________________________________________________________________________
| => ~/workspace/voltdb/tools/snapshotcomparer.sh --self --nonce MANUAL1581622336043 --dirs ./host0,./host1 **--ignoreOrder**
Finished comparing table AREA_CODE_STATE.

Finished comparing table VOTES.

Finished comparing table V_VOTES_BY_PHONE_NUMBER.

Finished comparing table CONTESTANTS.

Finished comparing all tables.