### PR TITLE
ENG-19393:

### DIFF
--- a/src/ee/common/SynchronizedThreadLock.cpp
+++ b/src/ee/common/SynchronizedThreadLock.cpp
@@ -200,7 +200,7 @@ void SynchronizedThreadLock::deactiveEngineLocals(int32_t partitionId) {
 bool SynchronizedThreadLock::countDownGlobalTxnStartCount(bool lowestSite) {
     VOLT_DEBUG("Entering countdown latch... %d", s_globalTxnStartCountdownLatch);
     vassert(s_globalTxnStartCountdownLatch > 0);
-    vassert(ThreadLocalPool::getEnginePartitionId() != 16383);
+    vassert(!isInMpEngineContext());
     vassert(!isInSingleThreadMode());
     if (lowestSite) {
         {
@@ -405,6 +405,10 @@ bool SynchronizedThreadLock::isHoldingResourceLock() {
 bool SynchronizedThreadLock::isInLocalEngineContext() {
     return ThreadLocalPool::getEnginePartitionId() ==
         ThreadLocalPool::getThreadPartitionId();
+}
+
+bool SynchronizedThreadLock::isInMpEngineContext() {
+    return (ThreadLocalPool::getEnginePartitionId() == 16383);
 }
 
 bool SynchronizedThreadLock::isInSingleThreadMode() {

--- a/src/ee/common/SynchronizedThreadLock.h
+++ b/src/ee/common/SynchronizedThreadLock.h
@@ -111,6 +111,7 @@ public:
     static bool isInSingleThreadMode();
     static void setIsInSingleThreadMode(bool value);
     static bool isInLocalEngineContext();
+    static bool isInMpEngineContext();
     static bool usingMpMemory();
     static void setUsingMpMemory(bool isUsingMpMemory);
     static bool isHoldingResourceLock();

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -169,7 +169,7 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
     }
 
     if (retValue == 0) {
-        table.stopSnapshot(true);
+        table.stopSnapshot(TABLE_STREAM_SNAPSHOT);
     }
     // Done when the table scan is finished and iteration is complete.
     return retValue;

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -399,7 +399,7 @@ public:
      */
     bool nextSnapshotTuple(TableTuple& tuple, TableStreamType streamType);
 
-    void stopSnapshot(bool activated = false);
+    void stopSnapshot(TableStreamType streamType, bool forceDeactivation = false);
 
     /**
      * Create a tree index on the primary key and then iterate it and hash


### PR DESCRIPTION
Fix deadlock in snapshot stream more because the stream more can call stopsnapshot (which enters the mp Context) while already in the mp context.

Also fixed memory logging checks to not rely on static variables.