### PR TITLE
ENG-19335: Add mastership change message as indeterminate

### DIFF
--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TruncateTableLoader.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TruncateTableLoader.java
@@ -175,8 +175,8 @@ public class TruncateTableLoader extends BenchmarkThread {
         // if we can't tell if the txn committed or not
         if (!result && TxnId2Utils.isTransactionStateIndeterminate(clientResponse)) {
             // the best we can do is check that neither table has been mutated is some unexpected way
-            if ( ! (afterRowCounts[0] == b4RowCounts[0] || afterRowCounts[0] == b4RowCounts[1])
-                    || ! (afterRowCounts[1] == b4RowCounts[0] || afterRowCounts[1] == b4RowCounts[1])) {
+            if ( ! (afterRowCounts[0] == b4RowCounts[0] && afterRowCounts[1] == b4RowCounts[1])
+                    && ! (afterRowCounts[1] == b4RowCounts[0] && afterRowCounts[0] == b4RowCounts[1])) {
                 String message = swapProcName + " on " + tableName + ", " + swapTableName
                         + " count(s) are not as expected after an indeterminate result: before: " + b4RowCounts[0] + ", " + b4RowCounts[1]
                         + " after: " + afterRowCounts[0] + ", " + afterRowCounts[1] + ", rollback: " + shouldRollback;
@@ -187,7 +187,7 @@ public class TruncateTableLoader extends BenchmarkThread {
             // if shouldRollback is set the operation will fail (ie. result will be false)
             // z==0 compares the counts in the swapped (success) configuration
             int z = result ? 0 : 1;
-            if (afterRowCounts[(z + 0) & 1] != b4RowCounts[1] || afterRowCounts[(z + 1) & 1] != b4RowCounts[0]) {
+            if (afterRowCounts[z] != b4RowCounts[1] || afterRowCounts[(z + 1) & 1] != b4RowCounts[0]) {
                 String message = swapProcName + " on " + tableName + ", " + swapTableName
                         + " failed to swap row counts correctly: went from " + b4RowCounts[0] + ", " + b4RowCounts[1]
                         + " to " + afterRowCounts[0] + ", " + afterRowCounts[1] + ", rollback: " + shouldRollback;

--- a/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2Utils.java
+++ b/tests/test_apps/txnid-selfcheck2/src/txnIdSelfCheck/TxnId2Utils.java
@@ -66,7 +66,8 @@ public enum TxnId2Utils {;
     static boolean isTransactionStateIndeterminate(ClientResponse cr) {
         String statusString = cr.getStatusString();
         return (statusString.matches("(?s).*No response received in the allotted time.*") ||
-                statusString.matches(".*Connection to database host \\(.*\\) was lost before a response was received.*"));
+                statusString.matches(".*Connection to database host \\(.*\\) was lost before a response was received.*") ||
+                statusString.matches(".*Transaction dropped due to change in mastership. It is possible the transaction was committed.*"));
     }
 
 


### PR DESCRIPTION
Consider the error message that mastership changed and the transaction may or may not been appliead as ndeterminate.

TruncateTableLoader: Update some logic to be simpler or more correct