### PR TITLE
Add stop-node stats check.

### DIFF
--- a/src/frontend/org/voltdb/PauseActivityStats.java
+++ b/src/frontend/org/voltdb/PauseActivityStats.java
@@ -35,8 +35,7 @@ import org.voltcore.logging.VoltLogger;
  * then other columns can be used to determine what the activity
  * relates to, and perhaps whether forward progress is being made.
  */
-public class PauseActivityStats extends StatsSource
-{
+public class PauseActivityStats extends StatsSource {
     private static final VoltLogger logger = new VoltLogger("HOST");
 
     private enum ColumnName {
@@ -66,8 +65,7 @@ public class PauseActivityStats extends StatsSource
      * Iterator through the single row of stats we make available.
      */
     @Override
-    protected Iterator<Object> getStatsRowKeyIterator(boolean interval)
-    {
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
         return new ActivityHelper.OneShotIterator();
     }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1201,7 +1201,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 } else if (determination.startAction.doesRecover()) {
                     action = "Restarting the database cluster from the command logs";
                 }
-                hostLog.info(String.format("%s [%s]", action, determination.startAction));
+                hostLog.info(action);
                 consoleLog.info(action);
             }
 

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1510,8 +1510,10 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             replaceDRConsumerStatsWithDummy();
 
             // Operator function helpers
-            getStatsAgent().registerStatsSource(StatsSelector.SHUTDOWN_CHECK, 0, new ShutdownActivityStats());
-            getStatsAgent().registerStatsSource(StatsSelector.PAUSE_CHECK, 0, new PauseActivityStats());
+            StatsAgent sa = getStatsAgent();
+            sa.registerStatsSource(StatsSelector.SHUTDOWN_CHECK, 0, new ShutdownActivityStats());
+            sa.registerStatsSource(StatsSelector.STOP_CHECK, 0, new StopActivityStats());
+            sa.registerStatsSource(StatsSelector.PAUSE_CHECK, 0, new PauseActivityStats());
 
             /*
              * Initialize the command log on rejoin and join before configuring the IV2

--- a/src/frontend/org/voltdb/ShutdownActivityStats.java
+++ b/src/frontend/org/voltdb/ShutdownActivityStats.java
@@ -40,8 +40,7 @@ import org.voltcore.logging.VoltLogger;
  * then other columns can be used to determine what the activity
  * relates to, and perhaps whether forward progress is being made.
  */
-public class ShutdownActivityStats extends StatsSource
-{
+public class ShutdownActivityStats extends StatsSource {
     private static final VoltLogger logger = new VoltLogger("HOST");
 
     private enum ColumnName {
@@ -73,8 +72,7 @@ public class ShutdownActivityStats extends StatsSource
      * Iterator through the one row of stats we make available.
      */
     @Override
-    protected Iterator<Object> getStatsRowKeyIterator(boolean interval)
-    {
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
         return new ActivityHelper.OneShotIterator();
     }
 

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -74,6 +74,7 @@ public enum StatsSelector {
 
     // Activity summary for use by 'operator' functions
     SHUTDOWN_CHECK,
+    STOP_CHECK,
     PAUSE_CHECK;
 
     /** Whether or not this stat supports interval collection */

--- a/src/frontend/org/voltdb/StopActivityStats.java
+++ b/src/frontend/org/voltdb/StopActivityStats.java
@@ -35,8 +35,7 @@ import org.voltcore.logging.VoltLogger;
  * then other columns can be used to determine what the activity
  * relates to, and perhaps whether forward progress is being made.
  */
-public class StopActivityStats extends StatsSource
-{
+public class StopActivityStats extends StatsSource {
     private static final VoltLogger logger = new VoltLogger("HOST");
 
     private enum ColumnName {
@@ -66,8 +65,7 @@ public class StopActivityStats extends StatsSource
      * Iterator through the single row of stats we make available.
      */
     @Override
-    protected Iterator<Object> getStatsRowKeyIterator(boolean interval)
-    {
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
         return new ActivityHelper.OneShotIterator();
     }
 

--- a/src/frontend/org/voltdb/StopActivityStats.java
+++ b/src/frontend/org/voltdb/StopActivityStats.java
@@ -1,0 +1,109 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltcore.logging.VoltLogger;
+
+/**
+ * The StopActivityStats statistics provide a summary of current
+ * cluster activity that can be used to determine when the cluster
+ * activity has subsided after a call to @PrepareStopNode.
+ *
+ * The result of the statistics request is a table with one
+ * row per host, and a summary of activity in various categories.
+ * Activity is summarized in the 'ACTIVE' column; if desired,
+ * then other columns can be used to determine what the activity
+ * relates to, and perhaps whether forward progress is being made.
+ */
+public class StopActivityStats extends StatsSource
+{
+    private static final VoltLogger logger = new VoltLogger("HOST");
+
+    private enum ColumnName {
+        ACTIVE, // 0 if all other gauges 0, else 1
+        PAR_LEADERS,
+        EXP_MASTERS,
+    };
+
+    public StopActivityStats() {
+        super(false);
+    }
+
+    /*
+     * Constructs a description of the columns we'll return
+     * in our stats table.
+     */
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        super.populateColumnSchema(columns);
+        for (ColumnName col : ColumnName.values()) {
+            VoltType type = (col == ColumnName.ACTIVE ? VoltType.TINYINT : VoltType.BIGINT);
+            columns.add(new ColumnInfo(col.name(), type));
+        }
+    }
+
+    /*
+     * Iterator through the single row of stats we make available.
+     */
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval)
+    {
+        return new ActivityHelper.OneShotIterator();
+    }
+
+    /*
+     * Main stats collection. We return a single row, and
+     * the key is irrelevant. Stats collected match those
+     * used by 'voltadmin pause --wait'.
+     */
+    private static final ActivityHelper.Type[] statsList = {
+        ActivityHelper.Type.LEADER, ActivityHelper.Type.EXMAST
+    };
+
+    @Override
+    protected void updateStatsRow(Object key, Object[] row) {
+        boolean active = false;
+        try {
+            ActivityHelper helper = new ActivityHelper();
+            active = helper.collect(statsList);
+            setValue(row, ColumnName.PAR_LEADERS, helper.leaderCount);
+            setValue(row, ColumnName.EXP_MASTERS, helper.exportMasters);
+        }
+        catch (Exception ex) {
+            logger.error("Unhandled exception in StopActivityStats: " + ex);
+        }
+        setValue(row, ColumnName.ACTIVE, active);
+        super.updateStatsRow(key, row);
+    }
+
+    /*
+     * Utilities to set a value in a row.
+     */
+    private void setValue(Object[] row, ColumnName col, long val) {
+        row[columnNameToIndex.get(col.name())] = val;
+    }
+
+    private void setValue(Object[] row, ColumnName col, boolean val) {
+        row[columnNameToIndex.get(col.name())] = (val ? 1 : 0);
+    }
+}

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -174,7 +174,7 @@ public interface ExportManagerInterface {
     default int getMastershipCount() {
         int count = 0;
         for (ExportStatsRow st : getStats(false)) {
-            if ("TRUE".equalsIgnoreCase(st.m_exportingRole)) {
+            if (Boolean.parseBoolean(st.m_exportingRole)) {
                 count++;
             }
         }

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -161,7 +161,7 @@ public interface ExportManagerInterface {
     public List<ExportStatsRow> getStats(final boolean interval);
 
     /**
-     * Used by graceful shutdown
+     * Used for export activity checks by 'operator' code
      */
     default long getTotalPendingCount() {
         long total = 0;
@@ -169,6 +169,16 @@ public interface ExportManagerInterface {
             total += st.m_tuplesPending;
         }
         return total;
+    }
+
+    default int getMastershipCount() {
+        int count = 0;
+        for (ExportStatsRow st : getStats(false)) {
+            if ("TRUE".equalsIgnoreCase(st.m_exportingRole)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public void initialize(CatalogContext catalogContext, List<Pair<Integer, Integer>> localPartitionsToSites,


### PR DESCRIPTION
Adds a stats class for use by kubernetes operator code. Effectively duplicates the check being made in 'voltadmin stop node' but isolates operator from details.

Most of this is cookie-cutter code similar to previous such stats additions.

Merge target is KO-integration branch!
