### PR TITLE
PBD: Always discard containers and use common offer

### DIFF
--- a/src/frontend/org/voltdb/utils/BinaryDequeGapWriter.java
+++ b/src/frontend/org/voltdb/utils/BinaryDequeGapWriter.java
@@ -42,6 +42,8 @@ public interface BinaryDequeGapWriter<M> {
      * The offer implementation should find the exact location where the data should
      * be inserted and insert it there. The id range being offered must not already
      * exist in the BinaryDeque.
+     * <p>
+     * {@code data} will be guaranteed to be discarded before this method returns
      *
      * @param data the bytes to be written
      * @param startId starting id of the data block being offered

--- a/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
+++ b/tests/frontend/org/voltdb/utils/TestPersistentBinaryDeque.java
@@ -982,8 +982,6 @@ public class TestPersistentBinaryDeque {
             m_pbd.offer( cont );
         } catch (IOException e) {
             return;
-        } finally {
-            cont.discard();
         }
         fail();
     }
@@ -997,8 +995,6 @@ public class TestPersistentBinaryDeque {
             m_pbd.push(objs);
         } catch (IOException e) {
             return;
-        } finally {
-            objs[0].discard();
         }
         fail();
     }
@@ -1160,8 +1156,6 @@ public class TestPersistentBinaryDeque {
             m_pbd.push(objs);
         } catch (IOException e) {
             return;
-        } finally {
-            objs[0].discard();
         }
         fail();
     }
@@ -1174,8 +1168,6 @@ public class TestPersistentBinaryDeque {
             m_pbd.offer( cont );
         } catch (IOException e) {
             return;
-        } finally {
-            cont.discard();
         }
         fail();
     }


### PR DESCRIPTION
The BinaryDeque.offer API states that the container will be discarded if
an exception is thrown. This was not true if exceptions were thrown
prior to the attempt to write the entry. Update the implementation so
that this is now guaranteed.

Move the common code in PBDRegularSegment.offer into a common offer
which takes a BBContainer.