### PR TITLE
ENG-19523 prevent cluster from crash caused heterogeneous responses from replicas

### DIFF
--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -390,7 +390,7 @@ public class FragmentTask extends FragmentTaskBase
                     if (currentFragResponse.getTableCount() == 0) {
                         // Make sure the response has at least 1 result with a valid DependencyId
                         currentFragResponse.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                                m_rawDummyResult, 0, m_rawDummyResult.length));
+                                RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                     }
                     exceptionThrown = true;
                 }

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -53,12 +53,11 @@ public class SysprocFragmentTask extends FragmentTaskBase
     final FragmentTaskMessage m_fragmentMsg;
     Map<Integer, List<VoltTable>> m_inputDeps;
     boolean m_respBufferable = true;
-    static final byte[] m_rawDummyResponse;
-
+    static final byte[] RAW_DUMMY_RESPONSE;
     static {
         VoltTable dummyResponse = new VoltTable(new ColumnInfo("STATUS", VoltType.TINYINT));
         dummyResponse.setStatusCode(VoltTableUtil.NULL_DEPENDENCY_STATUS);
-        m_rawDummyResponse = dummyResponse.buildReusableDependenyResult();
+        RAW_DUMMY_RESPONSE = dummyResponse.buildReusableDependenyResult();
     }
 
     // This constructor is used during live rejoin log replay.
@@ -105,7 +104,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
         for (int frag = 0; frag < m_fragmentMsg.getFragmentCount(); frag++) {
             final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
             response.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                    m_rawDummyResponse, 0, m_rawDummyResponse.length));
+                    RAW_DUMMY_RESPONSE, 0, RAW_DUMMY_RESPONSE.length));
         }
         response.setRespBufferable(m_respBufferable);
         m_initiator.deliver(response);
@@ -283,7 +282,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
             // Make sure the response has at least 1 result with a valid DependencyId
             response.addDependency(new
                     DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                            m_rawDummyResult, 0, m_rawDummyResult.length));
+                            RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
         }
     }
 

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -21,9 +21,10 @@ import org.voltcore.logging.VoltLogger;
 import org.voltdb.SiteProcedureConnection;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
+import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.dtxn.TransactionState;
+import org.voltdb.utils.VoltTableUtil;
 
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 
@@ -31,12 +32,14 @@ public abstract class TransactionTask extends SiteTasker
 {
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
-
-    protected static final byte[] m_rawDummyResult;
+    public static VoltTable DUMMAY_RESULT_TABLE;
+    protected static final byte[] RAW_DUMMY_RESULT;
 
     static {
         VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
-        m_rawDummyResult = dummyResult.buildReusableDependenyResult();
+        dummyResult.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
+        RAW_DUMMY_RESULT = dummyResult.buildReusableDependenyResult();
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));;
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -39,7 +39,7 @@ public abstract class TransactionTask extends SiteTasker
         VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
         dummyResult.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
         RAW_DUMMY_RESULT = dummyResult.buildReusableDependenyResult();
-        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));;
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/utils/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTableUtil.java
@@ -59,6 +59,7 @@ public class VoltTableUtil {
     // VoltTable status code to indicate null dependency table. Joining SPI replies to fragment
     // task messages with this.
     public static byte NULL_DEPENDENCY_STATUS = -1;
+    public static byte DUMMY_DEPENDENCY_STATUS = -2;
 
     private static final ThreadLocal<SimpleDateFormat> m_sdf = new ThreadLocal<SimpleDateFormat>() {
         @Override


### PR DESCRIPTION
When transactions hits failure on executing fragments, a dummy response is added to its dependency. A partition leader could receive various responses. A successful response has dependency tables with one schema while a failed response has dependency tables with another schema. When a transaction tries to combine the responses, schema mismatch will be encountered, which will crash cluster.