### PR TITLE
VoltDBEngine: Catalog updated cleanup

### DIFF
--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -619,6 +619,9 @@ class __attribute__((visibility("default"))) VoltDBEngine {
             processCatalogDeletes(timestamp, true, purgedStreams);
         }
 
+        template<class TableType, class MaterializedView>
+        void rebuildViewsOnTable(catalog::Table* catalogTable, TableType* table);
+
         void initMaterializedViewsAndLimitDeletePlans(bool updateReplicated = false);
         void initReplicatedMaterializedViewsAndLimitDeletePlans() {
             initMaterializedViewsAndLimitDeletePlans(true);

--- a/src/ee/storage/MaterializedViewTriggerForInsert.h
+++ b/src/ee/storage/MaterializedViewTriggerForInsert.h
@@ -76,7 +76,7 @@ public:
         std::vector<MATVIEW*> &obsoleteViewsOut) {
         // iterate through all of the existing views
         BOOST_FOREACH(MATVIEW* currView, viewsIn) {
-            std::string currentViewId = currView->destTable()->name();
+            const std::string& currentViewId = currView->destTable()->name();
 
             // iterate through all of the catalog views, looking for a match.
             std::map<std::string, catalog::MaterializedViewInfo*>::const_iterator viewIter;

--- a/tests/ee/expressions/function_test.cpp
+++ b/tests/ee/expressions/function_test.cpp
@@ -512,7 +512,9 @@ TEST_F(FunctionTest, NaturalLogTest) {
     try {
         testUnary(FUNC_LN, -1, 0);
     } catch(SQLException &sqlExcp) {
-    sawException = findString(sqlExcp.message(), "Invalid result value (nan)");
+        const std::string message = sqlExcp.message();
+        sawException = findString(message, "Invalid result value (nan)")
+                || findString(message, "Invalid result value (-nan)");
     }
     ASSERT_EQ(sawException, true);
 


### PR DESCRIPTION
Pull out rebuilding of views to common method.
Simplify checking if table is for current context
Use string references where possible
function_test.cpp: Accept both nan and -nan