### PR TITLE
ENG-19393:

### DIFF
--- a/src/ee/common/ExecuteWithMpMemory.cpp
+++ b/src/ee/common/ExecuteWithMpMemory.cpp
@@ -33,14 +33,14 @@ ExecuteWithMpMemory::~ExecuteWithMpMemory() {
 
 ConditionalExecuteWithMpMemory::ConditionalExecuteWithMpMemory(bool needMpMemory) : m_usingMpMemory(needMpMemory) {
     if (m_usingMpMemory) {
-        VOLT_DEBUG("Entering UseMPmemory");
+        VOLT_DEBUG("Entering Conditional UseMPmemory");
         SynchronizedThreadLock::assumeMpMemoryContext();
     }
 }
 
 ConditionalExecuteWithMpMemory::~ConditionalExecuteWithMpMemory() {
     if (m_usingMpMemory) {
-        VOLT_DEBUG("Exiting UseMPmemory");
+        VOLT_DEBUG("Exiting Conditional UseMPmemory");
         SynchronizedThreadLock::assumeLocalSiteContext();
     }
 }
@@ -99,6 +99,22 @@ ScopedReplicatedResourceLock::ScopedReplicatedResourceLock() {
 
 ScopedReplicatedResourceLock::~ScopedReplicatedResourceLock() {
     SynchronizedThreadLock::unlockReplicatedResource();
+}
+
+ConditionalExecuteWithMpMemoryAndScopedResourceLock::ConditionalExecuteWithMpMemoryAndScopedResourceLock(bool needMpMemory) : m_usingMpMemory(needMpMemory) {
+    if (m_usingMpMemory) {
+        VOLT_DEBUG("Entering Conditional (locked) UseMPmemory");
+        SynchronizedThreadLock::lockReplicatedResource();
+        SynchronizedThreadLock::assumeMpMemoryContext();
+    }
+}
+
+ConditionalExecuteWithMpMemoryAndScopedResourceLock::~ConditionalExecuteWithMpMemoryAndScopedResourceLock() {
+    if (m_usingMpMemory) {
+        VOLT_DEBUG("Exiting Conditional (locked) UseMPmemory");
+        SynchronizedThreadLock::assumeLocalSiteContext();
+        SynchronizedThreadLock::unlockReplicatedResource();
+    }
 }
 
 } // end namespace voltdb

--- a/src/ee/common/ExecuteWithMpMemory.h
+++ b/src/ee/common/ExecuteWithMpMemory.h
@@ -60,7 +60,7 @@ public:
     , m_okToExecute(!needMpMemoryOnLowestThread || m_usingMpMemoryOnLowestThread) {
         if (needMpMemoryOnLowestThread) {
             if (SynchronizedThreadLock::countDownGlobalTxnStartCount(isLowestSite)) {
-                VOLT_DEBUG("Entering UseMPmemory");
+                VOLT_DEBUG("Entering Conditional Sync UseMPmemory");
                 SynchronizedThreadLock::assumeMpMemoryContext();
                 // This must be done in here to avoid a race with the non-MP path.
                 initiator();
@@ -96,6 +96,16 @@ class ScopedReplicatedResourceLock {
 public:
     ScopedReplicatedResourceLock();
     ~ScopedReplicatedResourceLock();
+};
+
+class ConditionalExecuteWithMpMemoryAndScopedResourceLock {
+public:
+    ConditionalExecuteWithMpMemoryAndScopedResourceLock(bool needMpMemory);
+
+    ~ConditionalExecuteWithMpMemoryAndScopedResourceLock();
+
+private:
+    bool m_usingMpMemory;
 };
 
 } // end namespace voltdb

--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -35,8 +35,8 @@ typedef std::map<int32_t, EngineLocals> SharedEngineLocalsType;
 class SynchronizedUndoQuantumReleaseInterest : public UndoQuantumReleaseInterest {
 public:
     SynchronizedUndoQuantumReleaseInterest(UndoQuantumReleaseInterest *realInterest) :
-        m_realInterest(realInterest) {}
-    virtual ~SynchronizedUndoQuantumReleaseInterest() {}
+            m_realInterest(realInterest) { }
+    virtual ~SynchronizedUndoQuantumReleaseInterest() { }
     void finalizeRelease();
 private:
     UndoQuantumReleaseInterest *m_realInterest;
@@ -54,6 +54,7 @@ class SynchronizedThreadLock {
     friend class ExecuteWithAllSitesMemory;
     friend class ReplicatedMaterializedViewHandler;
     friend class ScopedReplicatedResourceLock;
+    friend class ConditionalExecuteWithMpMemoryAndScopedResourceLock;
     friend class VoltDBEngine;
     friend class ::DRBinaryLogTest;
 

--- a/src/ee/common/UndoLog.cpp
+++ b/src/ee/common/UndoLog.cpp
@@ -79,12 +79,7 @@ void UndoLog::release(const int64_t undoToken) {
         }
     }
     BOOST_FOREACH (auto interest, releaseInterests) {
-        ConditionalSynchronizedExecuteWithMpMemory possiblySynchronizedUseMpMemory
-                (false, //interest->isReplicatedTable(),
-                        ExecutorContext::getEngine()->isLowestSite(), []() {});
-        if (possiblySynchronizedUseMpMemory.okToExecute()) {
-            interest->finalizeRelease();
-        }
+        interest->finalizeRelease();
     }
 }
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -446,9 +446,11 @@ public:
     int tupleLimit() const { return m_tupleLimit; }
 
     bool isReplicatedTable() const {
+#ifndef NDEBUG
         if (!m_isMaterialized && m_isReplicated != (m_partitionColumn == -1)) {
             VOLT_ERROR("CAUTION: detected inconsistent isReplicate flag. Table name:%s\n", m_name.c_str());
         }
+#endif
         return m_isReplicated;
     }
 


### PR DESCRIPTION
Since the snapshot iterator may deallocate tuples or chunks, the COW needs to be in the correct Memory Context.