### PR TITLE
ENG-19339: Use common utility for parsing csv DDL

### DIFF
--- a/src/frontend/org/voltdb/compiler/DDLCompiler.java
+++ b/src/frontend/org/voltdb/compiler/DDLCompiler.java
@@ -1655,9 +1655,10 @@ public class DDLCompiler {
         String topicKeyColumnNames = node.attributes.get(SQLParser.CAPTURE_TOPIC_KEY_COLUMNS);
         if (topicKeyColumnNames != null) {
             List<String> definedColumns = new ArrayList<>();
-            for (String col : StringUtils.split(topicKeyColumnNames, ',')) {
+            for (String col : CatalogUtil.splitOnCommas(topicKeyColumnNames)) {
                 if (StringUtils.isBlank(col)) {
-                    continue;
+                    throw compiler.new VoltCompilerException(String
+                            .format("Blank column listed in the KEYS attribute of STREAM %s", table.getTypeName()));
                 }
                 if (definedColumns.contains(col)) {
                     // Do not tolerate any ambiguous key topic definition
@@ -1678,9 +1679,10 @@ public class DDLCompiler {
         String topicAllowedRoleNames = node.attributes.get(SQLParser.CAPTURE_TOPIC_ALLOWED_ROLES);
         if (topicAllowedRoleNames != null) {
             Set<String> definedRoles = new HashSet<>();
-            for (String role : StringUtils.split(topicAllowedRoleNames, ',')) {
+            for (String role : CatalogUtil.splitOnCommas(topicAllowedRoleNames)) {
                 if (StringUtils.isBlank(role)) {
-                    continue;
+                    throw compiler.new VoltCompilerException(String
+                            .format("Blank role listed in the ALLOW attribute of STREAM %s", table.getTypeName()));
                 }
                 if (definedRoles.contains(role)) {
                     // Tolerate duplicates

--- a/src/frontend/org/voltdb/exportclient/PersistedMetadata.java
+++ b/src/frontend/org/voltdb/exportclient/PersistedMetadata.java
@@ -20,12 +20,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.voltcore.utils.DeferredSerialization;
 import org.voltdb.catalog.Table;
 import org.voltdb.serdes.EncodeFormat;
+import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.SerializationHelper;
 
-import com.google.common.base.Splitter;
 import com.google_voltpatches.common.collect.ImmutableList;
 
 /**
@@ -62,10 +63,10 @@ public class PersistedMetadata implements DeferredSerialization {
     public PersistedMetadata(Table table, int partitionId, long initialGenerationId, long generationId) {
         m_format = table.getIstopic() ? EncodeFormat.checkedValueOf(table.getTopicformat()) : EncodeFormat.INVALID;
         String keyColumns = table.getTopickeycolumnnames();
-        if (keyColumns == null) {
+        if (StringUtils.isBlank(keyColumns)) {
             m_keyColumns = ImmutableList.of();
         } else {
-            m_keyColumns = ImmutableList.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().split(keyColumns));
+            m_keyColumns = ImmutableList.copyOf(CatalogUtil.splitOnCommas(keyColumns));
             if (m_keyColumns.size() > 0xFF) {
                 throw new IllegalArgumentException("Maximum number of key columns exceeded: " + m_keyColumns.size());
             }

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -175,6 +175,7 @@ import org.xml.sax.SAXException;
 
 import com.google_voltpatches.common.base.Charsets;
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.base.Splitter;
 import com.google_voltpatches.common.collect.ImmutableMap;
 import com.google_voltpatches.common.collect.ImmutableSortedMap;
 import com.google_voltpatches.common.collect.ImmutableSortedSet;
@@ -3848,5 +3849,15 @@ public abstract class CatalogUtil {
 
     public static Database getDatabase(Catalog catalog) {
         return getCluster(catalog).getDatabases().get("database");
+    }
+
+    /**
+     * Split {@code input} on {@code ,} trimming any leading or trailing white spaces
+     *
+     * @param input to be split
+     * @return {@link Iterable} of {@link String}s from {@code input}
+     */
+    public static Iterable<String> splitOnCommas(String input) {
+        return Splitter.on(',').trimResults().split(input);
     }
 }


### PR DESCRIPTION
Use a common utility for splitting a CSV which trims each entry.

Throw an error if a blank value is supplied for a column or role.