### PR TITLE
ENG-19505 allow snapshot stream to the end when serialization errors

### DIFF
--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -414,7 +414,8 @@ enum TableStreamType {
 // Serialization special values returned by serializeMore(), etc. instead
 // of the normal count. There's only one possible value for now.
 enum TableStreamSerializationError {
-    TABLE_STREAM_SERIALIZATION_ERROR = -1
+    TABLE_STREAM_SERIALIZATION_ERROR = -1,
+    TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES = -2
 };
 
 /**

--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2431,7 +2431,7 @@ int64_t VoltDBEngine::tableStreamSerializeMore(
         }
 
         remaining = table->streamMore(outputStreams, streamType, retPositions);
-        if (remaining <= 0) {
+        if (remaining <= 0 && remaining > TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) {
             m_snapshottingTables.erase(tableId);
             if (table->isReplicatedTable()) {
                 ScopedReplicatedResourceLock scopedLock;

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -342,6 +342,10 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
     return retValue;
 }
 
+int64_t CopyOnWriteContext::getRemainingCount() {
+    return m_tuplesRemaining;
+}
+
 bool CopyOnWriteContext::notifyTupleDelete(TableTuple &tuple) {
     assert(m_iterator.get() != NULL);
 

--- a/src/ee/storage/CopyOnWriteContext.h
+++ b/src/ee/storage/CopyOnWriteContext.h
@@ -89,6 +89,7 @@ public:
      */
     virtual bool notifyTupleDelete(TableTuple &tuple);
 
+    virtual int64_t getRemainingCount();
 private:
 
     /**

--- a/src/ee/storage/TableStreamer.cpp
+++ b/src/ee/storage/TableStreamer.cpp
@@ -176,8 +176,19 @@ int64_t TableStreamer::streamMore(TupleOutputStreamProcessor &outputStreams,
         if (streamPtr->m_streamType == streamType) {
             // Assert that we didn't find the stream type twice.
             assert(remaining == TABLE_STREAM_SERIALIZATION_ERROR);
-            remaining = streamPtr->m_context->handleStreamMore(outputStreams, retPositions);
-            if (remaining <= 0) {
+            try {
+                remaining = streamPtr->m_context->handleStreamMore(outputStreams, retPositions);
+            } catch (...) {
+                // Failed to serialize data but there are still more tuples to be streamed
+                // Return -2 (TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) to prevent this stream
+                // from being dropped: SnapshotSiteProcessor keeps pulling until all tuples are streamed.
+                if ( remaining == TABLE_STREAM_SERIALIZATION_ERROR) {
+                     if (streamPtr->m_context->getRemainingCount() > 0) {
+                          remaining = TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES;
+                     }
+                }
+            }
+            if (remaining <= 0 && remaining > TABLE_STREAM_SERIALIZATION_ERROR_MORE_TUPLES) {
                 // Drop the stream if it doesn't need to hang around (e.g. elastic).
                 if (streamPtr->m_context->handleDeactivation(streamType)) {
                     m_streams.push_back(streamPtr);

--- a/src/ee/storage/TableStreamerContext.h
+++ b/src/ee/storage/TableStreamerContext.h
@@ -159,6 +159,7 @@ public:
         return NULL;
     }
 
+    virtual int64_t getRemainingCount() { return TABLE_STREAM_SERIALIZATION_ERROR;}
 protected:
 
     /**

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -679,6 +679,11 @@ public class SnapshotSiteProcessor {
                 final long txnId = m_lastSnapshotTxnId;
                 final ExtensibleSnapshotDigestData snapshotDataForZookeeper = m_extraSnapshotData;
                 m_extraSnapshotData = null;
+                Thread.UncaughtExceptionHandler eh = new Thread.UncaughtExceptionHandler() {
+                    public void uncaughtException(Thread th, Throwable ex) {
+                         SNAP_LOG.warn("Error running snapshot completion task", ex);
+                     }
+                };
                 final Thread terminatorThread =
                     new Thread("Snapshot terminator") {
                     @Override
@@ -761,7 +766,7 @@ public class SnapshotSiteProcessor {
                         }
                     }
                 };
-
+                terminatorThread.setUncaughtExceptionHandler(eh);
                 m_snapshotTargetTerminators.add(terminatorThread);
                 terminatorThread.start();
             }

--- a/src/frontend/org/voltdb/TableStreamer.java
+++ b/src/frontend/org/voltdb/TableStreamer.java
@@ -47,6 +47,7 @@ public class TableStreamer {
 
     // Error code returned by EE.tableStreamSerializeMore().
     private static final byte SERIALIZATION_ERROR = -1;
+    private static final byte SERIALIZATION_ERROR_MORE_TUPLES = SERIALIZATION_ERROR -1;
 
     private final int m_tableId;
     private final TableStreamType m_type;
@@ -107,7 +108,8 @@ public class TableStreamer {
         prepareBuffers(outputBuffers);
 
         Pair<Long, int[]> serializeResult = context.tableStreamSerializeMore(m_tableId, m_type, outputBuffers);
-        if (serializeResult.getFirst() == SERIALIZATION_ERROR) {
+        long remaining = serializeResult.getFirst();
+        if ( remaining <= SERIALIZATION_ERROR ) {
             // Cancel the snapshot here
             for (DBBPool.BBContainer container : outputBuffers) {
                 container.discard();
@@ -116,7 +118,9 @@ public class TableStreamer {
             for (SnapshotTableTask task : m_tableTasks) {
                 task.m_target.reportSerializationFailure(ex);
             }
-            return Pair.of(null, false);
+            // There may be more tuples to be streamed when the error occurs. Continue streaming until all
+            // tuples are pulled. Otherwise a stream could not be pulled again if it can not be reactivated.
+            return Pair.of(null, remaining == SERIALIZATION_ERROR_MORE_TUPLES);
         }
 
         if (serializeResult.getSecond()[0] > 0) {
@@ -131,7 +135,7 @@ public class TableStreamer {
             }
         }
 
-        return Pair.of(writeFuture, serializeResult.getFirst() > 0);
+        return Pair.of(writeFuture, remaining > 0);
     }
 
     /**


### PR DESCRIPTION
When serialization error occurs, snapshot site processor will take the current table out for more rounds of streaming even though there may be more tuples to be streamed. The snapshot for the table is not done in engine but is marked as done in snapshot site processor, which allows next snapshot to be started on snapshot site processor but not in the engine. Snapshot can not be performed again.