### PR TITLE
ENG-19397: Copy all deployment fields

### DIFF
--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -654,7 +654,7 @@ public class VoltDB {
                     }
 
                     try {
-                        m_getOption = GetActionArgument.valueOf(GetActionArgument.class, argument.trim().toUpperCase());
+                        m_getOption = GetActionArgument.valueOf(argument.trim().toUpperCase());
                     } catch (IllegalArgumentException excp) {
                         System.err.println("FATAL:" + argument + " is not a valid \"get\" command argument. Valid arguments for get command are: " + GetActionArgument.supportedVerbs());
                         referToDocAndExit();

--- a/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
+++ b/src/frontend/org/voltdb/compiler/DeploymentFileSchema.xsd
@@ -34,6 +34,7 @@
   <xs:element name="deployment" type="deploymentType"/>
   <xs:complexType name="deploymentType">
     <xs:all>
+      <!--  If any types are added here CatalogUtil.shallowClusterAndPathsClone needs to be updated -->
       <xs:element name="cluster" minOccurs="1" maxOccurs="1" type="clusterType"/>
       <xs:element name="paths" minOccurs="0" maxOccurs="1" type="pathsType" />
       <xs:element name="partition-detection" minOccurs="0" type="partitionDetectionType"/>

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -3536,18 +3536,6 @@ public abstract class CatalogUtil {
     public static DeploymentType shallowClusterAndPathsClone(DeploymentType o) {
         DeploymentType clone = new DeploymentType();
 
-        clone.setPartitionDetection(o.getPartitionDetection());
-        clone.setHeartbeat(o.getHeartbeat());
-        clone.setHttpd(o.getHttpd());
-        clone.setSnapshot(o.getSnapshot());
-        clone.setExport(o.getExport());
-        clone.setUsers(o.getUsers());
-        clone.setCommandlog(o.getCommandlog());
-        clone.setSystemsettings(o.getSystemsettings());
-        clone.setSecurity(o.getSecurity());
-        clone.setDr(o.getDr());
-        clone.setImport(o.getImport());
-
         ClusterType other = o.getCluster();
         ClusterType cluster = new ClusterType();
 
@@ -3571,9 +3559,26 @@ public abstract class CatalogUtil {
         paths.setLargequeryswap(prev.getLargequeryswap());
 
         clone.setPaths(paths);
-        clone.setSsl(o.getSsl());
 
+        clone.setPartitionDetection(o.getPartitionDetection());
+        clone.setHeartbeat(o.getHeartbeat());
+        clone.setSsl(o.getSsl());
+        clone.setHttpd(o.getHttpd());
+        clone.setSnapshot(o.getSnapshot());
+        clone.setExport(o.getExport());
+        clone.setThreadpools(o.getThreadpools());
+        clone.setUsers(o.getUsers());
+        clone.setCommandlog(o.getCommandlog());
+        clone.setSystemsettings(o.getSystemsettings());
+        clone.setSecurity(o.getSecurity());
+        clone.setDr(o.getDr());
+        clone.setImport(o.getImport());
         clone.setSnmp(o.getSnmp());
+        clone.setFeatures(o.getFeatures());
+        clone.setTask(o.getTask());
+        clone.setTopics(o.getTopics());
+        clone.setAvro(o.getAvro());
+
         return clone;
     }
 


### PR DESCRIPTION
CatalogUtil.shallowClusterAndPathsClone is supposed to copy almost all of the fields for the original deployment instance but most of the new fields were not added. Add the missing fields and organize the copy order to match the declaration in DeploymentFileSchema.xsd for easier reading