### PR TITLE
ENG-19306: Closing PBD should stop retention enforcement to minimize the

### DIFF
--- a/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
+++ b/src/frontend/org/voltdb/utils/PersistentBinaryDeque.java
@@ -1693,6 +1693,7 @@ public class PersistentBinaryDeque<M> implements BinaryDeque<M> {
             return;
         }
 
+        stopRetentionPolicyEnforcement();
         if (m_gapWriter != null) {
             m_gapWriter.close();
         }


### PR DESCRIPTION
chance of retention threads getting "is closed" error.