### PR TITLE
ENG-19385: ensure SocketExporter retries blocks whenever unable to ge…

### DIFF
--- a/src/frontend/org/voltdb/exportclient/SocketExporter.java
+++ b/src/frontend/org/voltdb/exportclient/SocketExporter.java
@@ -233,8 +233,9 @@ public class SocketExporter extends ExportClientBase {
                     }
                 }
             } catch (IOException ex) {
-                m_logger.rateLimitedLog(120, Level.ERROR, null, "Failed to flush to export socket endpoint %s, some servers may be down.", host);
+                m_logger.rateLimitedLog(120, Level.ERROR, null, "Failed to flush to export socket endpoint %s, block will be retried.", host);
                 haplist.clear();
+                throw new RestartBlockException(true);
             }
         }
     }


### PR DESCRIPTION
…t an ack for the block

This failure happening systematically on TestElasticRemove.testDRExportRecoveryWhileDrainingNoSnapshot

junit.framework.AssertionFailedError
at org.voltdb.export.SocketExportTestServer.verifyExportedTuples(SocketExportTestServer.java:159)
at org.voltdb.elastic.ElasticRemoveExportDRTestHelper.verifyConsumerExportRowCount(ElasticRemoveExportDRTestHelper.java:160)
at org.voltdb.elastic.TestElasticRemove.runDRExportRecoveryWhileDraining(TestElasticRemove.java:403)
at org.voltdb.elastic.TestElasticRemove.testDRExportRecoveryWhileDrainingNoSnapshot(TestElasticRemove.java:256)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.lang.Thread.run(Thread.java:748)