### PR TITLE
ENG-19479: Add a way to force retrieving schema from catalog

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2551,10 +2551,11 @@ void VoltDBEngine::updateExecutorContextUndoQuantumForTest() {
     m_executorContext->setupForPlanFragments(m_currentUndoQuantum);
 }
 
-int VoltDBEngine::getSnapshotSchema(const CatalogId tableId, HiddenColumnFilter::Type hiddenColumnFilterType) {
+int VoltDBEngine::getSnapshotSchema(const CatalogId tableId, HiddenColumnFilter::Type hiddenColumnFilterType,
+        bool forceLive) {
     PersistentTable *table;
-    if (m_snapshottingTables.empty()) {
-        // Called prior to snapshot being activated
+    if (forceLive || m_snapshottingTables.empty()) {
+        // forced to get live schema or called prior to snapshot being activated
         Table* found = getTableById(tableId);
 
          if (!found) {

--- a/src/ee/execution/VoltDBEngine.h
+++ b/src/ee/execution/VoltDBEngine.h
@@ -499,7 +499,7 @@ class __attribute__((visibility("default"))) VoltDBEngine {
             m_isLowestSite = true;
         }
 
-        int getSnapshotSchema(CatalogId tableId, HiddenColumnFilter::Type hiddenColumnFilterType);
+        int getSnapshotSchema(CatalogId tableId, HiddenColumnFilter::Type hiddenColumnFilterType, bool forceLive);
 
         /**
          * Activate a table stream of the specified type for the specified table.

--- a/src/ee/voltdbjni.cpp
+++ b/src/ee/voltdbjni.cpp
@@ -1051,14 +1051,14 @@ SHAREDLIB_JNIEXPORT jboolean JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeS
 /*
  * Class:     org_voltdb_jni_ExecutionEngine
  * Method:    nativeGetSnapshotSchema
- * Signature: (JIB)I
+ * Signature: (JIBZ)I
  */
 SHAREDLIB_JNIEXPORT jint JNICALL Java_org_voltdb_jni_ExecutionEngine_nativeGetSnapshotSchema(
-        JNIEnv *env, jobject obj, jlong engine_ptr, jint tableId, jbyte schemaFilterType)
+        JNIEnv *env, jobject obj, jlong engine_ptr, jint tableId, jbyte schemaFilterType, jboolean forceLive)
 {
     VoltDBEngine *engine = castToEngine(engine_ptr);
     voltdb::HiddenColumnFilter::Type hiddenColumnFilter = static_cast<voltdb::HiddenColumnFilter::Type>(schemaFilterType);
-    return engine->getSnapshotSchema(tableId, hiddenColumnFilter);
+    return engine->getSnapshotSchema(tableId, hiddenColumnFilter, forceLive);
 }
 
 /*

--- a/src/frontend/org/voltdb/SiteSnapshotConnection.java
+++ b/src/frontend/org/voltdb/SiteSnapshotConnection.java
@@ -47,5 +47,9 @@ public interface SiteSnapshotConnection
         }
     }
 
-    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter);
+    public default void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter) {
+        populateSnapshotSchema(table, filter, false);
+    }
+
+    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter, boolean forceLive);
 }

--- a/src/frontend/org/voltdb/iv2/Site.java
+++ b/src/frontend/org/voltdb/iv2/Site.java
@@ -1154,8 +1154,8 @@ public class Site implements Runnable, SiteProcedureConnection, SiteSnapshotConn
     }
 
     @Override
-    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter) {
-        Pair<byte[], Integer> result = m_ee.getSnapshotSchema(table.getTableId(), filter);
+    public void populateSnapshotSchema(SnapshotTableInfo table, HiddenColumnFilter filter, boolean forceLive) {
+        Pair<byte[], Integer> result = m_ee.getSnapshotSchema(table.getTableId(), filter, forceLive);
         table.setSchema(result.getFirst(), result.getSecond());
     }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngine.java
@@ -610,7 +610,17 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
     /*
      * Interface frontend invokes to communicate to CPP execution engine.
      */
-    public abstract Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter);
+    /**
+     * Retrieve the schema for a table from the EE
+     *
+     * @param tableId            ID of the table
+     * @param hiddenColumnFilter {@link HiddenColumnFilter} to indicate which hidden columns to include in the schema
+     * @param forceLive          if {@code true} the current catalog schema will be used and not the one associated with
+     *                           the snapshot
+     * @return {@link Pair} with {@code first} being the encoded schema and {@code second} being the partition column id
+     */
+    public abstract Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter,
+            boolean forceLive);
 
     public abstract boolean activateTableStream(final int tableId,
                                                 TableStreamType type,
@@ -1232,9 +1242,10 @@ public abstract class ExecutionEngine implements FastDeserializer.Deserializatio
      * @param pointer          Pointer to an engine instance
      * @param tableId          ID of the table whose schema is being retrieved
      * @param schemaFilterType Type of filter to apply to schema
+     * @param forceLive        Force the schema to be read from current catalog and not snapshot schemas
      * @return error code indicating status of execution
      */
-    protected native int nativeGetSnapshotSchema(long pointer, int tableId, byte schemaFilterType);
+    protected native int nativeGetSnapshotSchema(long pointer, int tableId, byte schemaFilterType, boolean forceLive);
 
     /**
      * Active a table stream of the specified type for a table.

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -1569,7 +1569,8 @@ public class ExecutionEngineIPC extends ExecutionEngine {
     }
 
     @Override
-    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter) {
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter,
+            boolean forceLive) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -634,10 +634,11 @@ public class ExecutionEngineJNI extends ExecutionEngine {
     }
 
     @Override
-    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter)
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter,
+            boolean forceLive)
             throws EEException {
         m_nextDeserializer.clear();
-        checkErrorCode(nativeGetSnapshotSchema(pointer, tableId, hiddenColumnFilter.getId()));
+        checkErrorCode(nativeGetSnapshotSchema(pointer, tableId, hiddenColumnFilter.getId(), forceLive));
         try {
             return Pair.of(m_nextDeserializer.readVarbinary(), m_nextDeserializer.readInt());
         } catch (IOException e) {

--- a/src/frontend/org/voltdb/jni/MockExecutionEngine.java
+++ b/src/frontend/org/voltdb/jni/MockExecutionEngine.java
@@ -192,7 +192,8 @@ public class MockExecutionEngine extends ExecutionEngine {
     }
 
     @Override
-    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter) {
+    public Pair<byte[], Integer> getSnapshotSchema(int tableId, HiddenColumnFilter hiddenColumnFilter,
+            boolean forceLive) {
         return Pair.of(new byte[0], -1);
     }
 


### PR DESCRIPTION
Add a new boolean to getSnapshotSchema which forces the ee to retrieve the schame from the current catalog instead of from the snapshot schemas.

This is needed by elastic which needs to copy data from tables which are added ore modified during balance partitions.