### PR TITLE
ENG-19411: Continue processing persistent tables

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -1434,7 +1434,7 @@ bool VoltDBEngine::processCatalogAdditions(int64_t timestamp, bool updateReplica
                 }
                 // note, this is the end of the line for export tables for now,
                 // don't allow them to change schema yet
-                if (!tableSchemaChanged) {
+                if (!tableSchemaChanged && !persistentTable) {
                     continue;
                 }
             }


### PR DESCRIPTION
If a persistent table has a shadow stream processing of the table would
stop after the shadow stream was processed if there was no schema
change. When the table is a persistent table indexes and views still
need to be processed.