### PR TITLE
ENG-19206, repair all SPs with every CompleteTransactionMessage the MPI collects

### DIFF
--- a/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
+++ b/tests/frontend/org/voltdb/iv2/TestMpPromoteAlgo.java
@@ -252,7 +252,7 @@ public class TestMpPromoteAlgo
         needsRepair.add(1L);
         needsRepair.add(2L);
         needsRepair.add(3L);
-        inOrder.verify(mailbox, times(1)).repairReplicasWith(eq(needsRepair), any(CompleteTransactionMessage.class));
+        inOrder.verify(mailbox, times(3)).repairReplicasWith(eq(needsRepair), any(CompleteTransactionMessage.class));
 
         assertEquals(txnEgo(1003L), result.get().m_txnId);
     }


### PR DESCRIPTION
we used to assume repairing with only the latest CompleteTransactionMessage is enough to clear transaction queue and scoreboard of SP, but this assumption no longer holds when we introduce partition leader migration. The replica of the away leader may fall behind to other partitions, before it catches up a rollback completion message of newer transaction can eat up prior CompleteTransactionMessage if a MP repair happened during this window. This issue could lead to orphaned entry of scoreboard, which freezes the database.

Change-Id: I41fb00c57c22cf835980a5d2f7fbfd04e58d96fe