### PR TITLE
Add deepcopier callback 2

### DIFF
--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -183,15 +183,7 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
 }
 
 void CopyOnWriteContext::notifyTupleUpdate(TableTuple &tuple) {
-    auto const& entry = m_allocator.template update<storage::truth>(tuple.address());
-    if (tuple.m_schema->getUninlinedObjectColumnCount() != 0) {
-        auto e = const_cast<typename PersistentTable::Hook::added_entry_t&>(entry);
-        if (e.copy_of() != nullptr && e.status_of() == PersistentTable::Hook::added_entry_t::status::fresh) {
-            TableTuple copied(tuple.m_schema);
-            copied.move(const_cast<void*>(e.copy_of()));
-            copied.copyNonInlinedColumnObjects(tuple);
-        }
-    }
+    m_allocator.template update<storage::truth>(tuple.address());
 }
 
 }

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -603,9 +603,10 @@ namespace std {                                    // Need to declare these befo
     };
 }
 
-CompactingChunks::CompactingChunks(size_t tupleSize, function<void(void const*)> const& cb) noexcept :
+CompactingChunks::CompactingChunks(size_t tupleSize,
+        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
     list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
-    m_txnFirstChunk(*this), m_finalize(cb), m_batched(*this) {}
+    m_txnFirstChunk(*this), m_finalizerAndCopier(cb), m_batched(*this) {}
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
@@ -692,10 +693,10 @@ inline typename CompactingChunks::list_type::iterator CompactingChunks::releasab
 }
 
 inline void CompactingChunks::pop_finalize(typename CompactingChunks::list_type::iterator iter) const {
-    if (m_finalize && iter->range_begin() < iter->range_next()) {
+    if (m_finalizerAndCopier && iter->range_begin() < iter->range_next()) {
         for (char const* ptr = reinterpret_cast<char const*>(iter->range_begin());
                 ptr < iter->range_next(); ptr += tupleSize()) {
-            (*m_finalize)(ptr);
+            m_finalizerAndCopier->first(ptr);
         }
     }
 }
@@ -753,7 +754,7 @@ inline void CompactingChunks::clear(Remove_cb const& cb) {
                 [&cb] (void const* p) noexcept {cb(p);});
         if (frozen()) {
             assert(frozenBoundaries());
-            if (m_finalize) {              // finalize the region between frozen right, and txn end
+            if (m_finalizerAndCopier) {              // finalize the region between frozen right, and txn end
                 auto const& frozenRight = frozenBoundaries()->right();
                 if (less<position_type>()(frozenRight, *last())) {
                     for (auto id = frozenRight.chunkId();
@@ -766,7 +767,7 @@ inline void CompactingChunks::clear(Remove_cb const& cb) {
                                     iterp.second->range_begin());
                                 ptr < iterp.second->range_next();
                                 ptr += tupleSize()) {
-                            (*m_finalize)(ptr);
+                            m_finalizerAndCopier->first(ptr);
                         }
                     }
                 }
@@ -832,8 +833,8 @@ void* CompactingChunks::free(void* dst) {
         }
     } else {
         void* src = beginTxn().iterator()->free();
-        if (m_finalize) {
-            (*m_finalize)(src);
+        if (m_finalizerAndCopier) {
+            m_finalizerAndCopier->first(src);
         }
         auto& dst_iter = pos.second;
         if (dst_iter != beginTxn().iterator()) {    // cross-chunk movement needed
@@ -888,8 +889,8 @@ inline ChunksIdNonValidator& ChunksIdNonValidator::instance() {
 }
 
 inline void CompactingChunks::finalize(void const* p) const {
-    if (m_finalize) {
-        (*m_finalize)(p);
+    if (m_finalizerAndCopier) {
+        m_finalizerAndCopier->first(p);
     }
 }
 
@@ -1823,22 +1824,6 @@ inline void HistoryRetainTrait<gc_policy::batched>::remove(void const* addr) {
     }
 }
 
-template<typename Alloc, typename Trait, typename E> inline
-TxnPreHook<Alloc, Trait, E>::added_entry_t::added_entry_t(
-        typename TxnPreHook<Alloc, Trait, E>::added_entry_t::status s, void const* p) noexcept :
-m_status(s), m_copy(const_cast<void*>(p)) {}
-
-template<typename Alloc, typename Trait, typename E> inline
-typename TxnPreHook<Alloc, Trait, E>::added_entry_t::status
-TxnPreHook<Alloc, Trait, E>::added_entry_t::status_of() const noexcept {
-    return m_status;
-}
-
-template<typename Alloc, typename Trait, typename E> inline void*
-TxnPreHook<Alloc, Trait, E>::added_entry_t::copy_of() noexcept {
-    return m_copy;
-}
-
 template<typename Alloc, typename Trait, typename E>
 inline TxnPreHook<Alloc, Trait, E>::TxnPreHook(size_t tupleSize) :
     Trait([this](void const* key) {
@@ -1852,48 +1837,41 @@ inline TxnPreHook<Alloc, Trait, E>::TxnPreHook(size_t tupleSize) :
 
 template<typename Alloc, typename Trait, typename E>
 inline TxnPreHook<Alloc, Trait, E>::~TxnPreHook() {
-    if (m_finalize) {
+    if (m_finalizerAndCopier) {
         for_each(m_changes.cbegin(), m_changes.cend(),
                 [this] (typename map_type::value_type const& entry) {
-                    (*m_finalize)(entry.second);
+                    m_finalizerAndCopier->first(entry.second);
                 });
     }
 }
 
 template<typename Alloc, typename Trait, typename E> inline
-TxnPreHook<Alloc, Trait, E>::TxnPreHook(size_t tupleSize, function<void(void const*)> const& cb) :
+TxnPreHook<Alloc, Trait, E>::TxnPreHook(size_t tupleSize,
+        typename CompactingChunks::finalizer_and_copier_type const& cb) :
     Trait([this](void const* key) {
                 auto const& iter = m_changes.find(key);
                 if (iter != m_changes.end()) {
-                    (*m_finalize)(iter->second);               // call back on local copy of old value
+                    m_finalizerAndCopier->first(iter->second);               // call back on local copy of old value
                     m_changes.erase(iter);
                     m_changeStore.free(const_cast<void*>(key));
                 }
             }),
-    m_changeStore(tupleSize), m_finalize(cb) {}
+    m_changeStore(tupleSize), m_finalizerAndCopier(cb) {}
 
 template<typename Alloc, typename Trait, typename E1>
-template<typename IteratorObserver, typename E2> inline
-typename TxnPreHook<Alloc, Trait, E1>::added_entry_t TxnPreHook<Alloc, Trait, E1>::add(
+template<typename IteratorObserver, typename E2> inline void TxnPreHook<Alloc, Trait, E1>::add(
         void const* dst, IteratorObserver& obs) {
-    auto status = added_entry_t::status::not_frozen;
-    if (m_recording && added_entry_t::status::fresh ==
-            (status = obs(dst) ? added_entry_t::status::ignored : added_entry_t::status::fresh)) {
+    if (m_recording && ! obs(dst)) {
         auto const iter = m_changes.lower_bound(dst);
-        if (iter != m_changes.cend() && iter->first == dst) {          // copy already exists
-            return {added_entry_t::status::existing, iter->second};
-        } else {               // create a fresh copy
-            return {status,
-                m_changes.emplace_hint(
-                        iter, dst, memcpy(m_changeStore.allocate(), dst, m_changeStore.tupleSize()))->second};
+        if (iter == m_changes.cend() || iter->first != dst) {   // create a fresh copy
+            void *fresh = m_changeStore.allocate();
+            if (m_finalizerAndCopier) {                         // invoke deep copier
+                m_finalizerAndCopier->second(fresh, dst);
+            } else {
+                memcpy(fresh, dst, m_changeStore.tupleSize());
+            }
+            m_changes.emplace_hint(iter, dst, fresh);           // then, add map entry
         }
-    } else if (m_recording) {
-        // ignored state: the tuple may, or may not, have a local
-        // copy of its original value
-        auto const& iter = m_changes.find(dst);
-        return {status, iter == m_changes.cend() ? nullptr : iter->second};
-    } else {                   // not frozen
-        return {};
     }
 }
 
@@ -1907,9 +1885,9 @@ template<typename Alloc, typename Trait, typename E> inline void TxnPreHook<Allo
 
 template<typename Alloc, typename Trait, typename E> inline void TxnPreHook<Alloc, Trait, E>::thaw() {
     if (m_recording) {
-        if (m_finalize) {
+        if (m_finalizerAndCopier) {
             for_each(m_changes.begin(), m_changes.end(),
-                    [this](typename map_type::value_type& p) { (*m_finalize)(p.second); });
+                    [this](typename map_type::value_type& p) { m_finalizerAndCopier->first(p.second); });
         }
         m_changes.clear();
         m_changeStore.clear();
@@ -1935,7 +1913,8 @@ HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s) noexcept : Com
 
 template<typename Hook, typename E> inline
 HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s,
-        function<void(void const*)> const& cb) noexcept : CompactingChunks(s, cb), Hook(s, cb) {}
+        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
+CompactingChunks(s, cb), Hook(s, cb.first) {}
 
 template<typename Hook, typename E> inline void* HookedCompactingChunks<Hook, E>::allocate() {
     void* r = CompactingChunks::allocate();
@@ -1962,10 +1941,9 @@ HookedCompactingChunks<Hook, E>::remove(typename CompactingChunks::remove_direct
 }
 
 template<typename Hook, typename E>
-template<typename Tag> inline typename Hook::added_entry_t
-HookedCompactingChunks<Hook, E>::update(void* dst) {
+template<typename Tag> inline void HookedCompactingChunks<Hook, E>::update(void* dst) {
     VOLT_TRACE("update(%p)", dst);
-    return Hook::add(dst, reinterpret_cast<observer_type<Tag>&>(m_iterator_observer));
+    Hook::add(dst, reinterpret_cast<observer_type<Tag>&>(m_iterator_observer));
 }
 
 template<typename Hook, typename E>
@@ -1990,13 +1968,10 @@ template<typename Tag> inline void HookedCompactingChunks<Hook, E>::thaw() {
 }
 
 template<typename Hook, typename E>
-template<typename Tag> inline typename Hook::added_entry_t
-HookedCompactingChunks<Hook, E>::remove_add(void* p) {
+template<typename Tag> inline void HookedCompactingChunks<Hook, E>::remove_add(void* p) {
     CompactingChunks::m_batched.add(p);
     if (frozen()) {            // hook registration
-        return Hook::add(p, reinterpret_cast<observer_type<Tag>&>(m_iterator_observer));
-    } else {
-        return {Hook::added_entry_t::status::not_frozen, nullptr};
+        Hook::add(p, reinterpret_cast<observer_type<Tag>&>(m_iterator_observer));
     }
 }
 
@@ -2198,8 +2173,7 @@ HookedIteratorCodegen(NthBitChecker<6>); HookedIteratorCodegen(NthBitChecker<7>)
 #undef HookedIteratorCodegen3
 // template member methods
 #define HookedMethods4(tag, alloc, gc, alloc2)                                           \
-template typename TxnPreHook<alloc, HistoryRetainTrait<gc>>::added_entry_t               \
-    TxnPreHook<alloc, HistoryRetainTrait<gc>>::add<typename                              \
+template void TxnPreHook<alloc, HistoryRetainTrait<gc>>::add<typename                    \
         IterableTableTupleChunks<alloc2, tag, void>::IteratorObserver, void>(            \
             void const*,                                                                 \
             typename IterableTableTupleChunks<alloc2, tag, void>::IteratorObserver&)
@@ -2216,11 +2190,9 @@ template shared_ptr<typename IterableTableTupleChunks<                          
         HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>, tag, void>::hooked_iterator>    \
 HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::freeze<tag>();  \
 template void HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::thaw<tag>();              \
-template typename TxnPreHook<alloc, HistoryRetainTrait<gc>>::added_entry_t               \
-    HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::update<tag>(void*);                 \
+template void HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::update<tag>(void*);       \
 template void HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::clear<tag>();             \
-template typename TxnPreHook<alloc, HistoryRetainTrait<gc>>::added_entry_t               \
-HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::remove_add<tag>(void*);                 \
+template void HookedCompactingChunks<TxnPreHook<alloc, HistoryRetainTrait<gc>>, void>::remove_add<tag>(void*);   \
 HookedMethods3(tag, alloc, gc)
 
 #define HookedMethods1(tag, alloc)                                                       \

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -603,11 +603,10 @@ namespace std {                                    // Need to declare these befo
     };
 }
 
-CompactingChunks::CompactingChunks(size_t tupleSize, function<void(void const*)> const& cleaner,
-      function<void*(void*, void const*)> const& copier) noexcept :
-    list_type(tupleSize),CompactingStorageTrait(static_cast<list_type&>(*this)),
-    m_txnFirstChunk(*this),m_finalizerAndCopier(std::make_pair(cleaner, copier)), m_batched(*this) {
-}
+CompactingChunks::CompactingChunks(size_t tupleSize,
+        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
+    list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
+    m_txnFirstChunk(*this), m_finalizerAndCopier(cb), m_batched(*this) {}
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
@@ -1913,9 +1912,9 @@ template<typename Hook, typename E> inline
 HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s) noexcept : CompactingChunks(s), Hook(s) {}
 
 template<typename Hook, typename E> inline
-HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s, function<void(void const*)> const& cleaner,
-        function<void*(void*, void const*)> const& copier) noexcept :
-CompactingChunks(s, cleaner, copier), Hook(s, cleaner) {}
+HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s,
+        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
+CompactingChunks(s, cb), Hook(s, cb) {}
 
 template<typename Hook, typename E> inline void* HookedCompactingChunks<Hook, E>::allocate() {
     void* r = CompactingChunks::allocate();

--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -603,10 +603,11 @@ namespace std {                                    // Need to declare these befo
     };
 }
 
-CompactingChunks::CompactingChunks(size_t tupleSize,
-        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
-    list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
-    m_txnFirstChunk(*this), m_finalizerAndCopier(cb), m_batched(*this) {}
+CompactingChunks::CompactingChunks(size_t tupleSize, function<void(void const*)> const& cleaner,
+      function<void*(void*, void const*)> const& copier) noexcept :
+    list_type(tupleSize),CompactingStorageTrait(static_cast<list_type&>(*this)),
+    m_txnFirstChunk(*this),m_finalizerAndCopier(std::make_pair(cleaner, copier)), m_batched(*this) {
+}
 
 CompactingChunks::CompactingChunks(size_t tupleSize) noexcept :
     list_type(tupleSize), CompactingStorageTrait(static_cast<list_type&>(*this)),
@@ -1912,9 +1913,9 @@ template<typename Hook, typename E> inline
 HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s) noexcept : CompactingChunks(s), Hook(s) {}
 
 template<typename Hook, typename E> inline
-HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s,
-        typename CompactingChunks::finalizer_and_copier_type const& cb) noexcept :
-CompactingChunks(s, cb), Hook(s, cb.first) {}
+HookedCompactingChunks<Hook, E>::HookedCompactingChunks(size_t s, function<void(void const*)> const& cleaner,
+        function<void*(void*, void const*)> const& copier) noexcept :
+CompactingChunks(s, cleaner, copier), Hook(s, cleaner) {}
 
 template<typename Hook, typename E> inline void* HookedCompactingChunks<Hook, E>::allocate() {
     void* r = CompactingChunks::allocate();

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -669,7 +669,7 @@ namespace voltdb {
         public:
             // for use in HookedCompactingChunks::remove() [batch mode]:
             CompactingChunks(size_t tupleSize) noexcept;
-            CompactingChunks(size_t tupleSize, finalizer_and_copier_type const&) noexcept;
+            CompactingChunks(size_t tupleSize, function<void(void const*)> const&, function<void*(void*, void const*)> const&) noexcept;
             ~CompactingChunks();
             /**
              * Queries
@@ -813,8 +813,7 @@ namespace voltdb {
             using hook_type = Hook;                    // for hooked_iterator_type
             using Hook::release;                       // reminds to client: this must be called for GC to happen (instead of delaying it to thaw())
             HookedCompactingChunks(size_t) noexcept;
-            HookedCompactingChunks(size_t,
-                    typename CompactingChunks::finalizer_and_copier_type const&) noexcept;
+            HookedCompactingChunks(size_t, function<void(void const*)> const&, function<void*(void*, void const*)> const&) noexcept;
             template<typename Tag>
             shared_ptr<typename IterableTableTupleChunks<HookedCompactingChunks<Hook, E>, Tag, void>::hooked_iterator>
             freeze();

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -669,7 +669,7 @@ namespace voltdb {
         public:
             // for use in HookedCompactingChunks::remove() [batch mode]:
             CompactingChunks(size_t tupleSize) noexcept;
-            CompactingChunks(size_t tupleSize, function<void(void const*)> const&, function<void*(void*, void const*)> const&) noexcept;
+            CompactingChunks(size_t tupleSize, finalizer_and_copier_type const&) noexcept;
             ~CompactingChunks();
             /**
              * Queries
@@ -775,7 +775,7 @@ namespace voltdb {
             using is_hook = true_type;
 
             TxnPreHook(size_t);
-            TxnPreHook(size_t, function<void(void const*)> const&);
+            TxnPreHook(size_t, typename CompactingChunks::finalizer_and_copier_type const&);
             TxnPreHook(TxnPreHook const&) = delete;
             TxnPreHook(TxnPreHook&&) = delete;
             TxnPreHook& operator=(TxnPreHook const&) = delete;
@@ -813,7 +813,7 @@ namespace voltdb {
             using hook_type = Hook;                    // for hooked_iterator_type
             using Hook::release;                       // reminds to client: this must be called for GC to happen (instead of delaying it to thaw())
             HookedCompactingChunks(size_t) noexcept;
-            HookedCompactingChunks(size_t, function<void(void const*)> const&, function<void*(void*, void const*)> const&) noexcept;
+            HookedCompactingChunks(size_t, typename CompactingChunks::finalizer_and_copier_type const&) noexcept;
             template<typename Tag>
             shared_ptr<typename IterableTableTupleChunks<HookedCompactingChunks<Hook, E>, Tag, void>::hooked_iterator>
             freeze();

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -40,6 +40,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <vector>
+#include <functional>
 namespace voltdb {
 
 #define TABLE_BLOCKSIZE 2097152
@@ -120,13 +121,22 @@ void PersistentTable::initializeWithColumns(TupleSchema* schema,
     // that stores non-inlined tuple data.
     size_t tupleSize = schema->tupleLength() + TUPLE_HEADER_SIZE;
     if (m_schema->getUninlinedObjectColumnCount() > 0) {
-        auto const cleaner = [this] (void const* p) noexcept {
+        auto const cleaner = [this] (void const* p) {
             TableTuple tuple(this->m_schema);
             tuple.move(const_cast<void*>(p));
             this->decreaseStringMemCount(tuple.getNonInlinedMemorySizeForPersistentTable());
             tuple.freeObjectColumns();
         };
-        m_dataStorage.reset(new Alloc (tupleSize, cleaner));
+        auto const copier = [this, &tupleSize] (void* fresh, void const* dest) {
+            memcpy(fresh, dest, tupleSize);
+            TableTuple freshCopy(this->m_schema);
+            freshCopy.move(fresh);
+
+            TableTuple original (this->m_schema);
+            original.move(const_cast<void*>(dest));
+            freshCopy.copyNonInlinedColumnObjects(original);
+        };
+        m_dataStorage.reset(new Alloc (tupleSize, cleaner, copier));
     } else {
         m_dataStorage.reset(new Alloc{tupleSize});
     }
@@ -1201,15 +1211,7 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible, bool remove
     }
 
     allocator().remove_reserve(1);
-    auto const& entry = allocator().template remove_add<storage::truth>(target.address());
-    if (m_schema->getUninlinedObjectColumnCount() != 0) {
-        auto e = const_cast<typename Hook::added_entry_t&>(entry);
-        if (e.copy_of() != nullptr && e.status_of() == Hook::added_entry_t::status::fresh) {
-            TableTuple src(m_schema);
-            src.move(const_cast<void*>(e.copy_of()));
-            target.copyNonInlinedColumnObjects(src);
-        }
-    }
+    allocator().template remove_add<storage::truth>(target.address());
     target.setActiveFalse();
     finalizeRelease();
 }
@@ -1232,15 +1234,7 @@ void PersistentTable::deleteTupleRelease(char* tuple) {
         m_batchDeleteTupleCount = 0;
     }
 
-    auto const& entry = allocator().template remove_add<storage::truth>(tuple);
-    if (m_schema->getUninlinedObjectColumnCount() != 0) {
-        auto e = const_cast<typename Hook::added_entry_t&>(entry);
-        if (e.copy_of() != nullptr && e.status_of() == Hook::added_entry_t::status::fresh) {
-            TableTuple src(m_schema);
-            src.move(const_cast<void*>(e.copy_of()));
-            src.copyNonInlinedColumnObjects(target);
-        }
-    }
+    allocator().template remove_add<storage::truth>(tuple);
 }
 
 /*

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -137,7 +137,7 @@ void PersistentTable::initializeWithColumns(TupleSchema* schema,
             freshCopy.copyNonInlinedColumnObjects(original);
             return fresh;
         };
-        m_dataStorage.reset(new Alloc{tupleSize, make_pair(cleaner, copier)});
+        m_dataStorage.reset(new Alloc{tupleSize, {cleaner, copier}});
     } else {
         m_dataStorage.reset(new Alloc{tupleSize});
     }

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -1914,7 +1914,9 @@ public:
     }
 };
 
-auto const tuple_memcpy = [](void* dst, void const* src) { return memcpy(dst, src, TupleSize); };
+void* tuple_memcpy(void* dst, void const* src) {
+    return memcpy(dst, src, TupleSize);
+}
 
 TEST_F(TableTupleAllocatorTest, TestFinalizer_AllocsOnly) {
     // test allocation-only case
@@ -1922,7 +1924,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_AllocsOnly) {
     using Gen = StringGen<TupleSize>;
     Gen gen;
     finalize_verifier verifier{NumTuples};
-    Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+    Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
     size_t i;
     for (i = 0; i < NumTuples; ++i) {
         gen.fill(alloc.allocate());
@@ -1943,7 +1945,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_AllocAndRemoves) {
     using Gen = StringGen<TupleSize>;
     Gen gen;
     finalize_verifier verifier{NumTuples};
-    Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+    Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
     array<void const*, NumTuples> addresses;
     size_t i;
     for (i = 0; i < NumTuples; ++i) {
@@ -1971,7 +1973,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_FrozenRemovals) {
     using Gen = StringGen<TupleSize>;
     Gen gen;
     finalize_verifier verifier{NumTuples};
-    Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+    Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
     array<void const*, NumTuples> addresses;
     size_t i;
     for (i = 0; i < NumTuples; ++i) {
@@ -2003,7 +2005,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_AllocAndUpdates) {
     using Gen = StringGen<TupleSize>;
     Gen gen;
     finalize_verifier verifier{NumTuples + NumTuples / 2};
-    Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+    Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
     array<void const*, NumTuples> addresses;
     size_t i;
     for (i = 0; i < NumTuples; ++i) {
@@ -2029,7 +2031,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_InterleavedIterator) {
     using Gen = StringGen<TupleSize>;
     Gen gen;
     finalize_verifier verifier{NumTuples + NumTuples / 2};
-    Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+    Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
     array<void const*, NumTuples> addresses;
     size_t i;
     for (i = 0; i < NumTuples; ++i) {
@@ -2078,7 +2080,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_SimpleDtor) {
     Gen gen;
     finalize_verifier verifier{NumTuples};
     {
-        Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+        Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
         size_t i;
         for (i = 0; i < NumTuples; ++i) {
             gen.fill(alloc.allocate());
@@ -2094,7 +2096,7 @@ TEST_F(TableTupleAllocatorTest, TestFinalizer_Snapshot) {
     Gen gen;
     finalize_verifier verifier{NumTuples + AllocsPerChunk * 3};            // 2 additional chunks inserted, one chunk updated
     {
-        Alloc alloc(TupleSize, make_pair([&verifier](void const* p) { verifier(p); }, tuple_memcpy));
+        Alloc alloc(TupleSize, {[&verifier](void const* p) { verifier(p); }, tuple_memcpy});
         array<void const*, NumTuples + AllocsPerChunk * 2> addresses;
         size_t i;
         for (i = 0; i < NumTuples; ++i) {


### PR DESCRIPTION
Use explicit class def for optional pair of call backs.
Also optimized member storage for this optional pair in the hook class.
See also #7019 for the version based on implicit typedef of _truely_ optional pair of call backs.