### PR TITLE
ENG-19430: Guarantee that catalog update happens after quiesce

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -64,9 +64,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -369,11 +371,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     // Synchronize initialize and shutdown
     private final Object m_startAndStopLock = new Object();
 
-    // Synchronize updates of catalog contexts across the multiple sites on this host.
-    // Ensure that the first site to reach catalogUpdate() does all the work and that no
-    // others enter until that's finished.  CatalogContext is immutable and volatile, accessors
-    // should be able to always get a valid context without needing this lock.
-    private final Object m_catalogUpdateLock = new Object();
+    /*
+     * Synchronize updates of catalog contexts across the multiple sites on this host. Ensure that catalogUpdate() is
+     * only performed after all sites reach catalogUpdate(). Once all sites have reached this point the first site to
+     * execute will perform the actual update while the others wait.
+     */
+    private final UpdateBarrier m_catalogUpdateBarrier = new UpdateBarrier();
 
     // add a random number to the sampler output to make it likely to be unique for this process.
     private final VoltSampler m_sampler = new VoltSampler(10, "sample" + String.valueOf(new Random().nextInt() % 10000) + ".txt");
@@ -1001,6 +1004,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             ReadDeploymentResults readDepl = readPrimedDeployment(config);
+            m_catalogUpdateBarrier.setPartyCount(m_nodeSettings.getLocalSitesCount());
 
             if (config.m_startAction == StartAction.INITIALIZE) {
                 if (config.m_forceVoltdbCreate && m_nodeSettings.clean()) {
@@ -3905,7 +3909,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             boolean hasSecurityUserChange)
     {
         try {
-            synchronized(m_catalogUpdateLock) {
+            m_catalogUpdateBarrier.await();
+
+            synchronized (m_catalogUpdateBarrier) {
                 final ReplicationRole oldRole = getReplicationRole();
 
                 m_statusTracker.set(NodeState.UPDATING);
@@ -4081,6 +4087,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
                 return m_catalogContext;
             }
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw VoltDB.crashLocalVoltDB("Error waiting for barrier", true, e);
         } finally {
             //Set state back to UP
             m_statusTracker.set(NodeState.UP);
@@ -4091,7 +4099,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public CatalogContext settingsUpdate(
             ClusterSettings settings, final int expectedVersionId)
     {
-        synchronized(m_catalogUpdateLock) {
+        synchronized (m_catalogUpdateBarrier) {
             int stamp [] = new int[]{0};
             ClusterSettings expect = m_clusterSettings.get(stamp);
             if (   stamp[0] == expectedVersionId
@@ -5256,7 +5264,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     public void processReplicaDecommission(int leaderCount) {
-        synchronized(m_catalogUpdateLock) {
+        synchronized(m_catalogUpdateBarrier) {
             setMasterOnly();
             if (leaderCount != m_nodeSettings.getLocalActiveSitesCount()) {
                 NavigableMap<String, String> settings = m_nodeSettings.asMap();
@@ -5271,6 +5279,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 m_nodeSettings.store();
                 m_catalogContext.getDbSettings().setNodeSettings(m_nodeSettings);
                 hostLog.info("Update local active site count to :" + leaderCount);
+
+                // Update the catalog update barrier to expect the new partition count
+                m_catalogUpdateBarrier.setPartyCount(leaderCount);
 
                 // release export resources
                 ExportManagerInterface.instance().releaseResources(getNonLeaderPartitionIds());
@@ -5287,6 +5298,27 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             return (init != null && !(init.getServiceState().isNormal()));
         }
         return false;
+    }
+
+    /**
+     * Small wrapper class around a {@link CyclicBarrier}. This is used so that operations can synchronize on this
+     * instance and still be able to change the participant count in the barrier
+     */
+    private static final class UpdateBarrier {
+        private CyclicBarrier m_barrier;
+
+        UpdateBarrier() {}
+
+        synchronized void setPartyCount(int parties) {
+            if (m_barrier != null && m_barrier.getNumberWaiting() != 0) {
+                throw new IllegalStateException("Cannot change participant count while parties are waiting");
+            }
+            m_barrier = new CyclicBarrier(parties);
+        }
+
+        void await() throws InterruptedException, BrokenBarrierException {
+            m_barrier.await();
+        }
     }
 }
 

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -1183,8 +1183,8 @@ public class VoltDB {
         }
     }
 
-    public static void crashLocalVoltDB(String errMsg) {
-        crashLocalVoltDB(errMsg, false, null);
+    public static RuntimeException crashLocalVoltDB(String errMsg) {
+        return crashLocalVoltDB(errMsg, false, null);
     }
 
     /**


### PR DESCRIPTION
Catalog update is an MP procedure which occurs concurrently on all hosts. The order of operations is all sites call quiesce and then RealVoltDB.updateCatalog(). The first site on each host to call updateCatalog() performs the actual work. This can be an issue because the other sites on the host might still be performing the quiesce. When this happens the schema can be updated in export and DR before the buffers with the data from the previous schema are processed.

This results in the new schema being attached to the old rows.