### PR TITLE
ENG-19174-ap-legcy-broke-perf2:

### DIFF
--- a/tests/test_apps/measure-overhead/ddl.sql
+++ b/tests/test_apps/measure-overhead/ddl.sql
@@ -9,6 +9,9 @@ CREATE TABLE empty_p
 );
 PARTITION TABLE empty_p ON COLUMN id;
 
+-- make sure to load the Java code for the procedures, before creating them
+LOAD CLASSES measure-overhead.jar;
+
 -- stored procedures
 CREATE PROCEDURE PARTITION ON TABLE EMPTY_P COLUMN ID FROM CLASS measureoverhead.procedures.MO_ROSP;
 CREATE PROCEDURE PARTITION ON TABLE EMPTY_P COLUMN ID FROM CLASS measureoverhead.procedures.MO_RWSP;


### PR DESCRIPTION
Added, to tests/test_apps/FOO/ddl.sql, a 'LOAD CLASSES FOO.jar;' line,
where this time FOO is 'measure-overhead' (having previously done this
for overhead, oneshotkv, and scans, for this ticket; and for
voter[-selfcheck] earlier).