### PR TITLE
ENG-16168: Release all completely completed tasks

### DIFF
--- a/src/frontend/org/voltdb/iv2/Scoreboard.java
+++ b/src/frontend/org/voltdb/iv2/Scoreboard.java
@@ -86,8 +86,10 @@ public class Scoreboard {
             nextTaskCounter.txnId = next.getFirst().getMsgTxnId();
             nextTaskCounter.completionCount++;
             nextTaskCounter.timestamp = next.getFirst().getTimestamp();
+            nextTaskCounter.missingTxn |= next.getSecond() || next.getFirst().m_txnState.isDone();
         } else if (nextTaskCounter.txnId == next.getFirst().getMsgTxnId() &&
                 nextTaskCounter.timestamp == next.getFirst().getTimestamp()) {
+            nextTaskCounter.missingTxn |= next.getSecond();
             nextTaskCounter.completionCount++;
         }
         return pair;


### PR DESCRIPTION
[ backport 52b615def6d5589da432e922e8de047a912c1ef3 ]

The method TransactionTaskQueue.coordinatedTaskQueueOffer is suppose to
complete the task for the passed in task and any other fully completed tasks
behind it. However that wouldn't happen.
RelativeSiteOffset.releaseStashedCompleteTxns would return true if the next
task in all the Scoreboards was the same. That result would then be assigned to
the done variable and cause nothing else to be processed.

Instead of returning a boolean keep releasing completed transactions until they
are all gone or one is encountered which is not completed on all sites.