### PR TITLE
ENG-19383, adjust the minimum sync threshold for snapshot buffers.

### DIFF
--- a/src/frontend/org/voltcore/utils/Bits.java
+++ b/src/frontend/org/voltcore/utils/Bits.java
@@ -101,7 +101,7 @@ public final class Bits {
     public static long sync_file_range(VoltLogger logger, FileDescriptor fd, FileChannel fc, long syncStart, long positionAtSync) throws IOException {
         //Don't start writeback on the currently appending page to avoid
         //issues with stables pages, hence we move the end back one page
-        long syncedBytes = ((positionAtSync / Bits.pageSize()) - 1) * Bits.pageSize();
+        long syncedBytes = (positionAtSync / Bits.pageSize()) * Bits.pageSize();
         if (PosixAdvise.SYNC_FILE_RANGE_SUPPORTED) {
             final long retval = PosixAdvise.sync_file_range(fd,
                                                             syncStart,

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -296,10 +296,15 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
             private long syncedBytes = 0;
             @Override
             public void run() {
-                //Only sync for at least 4 megabyte of data, enough to amortize the cost of seeking
-                //on ye olden platters. Since we are appending to a file it's actually 2 seeks.
+                /*
+                 * Only sync for at least 4 megabyte of data, enough to amortize the cost of seeking
+                 * on ye olden platters. Since we are appending to a file it's actually 2 seeks.
+                 *
+                 * Sync for at least single page size (4K, thus more frequently) if bytes allowed to
+                 * write is running low.
+                 */
                 while (m_bytesWrittenSinceLastSync.get() > (1024 * 1024 * 4) ||
-                        (m_bytesWrittenSinceLastSync.get() > 0 &&
+                        (m_bytesWrittenSinceLastSync.get() > Bits.pageSize() &&
                                 s_bytesAllowedBeforeSync.availablePermits() < SnapshotSiteProcessor.m_snapshotBufferLength)) {
                     long positionAtSync = 0;
                     try {


### PR DESCRIPTION
Sync for at least single page size (4K, thus more frequently) if bytes allowed to
write is running low. 

Also fixed a miscalculation of stable page write boundary in Bits.java. When a dirty page is written to disk, write() to the same dirty page is blocked until flushing to disk is done. This is called "Stable Page Write". In sync_file_range() calls we avoid syncing the appending page, but the miscalculation of write boundary causes sync thread could only sync to the offset which is 2 pages away from the current write position.

The correct behavior should be:    
```
When current write position is in 
(the initial syncStart is 0)
* 0-4095 -> not allowed to flush, avoid stable page write.
* 4096-8191 -> flush [syncStart, 4095], set next syncStart to 4096
* 8192-12288 -> flush [syncStart, 8191], set next SyncStart to 8192
and so on.
```

