### PR TITLE
ENG-19308:

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -352,6 +352,15 @@ Table* VoltDBEngine::getTableByName(const std::string& name) const {
     return findInMapOrNull(name, m_tablesByName);
 }
 
+StreamedTable* VoltDBEngine::getStreamTableByName(const std::string& name) const {
+    return findInMapOrNull(name, m_exportingTables);
+}
+
+void VoltDBEngine::setStreamTableByName(std::string const& name, StreamedTable* newStreamTable) {
+    vassert(findInMapOrNull(name, m_exportingTables) != NULL);
+    m_exportingTables[name] = newStreamTable;
+}
+
 TableCatalogDelegate* VoltDBEngine::getTableDelegate(const std::string& name) const {
     // Caller responsible for checking null return value.
     return findInMapOrNull(name, m_delegatesByName);

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -165,6 +165,8 @@ class __attribute__((visibility("default"))) VoltDBEngine {
         catalog::Table* getCatalogTable(std::string const& name) const;
         Table* getTableById(int32_t tableId) const;
         Table* getTableByName(std::string const& name) const;
+        StreamedTable* getStreamTableByName(std::string const& name) const;
+        void setStreamTableByName(std::string const& name, StreamedTable* newStreamTable);
         TableCatalogDelegate* getTableDelegate(std::string const& name) const;
 
         // Serializes table_id to out. Throws a fatal exception if unsuccessful.

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -225,11 +225,12 @@ void PersistentTable::truncateTableUndo(TableCatalogDelegate* tcd,
         unsetTableForStreamIndexing();
     }
 
+    VoltDBEngine* engine = ExecutorContext::getEngine();
     if (m_shadowStream != nullptr) {
         m_shadowStream->moveWrapperTo(originalTable->m_shadowStream);
+        engine->setStreamTableByName(m_name, originalTable->m_shadowStream);
     }
 
-    VoltDBEngine* engine = ExecutorContext::getEngine();
     auto views = originalTable->views();
     // reset all view table pointers
     BOOST_FOREACH (auto originalView, views) {
@@ -390,6 +391,7 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, 
 
     if (m_shadowStream != nullptr) {
         m_shadowStream->moveWrapperTo(emptyTable->m_shadowStream);
+        engine->setStreamTableByName(m_name, emptyTable->m_shadowStream);
     }
 
     engine->rebuildTableCollections(replicatedTable, false);

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -399,6 +399,7 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     table = dynamic_cast<PersistentTable*>(engine->getTableByName("T"));
     ASSERT_NE(NULL, table);
     ASSERT_NE(nullptr, table->getStreamedTable());
+    ASSERT_EQ(table->getStreamedTable(), engine->getStreamTableByName("T"));
     ASSERT_NE(nullptr, table->getStreamedTable()->getWrapper());
 
     // Test rollback of truncate table
@@ -410,6 +411,7 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     ASSERT_EQ(nullptr, table->getStreamedTable()->getWrapper());
     rollback();
 
+    ASSERT_EQ(table->getStreamedTable(), engine->getStreamTableByName("T"));
     // wrapper should now be back on original table
     ASSERT_NE(nullptr, table->getStreamedTable()->getWrapper());
 }


### PR DESCRIPTION
When a table with a shadow stream (migrate or Change-Data-Capture) is truncated, the shadow stream of the new (empty) table is not updated correctly. Tosting did not find this previously because small tables are not replaced with new tables whereas now a truncate always creates a new empty table.