### PR TITLE
ENG-19442 allow snapshot stream to the end when serialization errors show up

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -414,7 +414,8 @@ enum TableStreamType {
 // Serialization special values returned by serializeMore(), etc. instead
 // of the normal count. There's only one possible value for now.
 enum TableStreamSerializationError {
-    TABLE_STREAM_SERIALIZATION_ERROR = -1
+    TABLE_STREAM_SERIALIZATION_ERROR = -1,
+    TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES = -2
 };
 
 /**

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2652,7 +2652,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
         }
 
         remaining = table->streamMore(outputStreams, streamType, retPositions);
-        if (remaining <= 0) {
+        if (remaining <= 0 && remaining > TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) {
             m_snapshottingTables.erase(tableId);
             if (table->isReplicatedTable()) {
                 ScopedReplicatedResourceLock scopedLock;

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -342,6 +342,10 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
     return retValue;
 }
 
+int64_t CopyOnWriteContext::getRemainingCount() {
+    return m_tuplesRemaining;
+}
+
 bool CopyOnWriteContext::notifyTupleDelete(TableTuple &tuple) {
     vassert(m_iterator.get() != NULL);
 

--- a/src/ee/storage/CopyOnWriteContext.h
+++ b/src/ee/storage/CopyOnWriteContext.h
@@ -89,6 +89,8 @@ public:
      */
     virtual bool notifyTupleDelete(TableTuple &tuple);
 
+    virtual int64_t getRemainingCount();
+
 private:
 
     /**

--- a/src/ee/storage/TableStreamer.cpp
+++ b/src/ee/storage/TableStreamer.cpp
@@ -162,8 +162,16 @@ int64_t TableStreamer::streamMore(TupleOutputStreamProcessor &outputStreams,
         if (streamPtr->m_streamType == streamType) {
             // Assert that we didn't find the stream type twice.
             vassert(remaining == TABLE_STREAM_SERIALIZATION_ERROR);
-            remaining = streamPtr->m_context->handleStreamMore(outputStreams, retPositions);
-            if (remaining <= 0) {
+            try {
+                remaining = streamPtr->m_context->handleStreamMore(outputStreams, retPositions);
+            } catch (...) {
+                if ( remaining == TABLE_STREAM_SERIALIZATION_ERROR) {
+                    if (streamPtr->m_context->getRemainingCount() > 0) {
+                        remaining = TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES;
+                    }
+                }
+            }
+            if (remaining <= 0 && remaining > TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) {
                 // Drop the stream if it doesn't need to hang around (e.g. elastic).
                 if (streamPtr->m_context->handleDeactivation(streamType)) {
                     m_streams.push_back(streamPtr);

--- a/src/ee/storage/TableStreamer.cpp
+++ b/src/ee/storage/TableStreamer.cpp
@@ -165,6 +165,9 @@ int64_t TableStreamer::streamMore(TupleOutputStreamProcessor &outputStreams,
             try {
                 remaining = streamPtr->m_context->handleStreamMore(outputStreams, retPositions);
             } catch (...) {
+                // Failed to serialize data but there are still more tuples to be streamed
+                // Return -2 (TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) to prevent this stream
+                // from being dropped: SnapshotSiteProcessor keeps pulling until all tuples are streamed.
                 if ( remaining == TABLE_STREAM_SERIALIZATION_ERROR) {
                     if (streamPtr->m_context->getRemainingCount() > 0) {
                         remaining = TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES;

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -158,7 +158,7 @@ public:
         // do not need to be applied to the post-truncated copy of the table.
         return NULL;
     }
-
+    virtual int64_t getRemainingCount() { return TABLE_STREAM_SERIALIZATION_ERROR;}
 protected:
 
     /**

--- a/src/frontend/org/voltdb/TableStreamer.java
+++ b/src/frontend/org/voltdb/TableStreamer.java
@@ -121,6 +121,8 @@ public class TableStreamer {
             for (SnapshotTableTask task : m_tableTasks) {
                 task.m_target.reportSerializationFailure(ex);
             }
+            // There may be more tuples to be streamed when the error occurs. Continue streaming until all
+            // tuples are pulled. Otherwise a stream could not be pulled again if it can not be reactivated.
             return Pair.of(null, remaining == SERIALIZATION_ERROR_MORE_TUPLES);
         }
 

--- a/src/frontend/org/voltdb/TableStreamer.java
+++ b/src/frontend/org/voltdb/TableStreamer.java
@@ -48,7 +48,7 @@ public class TableStreamer {
 
     // Error code returned by EE.tableStreamSerializeMore().
     private static final byte SERIALIZATION_ERROR = -1;
-
+    private static final byte SERIALIZATION_ERROR_MORE_TUPLES = SERIALIZATION_ERROR -1;
     private final int m_tableId;
     private final TableStreamType m_type;
     private final HiddenColumnFilter m_hiddenColumnFilter;
@@ -111,7 +111,8 @@ public class TableStreamer {
         prepareBuffers(outputBuffers);
 
         Pair<Long, int[]> serializeResult = context.tableStreamSerializeMore(m_tableId, m_type, outputBuffers);
-        if (serializeResult.getFirst() == SERIALIZATION_ERROR) {
+        long remaining = serializeResult.getFirst();
+        if ( remaining <= SERIALIZATION_ERROR ) {
             // Cancel the snapshot here
             for (DBBPool.BBContainer container : outputBuffers) {
                 container.discard();
@@ -120,7 +121,7 @@ public class TableStreamer {
             for (SnapshotTableTask task : m_tableTasks) {
                 task.m_target.reportSerializationFailure(ex);
             }
-            return Pair.of(null, false);
+            return Pair.of(null, remaining == SERIALIZATION_ERROR_MORE_TUPLES);
         }
 
         if (serializeResult.getSecond()[0] > 0) {
@@ -135,7 +136,7 @@ public class TableStreamer {
             }
         }
 
-        return Pair.of(writeFuture, serializeResult.getFirst() > 0);
+        return Pair.of(writeFuture, remaining > 0);
     }
 
     /**


### PR DESCRIPTION
When serialization error occurs, snapshot site processor will take  the current table out for more rounds of streaming even though there may be more tuples to be streamed. The snapshot  for the table is not done in engine but is marked as done  in snapshot site processor, which allows next snapshot to be started on snapshot site processor but not in the engine. Snapshot can not be performed again.