### PR TITLE
ENG-19277, force sync_file_range() if available snapshot write permits running low.

### DIFF
--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -299,7 +299,8 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
                 //Only sync for at least 4 megabyte of data, enough to amortize the cost of seeking
                 //on ye olden platters. Since we are appending to a file it's actually 2 seeks.
                 while (m_bytesWrittenSinceLastSync.get() > (1024 * 1024 * 4) ||
-                        s_bytesAllowedBeforeSync.availablePermits() < SnapshotSiteProcessor.m_snapshotBufferLength) {
+                        (m_bytesWrittenSinceLastSync.get() > 0 &&
+                                s_bytesAllowedBeforeSync.availablePermits() < SnapshotSiteProcessor.m_snapshotBufferLength)) {
                     long positionAtSync = 0;
                     try {
                         positionAtSync = m_channel.position();


### PR DESCRIPTION
Each table (and materialized view) has a snapshot data target. For all data targets combined together they can write up to 256M data between sync. Sync thread flushes dirty page to disk if any data target has more than 4MB data in page cache.

What will happen if snapshotting a large number of tables in the same time? 

One possibility is that every data target could have less than 4MB data in page cache, but in total all data targets write more than 256M data to file. Some targets will sleep because they fail to acquire the write permit, they will never wake up!
