### PR TITLE
ENG-19474 prevent cluster from crash caused heterogeneous responses  from replicas

### DIFF
--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -390,7 +390,7 @@ public class FragmentTask extends FragmentTaskBase
                     if (currentFragResponse.getTableCount() == 0) {
                         // Make sure the response has at least 1 result with a valid DependencyId
                         currentFragResponse.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                                m_rawDummyResult, 0, m_rawDummyResult.length));
+                                RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                     }
                     exceptionThrown = true;
                 }

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -19,7 +19,6 @@ package org.voltdb.iv2;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -101,6 +100,7 @@ public class SysProcDuplicateCounter extends DuplicateCounter
                     continue;
                 }
             }
+            tables.add(dep);
         }
 
         // needs to be a three long array to work
@@ -116,19 +116,23 @@ public class SysProcDuplicateCounter extends DuplicateCounter
             new FragmentResponseMessage((FragmentResponseMessage)m_lastResponse);
         // union up all the deps we've collected and jam them in
         for (Entry<Integer, List<VoltTable>> dep : m_alldeps.entrySet()) {
-            // Remove dummy results
-            List<VoltTable> depTables = dep.getValue().stream().filter(
-                    x -> x.getStatusCode() != VoltTableUtil.DUMMY_DEPENDENCY_STATUS).collect(Collectors.toList());
+            List<VoltTable> depTables = dep.getValue();
             VoltTable grouped;
-            if (depTables.isEmpty()) {
-                grouped = TransactionTask.DUMMAY_RESULT_TABLE;
-            } else if (depTables.size() == 1){
+            if (depTables.size() == 1){
                 grouped = depTables.get(0);
             } else {
-                grouped = VoltTableUtil.unionTables(depTables);
+                // Remove dummy results
+                depTables =  depTables.stream().filter(
+                        x -> x.getStatusCode() != VoltTableUtil.DUMMY_DEPENDENCY_STATUS).collect(Collectors.toList());
+                if (depTables.isEmpty()) {
+                    grouped = TransactionTask.DUMMAY_RESULT_TABLE;
+                } else if (depTables.size() == 1){
+                    grouped = depTables.get(0);
+                } else {
+                    grouped = VoltTableUtil.unionTables(depTables);
+                }
             }
             unioned.addDependency(new DependencyPair.TableDependencyPair(dep.getKey(), grouped));
-
         }
         // we should never rollback DR buffer for MP sysprocs because we don't report the DR buffer size and therefore don't know if it is empty or not.
         unioned.setDrBufferSize(1);

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -100,17 +100,13 @@ public class SysProcDuplicateCounter extends DuplicateCounter
                 }
             }
 
-
             // Avoid mixing dummy fragment results with normal results
             if (tables.isEmpty()) {
                 tables.add(dep);
-            } else {
-                if (dep.getTableSchema().length > 1 ||
-                        !TransactionTask.dummyResult.getTableSchema()[0].equals(dep.getTableSchema()[0])) {
-                   tables.add(dep);
-                }
+            } else if (dep.getStatusCode() != VoltTableUtil.DUMMY_DEPENDENCY_STATUS){
+                tables.add(dep);
                 // Remove dummy if any
-                tables.remove(TransactionTask.dummyResult);
+                tables.remove(SysprocFragmentTask.DUMMAY_RESULT_TABLE);
             }
         }
 

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -100,7 +100,18 @@ public class SysProcDuplicateCounter extends DuplicateCounter
                 }
             }
 
-            tables.add(dep);
+
+            // Avoid mixing dummy fragment results with normal results
+            if (tables.isEmpty()) {
+                tables.add(dep);
+            } else {
+                if (dep.getTableSchema().length > 1 ||
+                        !TransactionTask.dummyResult.getTableSchema()[0].equals(dep.getTableSchema()[0])) {
+                   tables.add(dep);
+                }
+                // Remove dummy if any
+                tables.remove(TransactionTask.dummyResult);
+            }
         }
 
         // needs to be a three long array to work

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -53,12 +53,11 @@ public class SysprocFragmentTask extends FragmentTaskBase
     final FragmentTaskMessage m_fragmentMsg;
     Map<Integer, List<VoltTable>> m_inputDeps;
     boolean m_respBufferable = true;
-    static final byte[] m_rawDummyResponse;
-
+    static final byte[] RAW_DUMMY_RESPONSE;
     static {
         VoltTable dummyResponse = new VoltTable(new ColumnInfo("STATUS", VoltType.TINYINT));
         dummyResponse.setStatusCode(VoltTableUtil.NULL_DEPENDENCY_STATUS);
-        m_rawDummyResponse = dummyResponse.buildReusableDependenyResult();
+        RAW_DUMMY_RESPONSE = dummyResponse.buildReusableDependenyResult();
     }
 
     // This constructor is used during live rejoin log replay.
@@ -105,7 +104,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
         for (int frag = 0; frag < m_fragmentMsg.getFragmentCount(); frag++) {
             final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
             response.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                    m_rawDummyResponse, 0, m_rawDummyResponse.length));
+                    RAW_DUMMY_RESPONSE, 0, RAW_DUMMY_RESPONSE.length));
         }
         response.setRespBufferable(m_respBufferable);
         m_initiator.deliver(response);
@@ -283,7 +282,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
             // Make sure the response has at least 1 result with a valid DependencyId
             response.addDependency(new
                     DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                            m_rawDummyResult, 0, m_rawDummyResult.length));
+                            RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -31,11 +31,11 @@ public abstract class TransactionTask extends SiteTasker
 {
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
-
+    public static VoltTable dummyResult;
     protected static final byte[] m_rawDummyResult;
 
     static {
-        VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
+        dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
         m_rawDummyResult = dummyResult.buildReusableDependenyResult();
     }
 

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -37,7 +37,7 @@ public abstract class TransactionTask extends SiteTasker
 
     static {
         DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
-        DUMMAY_RESULT_TABLE.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
+//        DUMMAY_RESULT_TABLE.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
         RAW_DUMMY_RESULT = DUMMAY_RESULT_TABLE.buildReusableDependenyResult();
     }
 

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -36,9 +36,10 @@ public abstract class TransactionTask extends SiteTasker
     protected static final byte[] RAW_DUMMY_RESULT;
 
     static {
-        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
-//        DUMMAY_RESULT_TABLE.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
-        RAW_DUMMY_RESULT = DUMMAY_RESULT_TABLE.buildReusableDependenyResult();
+        VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
+        dummyResult.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
+        RAW_DUMMY_RESULT = dummyResult.buildReusableDependenyResult();
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));;
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -39,7 +39,7 @@ public abstract class TransactionTask extends SiteTasker
         VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
         dummyResult.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
         RAW_DUMMY_RESULT = dummyResult.buildReusableDependenyResult();
-        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));;
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -21,9 +21,10 @@ import org.voltcore.logging.VoltLogger;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
+import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.dtxn.TransactionState;
+import org.voltdb.utils.VoltTableUtil;
 
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 
@@ -31,12 +32,13 @@ public abstract class TransactionTask extends SiteTasker
 {
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
-    public static VoltTable dummyResult;
-    protected static final byte[] m_rawDummyResult;
+    public static VoltTable DUMMAY_RESULT_TABLE;
+    protected static final byte[] RAW_DUMMY_RESULT;
 
     static {
-        dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
-        m_rawDummyResult = dummyResult.buildReusableDependenyResult();
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
+        DUMMAY_RESULT_TABLE.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
+        RAW_DUMMY_RESULT = DUMMAY_RESULT_TABLE.buildReusableDependenyResult();
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/utils/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTableUtil.java
@@ -60,6 +60,10 @@ public class VoltTableUtil {
     // task messages with this.
     public static byte NULL_DEPENDENCY_STATUS = -1;
 
+    // VoltTable status code to indicate dummy dependency table. Joining SPI replies to fragment
+    // task messages with this.
+    public static byte DUMMY_DEPENDENCY_STATUS = -2;
+
     private static final ThreadLocal<SimpleDateFormat> m_sdf = new ThreadLocal<SimpleDateFormat>() {
         @Override
         public SimpleDateFormat initialValue() {


### PR DESCRIPTION
When transactions hits failure on executing fragments, a dummy response is added to its dependency.  A partition leader could receive  various responses. A successful response has   dependency tables with one schema  while  a failed  response has  dependency tables with another schema.  When a transaction tries to combine the responses, schema mismatch will be encountered, which will crash cluster. 