### PR TITLE
KO-137, user-friendly statistics API to monitor snapshot completion.

### DIFF
--- a/src/frontend/org/voltdb/SnapshotDaemon.java
+++ b/src/frontend/org/voltdb/SnapshotDaemon.java
@@ -217,9 +217,9 @@ public class SnapshotDaemon implements SnapshotCompletionInterest {
                                                               0,
                                                               snapshotStatus);
         // Snapshot status summary is a one-row-per-snapshot stats
-        VoltDB.instance().getStatsAgent().registerStatsSource(StatsSelector.SNAPSHOTSTATUSSUMMARY,
+        VoltDB.instance().getStatsAgent().registerStatsSource(StatsSelector.SNAPSHOTSUMMARY,
                                                               0,
-                                                              new SnapshotStatusSummary(
+                                                              new SnapshotSummary(
                                                                       VoltDB.instance().getCommandLogSnapshotPath(),
                                                                       VoltDB.instance().getSnapshotPath()));
         VoltDB.instance().getSnapshotCompletionMonitor().addInterest(this);

--- a/src/frontend/org/voltdb/SnapshotStatusSummary.java
+++ b/src/frontend/org/voltdb/SnapshotStatusSummary.java
@@ -1,0 +1,158 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.voltcore.utils.Pair;
+import org.voltdb.SnapshotStatus.SnapshotTypeChecker;
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.sysprocs.SnapshotRegistry;
+import org.voltdb.sysprocs.SnapshotRegistry.Snapshot;
+
+public class SnapshotStatusSummary extends StatsSource {
+
+    private enum SnapshotResult {
+        SUCCESS,
+        FAILURE;
+    }
+
+    SnapshotTypeChecker m_typeChecker = new SnapshotTypeChecker();
+
+    /**
+     * Since there are multiple tables inside a Snapshot object, and we cannot
+     * get a copy of the tables directly, flattens the tables in a Snapshot
+     * object into a flat list.
+     */
+    private class StatusIterator implements Iterator<Object> {
+        private final List<Pair<Snapshot, Boolean>> m_snapshots;
+        private final Iterator<Pair<Snapshot, Boolean>> m_iter;
+
+        private StatusIterator(Iterator<Snapshot> i) {
+            m_snapshots = new LinkedList<Pair<Snapshot, Boolean>>();
+
+            while (i.hasNext()) {
+                final Snapshot s = i.next();
+                s.iterateTableErrors(new Snapshot.ErrorScanner() {
+                    @Override
+                    public void update(boolean hasError) {
+                        m_snapshots.add(Pair.of(s, hasError));
+                    }
+                });
+            }
+
+            m_iter = m_snapshots.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return m_iter.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return m_iter.next();
+        }
+
+        @Override
+        public void remove() {
+            m_iter.remove();
+        }
+    }
+
+    public SnapshotStatusSummary(String truncationSnapshotPath, String autoSnapshotPath) {
+        super(false);
+        m_typeChecker.setSnapshotPath(truncationSnapshotPath, autoSnapshotPath);
+    }
+
+    // if any node has different result, that's a failure
+    static VoltTable[] summarize(VoltTable perHostStats) {
+        if (perHostStats.getRowCount() == 0) {
+            return new VoltTable[] { perHostStats};
+        }
+        Map<String, VoltTableRow> snapshotMap = new TreeMap<>();
+        perHostStats.resetRowPosition();
+        while (perHostStats.advanceRow()) {
+            String nonce = perHostStats.getString("NONCE");
+            String result = perHostStats.getString("RESULT");
+            VoltTableRow row = snapshotMap.get(nonce);
+            if (row == null) {
+                snapshotMap.put(nonce, perHostStats.cloneRow());
+            } else {
+                String res = row.getString("RESULT");
+                if (!res.equalsIgnoreCase(result)) {
+                    VoltTable newRow = new VoltTable(perHostStats.getTableSchema());
+                    newRow.addRow(row.getString("NONCE"), row.getLong("TXNID"),
+                            row.getLong("START_TIME"), row.getLong("END_TIME"),
+                            row.getLong("DURATION"), SnapshotResult.FAILURE.toString(),
+                            row.getString("TYPE"));
+                    snapshotMap.put(nonce, newRow);
+                }
+            }
+        }
+
+        perHostStats.clearRowData();
+        for (Map.Entry<String, VoltTableRow> e : snapshotMap.entrySet()) {
+            perHostStats.add(e.getValue());
+        }
+        return new VoltTable[] { perHostStats };
+    }
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        columns.add(new ColumnInfo("NONCE", VoltType.STRING));
+        columns.add(new ColumnInfo("TXNID", VoltType.BIGINT));
+        columns.add(new ColumnInfo("START_TIME", VoltType.BIGINT));
+        columns.add(new ColumnInfo("END_TIME", VoltType.BIGINT));
+        columns.add(new ColumnInfo("DURATION", VoltType.BIGINT));
+        columns.add(new ColumnInfo("RESULT", VoltType.STRING));
+        columns.add(new ColumnInfo("TYPE", VoltType.STRING));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void updateStatsRow(Object rowKey, Object[] rowValues) {
+        Pair<Snapshot, Boolean> p = (Pair<Snapshot, Boolean>) rowKey;
+        Snapshot s = p.getFirst();
+        double duration = 0;
+        Boolean hasError = p.getSecond();
+        if (s.timeFinished != 0) {
+            duration =
+                (s.timeFinished - s.timeStarted) / 1000.0;
+        }
+
+        rowValues[columnNameToIndex.get("NONCE")] = s.nonce;
+        rowValues[columnNameToIndex.get("TXNID")] = s.txnId;
+        rowValues[columnNameToIndex.get("START_TIME")] = s.timeStarted;
+        rowValues[columnNameToIndex.get("END_TIME")] = s.timeFinished;
+        rowValues[columnNameToIndex.get("DURATION")] = duration;
+        rowValues[columnNameToIndex.get("RESULT")] =
+                hasError ? SnapshotResult.FAILURE.toString() : SnapshotResult.SUCCESS.toString();
+        rowValues[columnNameToIndex.get("TYPE")] = m_typeChecker.getSnapshotType(s.path);
+    }
+
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
+        return new StatusIterator(SnapshotRegistry.getSnapshotHistory().iterator());
+    }
+
+}

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -17,8 +17,8 @@
 package org.voltdb;
 
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.Map;
+import java.util.Set;
 
 import org.cliffc_voltpatches.high_scale_lib.NonBlockingHashMap;
 import org.cliffc_voltpatches.high_scale_lib.NonBlockingHashSet;
@@ -87,6 +87,8 @@ public class StatsAgent extends OpsAgent
         case TASK_SCHEDULER:
             TaskStatsSource.convert(subselector, request.aggregateTables);
             break;
+        case SNAPSHOTSTATUSSUMMARY:
+            request.aggregateTables = SnapshotStatusSummary.summarize(request.aggregateTables[0]);
         default:
         }
     }

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -87,8 +87,8 @@ public class StatsAgent extends OpsAgent
         case TASK_SCHEDULER:
             TaskStatsSource.convert(subselector, request.aggregateTables);
             break;
-        case SNAPSHOTSTATUSSUMMARY:
-            request.aggregateTables = SnapshotStatusSummary.summarize(request.aggregateTables[0]);
+        case SNAPSHOTSUMMARY:
+            request.aggregateTables = SnapshotSummary.summarize(request.aggregateTables[0]);
         default:
         }
     }

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -38,7 +38,7 @@ public enum StatsSelector {
     CPU,            // return CPU Stats
     MANAGEMENT(MEMORY, INITIATOR, PROCEDURE, IOSTATS, TABLE, INDEX, STARVATION, QUEUE, CPU), // Returns pretty much everything
     SNAPSHOTSTATUS(false),
-    SNAPSHOTSTATUSSUMMARY(false),
+    SNAPSHOTSUMMARY(false),
     PROCEDUREPROFILE(PROCEDURE), // performs an aggregation of the procedure statistics
     PROCEDUREINPUT(PROCEDURE),
     PROCEDUREOUTPUT(PROCEDURE),

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -38,6 +38,7 @@ public enum StatsSelector {
     CPU,            // return CPU Stats
     MANAGEMENT(MEMORY, INITIATOR, PROCEDURE, IOSTATS, TABLE, INDEX, STARVATION, QUEUE, CPU), // Returns pretty much everything
     SNAPSHOTSTATUS(false),
+    SNAPSHOTSTATUSSUMMARY(false),
     PROCEDUREPROFILE(PROCEDURE), // performs an aggregation of the procedure statistics
     PROCEDUREINPUT(PROCEDURE),
     PROCEDUREOUTPUT(PROCEDURE),

--- a/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRegistry.java
@@ -105,11 +105,25 @@ public class SnapshotRegistry {
             public void next(Table t);
         }
 
+        public interface ErrorScanner {
+            public void update(boolean hasError);
+        }
+
         public void iterateTables(TableIterator ti) {
             synchronized (tables) {
                 for (Table t : tables.values()) {
                     ti.next(t);
                 }
+            }
+        }
+
+        public void iterateTableErrors(ErrorScanner sc) {
+            synchronized (tables) {
+                if (tables.isEmpty()) {
+                    return;
+                }
+                boolean hasError = tables.values().stream().anyMatch(t -> t.error != null);
+                sc.update(hasError);
             }
         }
 


### PR DESCRIPTION
Comparing to stats API SNAPSHOTSTATUS, this API is friendly to outside observers who monitor the completion of snapshot. Because SnapshotStatus returns per-host-per-table information. Monitoring snapshot completion, the outside watcher needs to know 
1) the expected number of node,
2) the number of table.

to aggregate all rows with the same nonce.

SNAPSHOTSTATUSSUMMARY returns one row per snapshot, the result is aggregated from all nodes.

Example output:
```
exec @Statistics SNAPSHOTSTATUSSUMMARY 0;
NONCE                TXNID             START_TIME     END_TIME       DURATION  RESULT   TYPE
-------------------- ----------------- -------------- -------------- --------- -------- -----
MANUAL1588593223049   3619631923314687  1588593223113  1588593223383         0 SUCCESS  AUTO
MANUAL1588593248397   3619631923331071  1588593248457  1588593248702         0 SUCCESS  AUTO
```
Change-Id: I3c2921cd94b38827fe0301330dd9a1dfa4e140cd