### PR TITLE
ENG-19505 allow snapshot stream to the end when serialization errors …

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -414,7 +414,8 @@ enum TableStreamType {
 // Serialization special values returned by serializeMore(), etc. instead
 // of the normal count. There's only one possible value for now.
 enum TableStreamSerializationError {
-    TABLE_STREAM_SERIALIZATION_ERROR = -1
+    TABLE_STREAM_SERIALIZATION_ERROR = -1,
+    TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES = -2
 };
 
 /**

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2652,7 +2652,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
         }
 
         remaining = table->streamMore(outputStreams, streamType, retPositions);
-        if (remaining <= 0) {
+        if (remaining <= 0 && remaining > TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) {
             m_snapshottingTables.erase(tableId);
             if (table->isReplicatedTable()) {
                 ScopedReplicatedResourceLock scopedLock;

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -342,6 +342,10 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
     return retValue;
 }
 
+int64_t CopyOnWriteContext::getRemainingCount() {
+    return m_tuplesRemaining;
+}
+
 bool CopyOnWriteContext::notifyTupleDelete(TableTuple &tuple) {
     vassert(m_iterator.get() != NULL);
 

--- a/src/ee/storage/CopyOnWriteContext.h
+++ b/src/ee/storage/CopyOnWriteContext.h
@@ -89,6 +89,7 @@ public:
      */
     virtual bool notifyTupleDelete(TableTuple &tuple);
 
+    virtual int64_t getRemainingCount();
 private:
 
     /**

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -159,6 +159,8 @@ public:
         return NULL;
     }
 
+    virtual int64_t getRemainingCount() { return TABLE_STREAM_SERIALIZATION_ERROR;}
+
 protected:
 
     /**

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -706,6 +706,11 @@ public class SnapshotSiteProcessor {
                 final long txnId = m_lastSnapshotTxnId;
                 final ExtensibleSnapshotDigestData snapshotDataForZookeeper = m_extraSnapshotData;
                 m_extraSnapshotData = null;
+                Thread.UncaughtExceptionHandler eh = new Thread.UncaughtExceptionHandler() {
+                   public void uncaughtException(Thread th, Throwable ex) {
+                        SNAP_LOG.warn("Error running snapshot completion task", ex);
+                    }
+                };
                 final Thread terminatorThread =
                     new Thread("Snapshot terminator") {
                     @Override
@@ -782,7 +787,7 @@ public class SnapshotSiteProcessor {
                         }
                     }
                 };
-
+                terminatorThread.setUncaughtExceptionHandler(eh);
                 m_snapshotTargetTerminators.add(terminatorThread);
                 terminatorThread.start();
             }


### PR DESCRIPTION
…show up. When serialization error occurs, snapshot site processor will take the current table out for more rounds of streaming even though there may be more tuples to be streamed. The snapshot for the table is not done in engine but is marked as done in snapshot site processor, which allows next snapshot to be started on snapshot site processor but not in the engine. Snapshot can not be performed again.