### PR TITLE
ENG-19355: Move ExportTupleStream to new StreamedTable

### DIFF
--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -225,6 +225,10 @@ void PersistentTable::truncateTableUndo(TableCatalogDelegate* tcd,
         unsetTableForStreamIndexing();
     }
 
+    if (m_shadowStream != nullptr) {
+        m_shadowStream->moveWrapperTo(originalTable->m_shadowStream);
+    }
+
     VoltDBEngine* engine = ExecutorContext::getEngine();
     auto views = originalTable->views();
     // reset all view table pointers
@@ -382,6 +386,10 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, 
         vassert(! emptyTable->hasPurgeFragment());
         boost::shared_ptr<ExecutorVector> evPtr = getPurgeExecutorVector();
         emptyTable->swapPurgeExecutorVector(evPtr);
+    }
+
+    if (m_shadowStream != nullptr) {
+        m_shadowStream->moveWrapperTo(emptyTable->m_shadowStream);
     }
 
     engine->rebuildTableCollections(replicatedTable, false);

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -146,6 +146,14 @@ public:
         }
     }
 
+    /**
+     * Move the ExportTupleStream wrapper from this streamed table to other. Setting this wrapper to null
+     */
+    void moveWrapperTo(StreamedTable *other) {
+        other->setWrapper(m_wrapper);
+        m_wrapper = nullptr;
+    }
+
     ExportTupleStream* getWrapper() {
         return m_wrapper;
     }


### PR DESCRIPTION
When recreating a table because of a truncate if the table has a shadow stream the ExportTupleStream in the StreamedTable needs to be moved from the original StreamedTable to the new one. If the transaction is undone the stream needs to be moved back.