### PR TITLE
For a specified status listener port, set reuseaddr.

### DIFF
--- a/src/frontend/org/voltdb/operator/StatusListener.java
+++ b/src/frontend/org/voltdb/operator/StatusListener.java
@@ -126,6 +126,9 @@ public class StatusListener {
                 connector.setPort(port);
                 connector.setName("status-connector");
                 connector.setIdleTimeout(CONNTMO);
+                if (portReq != 0) { // only if port specified
+                    connector.setReuseAddress(true); // in case of fast fail/restart
+                }
                 connector.open();
                 return connector;
             }


### PR DESCRIPTION
Prevent occasional error from fast exit/restart (the usual TCP TIME_WAIT thing). I've seen this once or twice in manual testing.

(Not used for 'find free port' case since it is obviously not consistent with that)

Obviously, requires the admin to have correctly specified port numbers in the first case. 
