### PR TITLE
ENG-19524 reset catalog staging status if published upon UAC restart

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -409,6 +409,8 @@ public class UpdateCore extends VoltSystemProcedure {
                 Arrays.equals(context.getCatalogHash(), catalogHash) &&
                 Arrays.equals(context.getDeploymentHash(), deploymentHash)) {
                 log.info("Restarting catalog update");
+                // Catalog may have been published, reset the status to PENDING if COMPLETE
+                CatalogUtil.unPublishCatalog(zk, expectedCatalogVersion + 1);
             } else {
                 // impossible to happen since we only allow catalog update sequentially
                 String errMsg = "Invalid catalog update.  Catalog or deployment change was planned " +

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2780,6 +2780,29 @@ public abstract class CatalogUtil {
         }
     }
 
+    /**
+     * Change the state of given ZK node that represents catalog version from COMPLETE to PENDING
+     * @param zk
+     * @param version
+     * @throws KeeperException
+     * @throws InterruptedException
+     */
+    public static void unPublishCatalog(ZooKeeper zk, int version) throws KeeperException, InterruptedException {
+        String path = VoltZK.catalogbytes + "/" + version;
+        Stat stat = new Stat();
+        byte[] data = zk.getData(path, false, stat);
+        ByteBuffer buffer = ByteBuffer.wrap(data);// flag (byte) + expected catalog segment count (int) + txnId (long)
+        byte status = buffer.get();
+        if (status == (byte)ZKCatalogStatus.COMPLETE.ordinal()) {
+            int catalogSegmentCount = buffer.getInt();
+            // Rewrite the flag
+            buffer.position(0);
+            buffer.put((byte)ZKCatalogStatus.PENDING.ordinal());
+            buffer.putInt(catalogSegmentCount);
+            zk.setData(path, buffer.array(), stat.getVersion());
+        }
+    }
+
     public static void stageCatalogToZK(ZooKeeper zk, int version, long genId, long txnId, SegmentedCatalog catalogAndDeployment)
             throws KeeperException, InterruptedException {
         updateCatalogToZK(zk, version, genId, catalogAndDeployment, ZKCatalogStatus.PENDING, txnId);


### PR DESCRIPTION
UAC fragment processing assumes that staging catalog is pending status. If UAC is restarted after catalog staging is completed, the staged catalog in pending status won't found for command logging. NPE will be thrown. For UAC restart, the status of the catalog staging should be reset to pending.