### PR TITLE
ENG-19377:

### DIFF
--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -41,22 +41,27 @@ StreamedTable::StreamedTable(int partitionColumn)
     : Table(1)
     , m_stats(this)
     , m_executorContext(ExecutorContext::getExecutorContext())
-    , m_wrapper(NULL)
+    , m_wrapper(nullptr)
     , m_sequenceNo(0)
     , m_partitionColumn(partitionColumn)
 {
 }
 
-StreamedTable::StreamedTable(ExportTupleStream *wrapper, int partitionColumn)
+StreamedTable::StreamedTable(ExportTupleStream *wrapper)
     : Table(1)
     , m_stats(this)
     , m_executorContext(ExecutorContext::getExecutorContext())
     , m_wrapper(wrapper)
     , m_sequenceNo(0)
-    , m_partitionColumn(partitionColumn)
+    , m_partitionColumn(-1)
 {
 }
 
+StreamedTable *
+StreamedTable::createForTest(ExportTupleStream *wrapper) {
+    StreamedTable * st = new StreamedTable(wrapper);
+    return st;
+}
 StreamedTable *
 StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
     TupleSchema *schema, std::string tableName, std::vector<std::string> & columnNames) {
@@ -97,7 +102,7 @@ StreamedTable::~StreamedTable() {
         delete m_views[i];
     }
     //When stream is dropped its wrapper is kept safe in pending list until tick or push pushes all buffers and deleted there after.
-    if (m_wrapper) {
+    if (m_wrapper != nullptr) {
         delete m_wrapper;
     }
 }

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -62,7 +62,7 @@ class StreamedTable : public Table, public UndoQuantumReleaseInterest {
 public:
     StreamedTable(int partitionColumn = -1);
     //Used for test
-    StreamedTable(ExportTupleStream *wrapper, int partitionColumn = -1);
+    static StreamedTable* createForTest(ExportTupleStream *wrapper);
     static StreamedTable* createForTest(size_t, ExecutorContext*, TupleSchema *schema,
             std::string tableName, std::vector<std::string> & columnNames);
 
@@ -159,6 +159,8 @@ public:
     }
 
 private:
+    StreamedTable(ExportTupleStream *wrapper);
+
     // Just say 0
     size_t allocatedBlockCount() const;
 

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -108,7 +108,7 @@ StreamedTable* TableFactory::getStreamedTableForTest(
             voltdb::CatalogId databaseId, const std::string &name, TupleSchema* schema,
             const std::vector<std::string> &columnNames, ExportTupleStream* wrapper,
             bool exportEnabled) {
-    StreamedTable *table = new StreamedTable(wrapper);
+    StreamedTable *table = StreamedTable::createForTest(wrapper);
 
     initCommon(databaseId, table, name, schema, columnNames,true);
 

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -164,6 +164,7 @@ protected:
 
             "add /clusters#cluster/databases#database tables X\n"
             "set /clusters#cluster/databases#database/tables#X isreplicated false\n"
+            "set /clusters#cluster/databases#database/tables#X tableType 1\n"
             "set $PREV partitioncolumn /clusters#cluster/databases#database/tables#T/columns#PK\n"
             "set $PREV estimatedtuplecount 0\n"
             "set $PREV materializer null\n"
@@ -389,10 +390,11 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     added = tableutil::addRandomTuples(table, tuplesToInsert);
     ASSERT_TRUE(added);
     table->truncateTable(engine, false);
+
+    // Old table wrapper should be null (before the commit which deallocates the old table)
+    ASSERT_EQ(nullptr, table->getStreamedTable()->getWrapper());
     commit();
 
-    // Old table wrapper should be null
-    ASSERT_EQ(nullptr, table->getStreamedTable()->getWrapper());
 
     // refresh table pointer by fetching the table from catalog as in truncate old table
     // gets replaced with new cloned empty table


### PR DESCRIPTION
A CppUnit test was verifying the transfer of a export stream wrapper to a newly created table after a truncate. However, the check was performed after the commit (when the table being checked) was deleted.