### PR TITLE
ENG-19495: Change fatal log message on proc call error to info so test can complete.

### DIFF
--- a/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
+++ b/tests/test_apps/genqa/src/genqa/AsyncExportClient.java
@@ -352,9 +352,9 @@ public class AsyncExportClient
                                                       0);
                     }
                     catch (Exception e) {
-                        log.fatal("Exception: " + e);
+                        log.info("Exception: " + e);
                         e.printStackTrace();
-                        System.exit(-1);
+                        // System.exit(-1);
                     }
                 }
             }


### PR DESCRIPTION
Proc call error, adjusted so error message is put into the log but not fatal level so the test can continue.