### PR TITLE
ENG-19469:

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -176,6 +176,7 @@ VoltDBEngine::initialize(int32_t clusterIndex,
                          std::string hostname,
                          int32_t drClusterId,
                          int32_t defaultDrBufferSize,
+                         bool drIgnoreConflicts,
                          int64_t tempTableMemoryLimit,
                          bool createDrReplicatedStream,
                          int32_t compactionThreshold)
@@ -216,6 +217,10 @@ VoltDBEngine::initialize(int32_t clusterIndex,
     m_templateSingleLongTable[34] = 's';
     m_templateSingleLongTable[38] = 1; // row count
     m_templateSingleLongTable[42] = 8; // row size
+
+    if (drIgnoreConflicts) {
+        m_wrapper.enableIgnoreConflicts();
+    }
 
     // configure DR stream and DR compatible stream
     m_drStream = new DRTupleStream(partitionId, defaultDrBufferSize);

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -116,6 +116,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
                         std::string hostname,
                         int32_t drClusterId,
                         int32_t defaultDrBufferSize,
+                        bool drIgnoreConflicts,
                         int64_t tempTableMemoryLimit,
                         bool createDrReplicatedStream,
                         int32_t compactionThreshold = 95);

--- a/src/ee/storage/BinaryLogSink.cpp
+++ b/src/ee/storage/BinaryLogSink.cpp
@@ -305,9 +305,14 @@ void validateChecksum(uint32_t checksum, const char *start, const char *end) {
     }
 }
 
-bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple,
+} //end of anonymous namespace
+
+bool BinaryLogSink::handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple,
         const TableTuple *expectedTuple, TableTuple *newTuple, int64_t uniqueId, int32_t remoteClusterId,
         DRRecordType actionType, DRConflictType deleteConflict, DRConflictType insertConflict) {
+    if (m_drIgnoreConflicts) {
+        return true;
+    }
     if (!engine) {
         return false;
     }
@@ -484,9 +489,7 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
     return true;
 }
 
-} //end of anonymous namespace
-
-BinaryLogSink::BinaryLogSink() {}
+BinaryLogSink::BinaryLogSink() : m_drIgnoreConflicts(false) {}
 
 int64_t BinaryLogSink::applyTxn(ReferenceSerializeInputLE *taskInfo,
                                 boost::unordered_map<int64_t, PersistentTable*> &tables,

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -28,6 +28,7 @@ namespace voltdb {
 class PersistentTable;
 class Pool;
 class VoltDBEngine;
+class TableTuple;
 
 /*
  * Responsible for applying binary logs to table data
@@ -40,11 +41,20 @@ public:
                      Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
                      const char *txnStart);
 
+    inline void enableIngoreConflicts() { m_drIgnoreConflicts = true; }
+
 private:
     int64_t apply(ReferenceSerializeInputLE *taskInfo, const DRRecordType type,
                   boost::unordered_map<int64_t, PersistentTable*> &tables,
                   Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
                   const char *txnStart, int64_t sequenceNumber, int64_t uniqueId, bool skipRow);
+
+    bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple,
+            const TableTuple *expectedTuple, TableTuple *newTuple, int64_t uniqueId, int32_t remoteClusterId,
+            DRRecordType actionType, DRConflictType deleteConflict, DRConflictType insertConflict);
+
+private:
+    bool m_drIgnoreConflicts;
 };
 
 

--- a/src/ee/storage/BinaryLogSinkWrapper.h
+++ b/src/ee/storage/BinaryLogSinkWrapper.h
@@ -38,6 +38,11 @@ public:
 
     int64_t apply(const char* taskParams, boost::unordered_map<int64_t, PersistentTable*> &tables,
                   Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId);
+
+    inline void enableIgnoreConflicts() {
+        m_sink.enableIngoreConflicts();
+        m_compatibleSink.enableIngoreConflicts();
+    }
 private:
     BinaryLogSink m_sink;
     CompatibleBinaryLogSink m_compatibleSink;

--- a/src/ee/storage/CompatibleBinaryLogSink.cpp
+++ b/src/ee/storage/CompatibleBinaryLogSink.cpp
@@ -330,8 +330,13 @@ void validateChecksum(uint32_t checksum, const char *start, const char *end) {
     }
 }
 
-bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple, const TableTuple *expectedTuple, TableTuple *newTuple,
+} // end of anonymous namespace
+
+bool CompatibleBinaryLogSink::handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple, const TableTuple *expectedTuple, TableTuple *newTuple,
         int64_t uniqueId, int32_t remoteClusterId, DRRecordType actionType, DRConflictType deleteConflict, DRConflictType insertConflict) {
+    if (m_drIgnoreConflicts) {
+        return true;
+    }
     if (!engine) {
         return false;
     }
@@ -506,7 +511,6 @@ bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, 
 
     return true;
 }
-} // end of anonymous namespace
 
 int64_t CompatibleBinaryLogSink::apply(ReferenceSerializeInputLE *taskInfo,
                                        boost::unordered_map<int64_t, PersistentTable*> &tables,

--- a/src/ee/storage/CompatibleBinaryLogSink.h
+++ b/src/ee/storage/CompatibleBinaryLogSink.h
@@ -30,19 +30,28 @@ namespace voltdb {
 class PersistentTable;
 class Pool;
 class VoltDBEngine;
+class TableTuple;
 
 /*
  * Responsible for applying binary logs to table data
  */
 class CompatibleBinaryLogSink {
 public:
-    CompatibleBinaryLogSink() {}
+    CompatibleBinaryLogSink() : m_drIgnoreConflicts(false) {}
 
     int64_t apply(ReferenceSerializeInputLE *taskInfo,
                   boost::unordered_map<int64_t, PersistentTable*> &tables,
                   Pool *pool, VoltDBEngine *engine, int32_t remoteClusterId,
                   const char *recordStart, int64_t *uniqueId,
                   int64_t *sequenceNumber);
+
+    inline void enableIngoreConflicts() { m_drIgnoreConflicts = true; }
+
+private:
+    bool handleConflict(VoltDBEngine *engine, PersistentTable *drTable, Pool *pool, TableTuple *existingTuple, const TableTuple *expectedTuple, TableTuple *newTuple,
+            int64_t uniqueId, int32_t remoteClusterId, DRRecordType actionType, DRConflictType deleteConflict, DRConflictType insertConflict);
+
+    bool m_drIgnoreConflicts;
 };
 
 

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -590,6 +590,7 @@ int8_t VoltDBIPC::initialize(struct ipc_command *cmd) {
         int hostId;
         int drClusterId;
         int defaultDrBufferSize;
+        int drIgnoreConflicts;
         int64_t logLevels;
         int64_t tempTableMemory;
         int32_t createDrReplicatedStream;
@@ -608,10 +609,12 @@ int8_t VoltDBIPC::initialize(struct ipc_command *cmd) {
     cs->hostId = ntohl(cs->hostId);
     cs->drClusterId = ntohl(cs->drClusterId);
     cs->defaultDrBufferSize = ntohl(cs->defaultDrBufferSize);
+    cs->drIgnoreConflicts = ntohl(cs->drIgnoreConflicts);
     cs->logLevels = ntohll(cs->logLevels);
     cs->tempTableMemory = ntohll(cs->tempTableMemory);
     cs->createDrReplicatedStream = ntohl(cs->createDrReplicatedStream);
     bool createDrReplicatedStream = cs->createDrReplicatedStream != 0;
+    bool drIgnoreConflicts = cs->drIgnoreConflicts != 0;
     cs->hostnameLength = ntohl(cs->hostnameLength);
 
     std::string hostname(cs->data, cs->hostnameLength);
@@ -634,6 +637,7 @@ int8_t VoltDBIPC::initialize(struct ipc_command *cmd) {
                                  hostname,
                                  cs->drClusterId,
                                  cs->defaultDrBufferSize,
+                                 drIgnoreConflicts,
                                  cs->tempTableMemory,
                                  createDrReplicatedStream) == true) {
             return kErrorCode_Success;

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -267,6 +267,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeIniti
     jbyteArray hostname,
     jint drClusterId,
     jint defaultDrBufferSize,
+    jboolean drIgnoreConflicts,
     jlong tempTableMemory,
     jboolean createDrReplicatedStream,
     jint compactionThreshold)
@@ -295,6 +296,7 @@ SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeIniti
                                    hostString,
                                    drClusterId,
                                    defaultDrBufferSize,
+                                   drIgnoreConflicts,
                                    tempTableMemory,
                                    createDrReplicatedStream,
                                    static_cast<int32_t>(compactionThreshold));

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -651,6 +651,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
         ExecutionEngine eeTemp = null;
         Deployment deploy = m_context.cluster.getDeployment().get("deployment");
         final int defaultDrBufferSize = Integer.getInteger("DR_DEFAULT_BUFFER_SIZE", 512 * 1024); // 512KB
+        final boolean drIgnoreConflicts = Boolean.getBoolean("DR_IGNORE_CONFLICTS");
         try {
             if (m_backend == BackendTarget.NATIVE_EE_JNI) {
                 eeTemp =
@@ -662,6 +663,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                         hostname,
                         m_context.cluster.getDrclusterid(),
                         defaultDrBufferSize,
+                        drIgnoreConflicts,
                         deploy.getSystemsettings().get("systemsettings").getTemptablemaxsize(),
                         hashinatorConfig,
                         m_mpDrGateway != null);
@@ -677,6 +679,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                         hostname,
                         m_context.cluster.getDrclusterid(),
                         defaultDrBufferSize,
+                        drIgnoreConflicts,
                         m_context.cluster.getDeployment().get("deployment").
                         getSystemsettings().get("systemsettings").getTemptablemaxsize(),
                         hashinatorConfig,
@@ -694,6 +697,7 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
                             hostname,
                             m_context.cluster.getDrclusterid(),
                             defaultDrBufferSize,
+                            drIgnoreConflicts,
                             deploy.getSystemsettings().get("systemsettings").getTemptablemaxsize(),
                             m_backend,
                             VoltDB.instance().getConfig().m_ipcPort,

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -823,6 +823,7 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
             byte hostname[],
             int drClusterId,
             int defaultDrBufferSize,
+            boolean drIgnoreConflicts,
             long tempTableMemory,
             boolean createDrReplicatedStream,
             int compactionThreshold);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -623,6 +623,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             final String hostname,
             final int drClusterId,
             final int defaultDrBufferSize,
+            final boolean drIgnoreConflicts,
             final int tempTableMemory,
             final BackendTarget target,
             final int port,
@@ -654,6 +655,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                 m_hostname,
                 drClusterId,
                 defaultDrBufferSize,
+                drIgnoreConflicts,
                 1024 * 1024 * tempTableMemory,
                 hashinatorConfig,
                 createDrReplicatedStream);
@@ -692,6 +694,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
             final String hostname,
             final int drClusterId,
             final int defaultDrBufferSize,
+            final boolean drIgnoreConflicts,
             final long tempTableMemory,
             final HashinatorConfig hashinatorConfig,
             final boolean createDrReplicatedStream)
@@ -708,6 +711,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         m_data.putInt(hostId);
         m_data.putInt(drClusterId);
         m_data.putInt(defaultDrBufferSize);
+        m_data.putInt(drIgnoreConflicts ? 1 : 0);
         m_data.putLong(EELoggers.getLogLevels());
         m_data.putLong(tempTableMemory);
         m_data.putInt(createDrReplicatedStream ? 1 : 0);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -118,6 +118,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
             final String hostname,
             final int drClusterId,
             final int defaultDrBufferSize,
+            final boolean drIgnoreConflicts,
             final int tempTableMemory,
             final HashinatorConfig hashinatorConfig,
             final boolean createDrReplicatedStream)
@@ -146,6 +147,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
                     getStringBytes(hostname),
                     drClusterId,
                     defaultDrBufferSize,
+                    drIgnoreConflicts,
                     tempTableMemory * 1024 * 1024,
                     createDrReplicatedStream,
                     EE_COMPACTION_THRESHOLD);

--- a/tests/ee/execution/add_drop_table.cpp
+++ b/tests/ee/execution/add_drop_table.cpp
@@ -60,6 +60,7 @@ class AddDropTableTest : public Test {
                              m_hostName,
                              m_drClusterId,
                              1024,
+                             false,
                              DEFAULT_TEMP_TABLE_MEMORY,
                              false);
         m_engine->updateHashinator( HASHINATOR_LEGACY,

--- a/tests/ee/execution/engine_test.cpp
+++ b/tests/ee/execution/engine_test.cpp
@@ -419,7 +419,7 @@ public:
                              m_exception_buffer.get(), 4096);
         m_engine->resetReusedResultOutputBuffer();
         int partitionCount = 3;
-        ASSERT_TRUE(m_engine->initialize(this->m_cluster_id, this->m_site_id, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false));
+        ASSERT_TRUE(m_engine->initialize(this->m_cluster_id, this->m_site_id, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false));
         m_engine->updateHashinator( HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         ASSERT_TRUE(m_engine->loadCatalog( -2, m_catalog_string));
 

--- a/tests/ee/indexes/index_test.cpp
+++ b/tests/ee/indexes/index_test.cpp
@@ -177,7 +177,7 @@ public:
         m_exceptionBuffer = new char[4096];
         m_engine->setBuffers( NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         int partitionCount = 1;
-        m_engine->initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(0, 0, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         table = dynamic_cast<PersistentTable*>(
             TableFactory::getPersistentTable(database_id, "test_wide_table",
@@ -313,7 +313,7 @@ public:
         m_exceptionBuffer = new char[4096];
         m_engine->setBuffers( NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         int partitionCount = 1;
-        m_engine->initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(0, 0, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
         table = dynamic_cast<PersistentTable*>(TableFactory::getPersistentTable(database_id, (const string)"test_table", schema, columnNames, signature));
 

--- a/tests/ee/storage/CompactionTest.cpp
+++ b/tests/ee/storage/CompactionTest.cpp
@@ -74,7 +74,7 @@ public:
         m_tuplesDeletedInLastUndo = 0;
         m_engine = new voltdb::VoltDBEngine();
         int partitionCount = 1;
-        m_engine->initialize(1,1, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(1,1, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator(HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
 
         m_columnNames.push_back("1");

--- a/tests/ee/storage/CopyOnWriteTest.cpp
+++ b/tests/ee/storage/CopyOnWriteTest.cpp
@@ -148,7 +148,7 @@ public:
         m_tuplesDeletedInLastUndo = 0;
         m_engine = new voltdb::VoltDBEngine();
         int partitionCount = 1;
-        m_engine->initialize(1,1, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(1,1, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator( HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
 
         m_columnNames.push_back("1");

--- a/tests/ee/storage/PersistentTableMemStatsTest.cpp
+++ b/tests/ee/storage/PersistentTableMemStatsTest.cpp
@@ -48,7 +48,7 @@ public:
     PersistentTableMemStatsTest() {
         m_engine = new VoltDBEngine();
         int partitionCount = 1;
-        m_engine->initialize(1,1, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(1,1, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator( HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
 
         m_columnNames.push_back("0");

--- a/tests/ee/storage/constraint_test.cpp
+++ b/tests/ee/storage/constraint_test.cpp
@@ -82,7 +82,7 @@ public:
         m_engine.setBuffers( NULL, 0, NULL, 0, m_exceptionBuffer, 4096);
         m_engine.resetReusedResultOutputBuffer();
         int partitionCount = 1;
-        m_engine.initialize(0, 0, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine.initialize(0, 0, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine.updateHashinator( HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
     }
     ~ConstraintTest() {

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -46,7 +46,7 @@ public:
     PersistentTableLogTest() {
         m_engine = new voltdb::VoltDBEngine();
         int partitionCount = 1;
-        m_engine->initialize(1,1, 0, 0, "", 0, 1024, DEFAULT_TEMP_TABLE_MEMORY, false);
+        m_engine->initialize(1,1, 0, 0, "", 0, 1024, false, DEFAULT_TEMP_TABLE_MEMORY, false);
         m_engine->updateHashinator( HASHINATOR_LEGACY, (char*)&partitionCount, NULL, 0);
 
         m_columnNames.push_back("1");

--- a/tests/frontend/org/voltdb/TestTheHashinator.java
+++ b/tests/frontend/org/voltdb/TestTheHashinator.java
@@ -239,6 +239,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         config, false);
 
@@ -274,6 +275,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         hashinatorConfig, false);
 
@@ -348,6 +350,7 @@ public class TestTheHashinator {
                             "",
                             0,
                             64*1024,
+                            false,
                             100,
                             hashinatorConfig, false);
 
@@ -395,6 +398,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         new HashinatorConfig(hashinatorType, configBytes, 0, 0), false);
 
@@ -430,7 +434,7 @@ public class TestTheHashinator {
     @Test
     public void testSameLongHash() throws Exception {
         byte configBytes[] = TheHashinator.getConfigureBytes(1);
-        ExecutionEngine ee = new ExecutionEngineJNI(1, 1, 0, 0, "", 0, 64*1024, 100, new HashinatorConfig(hashinatorType, configBytes, 0, 0), false);
+        ExecutionEngine ee = new ExecutionEngineJNI(1, 1, 0, 0, "", 0, 64*1024, false, 100, new HashinatorConfig(hashinatorType, configBytes, 0, 0), false);
 
         /**
          *  Run with 10k of random values and make sure C++ and Java hash to
@@ -470,6 +474,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         new HashinatorConfig(hashinatorType, configBytes, 0, 0), false);
 
@@ -541,6 +546,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         new HashinatorConfig(hashinatorType, TheHashinator.getConfigureBytes(2), 0, 0), false);
         final byte configBytes[] = TheHashinator.getConfigureBytes(2);
@@ -607,6 +613,7 @@ public class TestTheHashinator {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         new HashinatorConfig(hashinatorType, TheHashinator.getConfigureBytes(6), 0, 0), false);
         for (int i = 0; i < 2500; i++) {

--- a/tests/frontend/org/voltdb/TestTwoSitePlans.java
+++ b/tests/frontend/org/voltdb/TestTwoSitePlans.java
@@ -115,6 +115,7 @@ public class TestTwoSitePlans extends TestCase {
                                 "",
                                 0,
                                 64*1024,
+                                false,
                                 100,
                                 new HashinatorConfig(HashinatorType.LEGACY, configBytes, 0, 0), false));
             }
@@ -135,6 +136,7 @@ public class TestTwoSitePlans extends TestCase {
                                 "",
                                 0,
                                 64*1024,
+                                false,
                                 100,
                                 new HashinatorConfig(HashinatorType.LEGACY, configBytes, 0, 0), false));
             }

--- a/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
+++ b/tests/frontend/org/voltdb/jni/TestExecutionEngine.java
@@ -165,6 +165,7 @@ public class TestExecutionEngine extends TestCase {
                                 "",
                                 0,
                                 64*1024,
+                                false,
                                 100,
                                 new HashinatorConfig(HashinatorType.LEGACY, configBytes, 0, 0), false));
             }
@@ -280,6 +281,7 @@ public class TestExecutionEngine extends TestCase {
                                 "",
                                 0,
                                 64*1024,
+                                false,
                                 100,
                                 new HashinatorConfig(HashinatorType.LEGACY, configBytes, 0, 0), false));
             }
@@ -342,6 +344,7 @@ public class TestExecutionEngine extends TestCase {
                         "",
                         0,
                         64*1024,
+                        false,
                         100,
                         new HashinatorConfig(HashinatorType.LEGACY, LegacyHashinator.getConfigureBytes(1), 0, 0), false);
         m_project = new TPCCProjectBuilder();

--- a/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
+++ b/tests/frontend/org/voltdb/jni/TestFragmentProgressUpdate.java
@@ -596,6 +596,7 @@ public class TestFragmentProgressUpdate extends TestCase {
                 "",
                 0,
                 64*1024,
+                false,
                 100,
                 new HashinatorConfig(HashinatorType.LEGACY,
                                      LegacyHashinator.getConfigureBytes(1),


### PR DESCRIPTION
Provide a Java Property: DR_IGNORE_CONFLICTS to ignore all conflicts generated by XDCR Binary logs and preserve the existing row state. Note that for transactions that update multiple rows, the consequence is that parts of the transaction will be executed while changes with conflicts will be skipped.