### PR TITLE
Eng 19338 gram hang misc

### DIFF
--- a/tests/sqlgrammar/run.sh
+++ b/tests/sqlgrammar/run.sh
@@ -517,6 +517,9 @@ function exit-with-code() {
     find-directories-if-needed
     cd $HOME_DIR
 
+    if [[ "$PRINT_ERROR_CODE" -ne "0" ]]; then
+        echo -e "\nTo learn more about how to run this script, use the 'help' (and/or 'tests-help') option:\n    $0 help"
+    fi
     if [[ -n "$MINUTES_WARNING" ]]; then
         echo -e $MINUTES_WARNING
     fi

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -344,8 +344,8 @@ function tt-sqlcoverage() {
 # the rest unchanged
 function tt-set-tt-build-args() {
     if [[ "$TT_DEBUG" -ge "2" ]]; then echo -e "\n$0 performing: $FUNCNAME"; fi
+    TT_BUILD_ARGS=()
     for arg in $@; do
-        TT_BUILD_ARGS=()
         if [[ "$arg" == "--debug" ]]; then
             TT_BUILD_ARGS+=("-Dbuild=debug")
         elif [[ "$arg" == "--pool" ]]; then

--- a/tests/test-tools.sh
+++ b/tests/test-tools.sh
@@ -354,7 +354,7 @@ function tt-set-tt-build-args() {
             TT_BUILD_ARGS+=("-Dbuild=release")
         else
             if [[ "$arg" == --* ]]; then
-                echo -e "\nWARNING: unrecognized build arg $arg will be passed in, but effect is unknown"
+                echo -e "\nWARNING: in $FUNCNAME, unrecognized build arg $arg will be passed on, but effect is unknown"
             fi
             TT_BUILD_ARGS+=("$arg")
         fi


### PR DESCRIPTION
Multiple improvements & minor tweaks to grammar-gen scripts run.sh & test-tools.sh (already merged to master, now merging to the ENG-18744 branch):
1. Added code to not run certain functions if previous ones failed (e.g. if 'build[-pro]' fails, 'server[-pro]' is skipped; if 'server[-pro]' fails (or is skipped), 'tests-only' is skipped) - which is ENG-19338;
2. Print a warning if the number of minutes (for the tests to run) was unspecified and used the default value of '1' (Lukai's request);
3. Added the tt-set-tt-build-args function (& tweaked 'tt-build[-pro]'), to interpret the '--debug', '--pool', and '--release' abbreviations (this used to happen in the Jenkins script, but someone "simplified" it, and anyway it belongs here);
4. Changed the 'prepare[-pro]' functions (and therefore the 'all[-pro]' functions, which call them) to not call 'build[-pro]', if it has already been called, making it easier to separately insert build and test args, e.g. with the command:
'./run.sh build --debug all --minutes=5'
5. Tweaks related to VOLTDB_PRO_DIR, VOLTDB_BIN_DIR, and therefore to setting the PATH, when needed;
6. Regularized the 'echo' statements at the beginning of each function, generally making that the first statement, except for calls to '...-if-needed' functions (or if we also want to echo a computed value);
7. Modified most of the '...-if-needed' functions to avoid retrying the the same thing (e.g. 'build') over and over again, if it failed the first time;
8. Regularized function names in test-tools.sh, to always start with 'tt-', never with 'test-tools-' (this was previously inconsistent), but added some deprecated functions with the old names, which just call the new ones (since test-tools.sh is called by other tests besides grammar-gen);
9. Renamed the '[tt-]debug' functions to the less confusing '[tt-]print-vars';
10. Added an echo of all arguments, at the very beginning; improved some error messages; added time elapsed at the end; other trivial tweaks.