### PR TITLE
ENG-19523 prevent cluster from crash caused heterogeneous responses f…

### DIFF
--- a/src/frontend/org/voltdb/iv2/FragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/FragmentTask.java
@@ -390,7 +390,7 @@ public class FragmentTask extends FragmentTaskBase
                     if (currentFragResponse.getTableCount() == 0) {
                         // Make sure the response has at least 1 result with a valid DependencyId
                         currentFragResponse.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                                m_rawDummyResult, 0, m_rawDummyResult.length));
+                                RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                     }
                     exceptionThrown = true;
                 }

--- a/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
+++ b/src/frontend/org/voltdb/iv2/SysProcDuplicateCounter.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.voltcore.messaging.TransactionInfoBaseMessage;
 import org.voltdb.DependencyPair;
@@ -114,8 +115,14 @@ public class SysProcDuplicateCounter extends DuplicateCounter
             new FragmentResponseMessage((FragmentResponseMessage)m_lastResponse);
         // union up all the deps we've collected and jam them in
         for (Entry<Integer, List<VoltTable>> dep : m_alldeps.entrySet()) {
-            VoltTable grouped = VoltTableUtil.unionTables(dep.getValue());
-            unioned.addDependency(new DependencyPair.TableDependencyPair(dep.getKey(), grouped));
+            List<VoltTable> depTables = dep.getValue().stream().filter(
+                    x -> x.getStatusCode() != VoltTableUtil.DUMMY_DEPENDENCY_STATUS).collect(Collectors.toList());
+
+            if (depTables.isEmpty()){
+                unioned.addDependency(new DependencyPair.TableDependencyPair(dep.getKey(), TransactionTask.DUMMAY_RESULT_TABLE));
+            } else {
+                unioned.addDependency(new DependencyPair.TableDependencyPair(dep.getKey(), VoltTableUtil.unionTables(depTables)));
+            }
         }
         // we should never rollback DR buffer for MP sysprocs because we don't report the DR buffer size and therefore don't know if it is empty or not.
         unioned.setDrBufferSize(1);

--- a/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
+++ b/src/frontend/org/voltdb/iv2/SysprocFragmentTask.java
@@ -54,12 +54,12 @@ public class SysprocFragmentTask extends FragmentTaskBase
     final FragmentTaskMessage m_fragmentMsg;
     Map<Integer, List<VoltTable>> m_inputDeps;
     boolean m_respBufferable = true;
-    static final byte[] m_rawDummyResponse;
+    static final byte[] RAW_DUMMY_RESPONSE;
 
     static {
         VoltTable dummyResponse = new VoltTable(new ColumnInfo("STATUS", VoltType.TINYINT));
         dummyResponse.setStatusCode(VoltTableUtil.NULL_DEPENDENCY_STATUS);
-        m_rawDummyResponse = dummyResponse.buildReusableDependenyResult();
+        RAW_DUMMY_RESPONSE = dummyResponse.buildReusableDependenyResult();
     }
 
     // This constructor is used during live rejoin log replay.
@@ -106,7 +106,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
         for (int frag = 0; frag < m_fragmentMsg.getFragmentCount(); frag++) {
             final int outputDepId = m_fragmentMsg.getOutputDepId(frag);
             response.addDependency(new DependencyPair.BufferDependencyPair(outputDepId,
-                    m_rawDummyResponse, 0, m_rawDummyResponse.length));
+                    RAW_DUMMY_RESPONSE, 0, RAW_DUMMY_RESPONSE.length));
         }
         response.setRespBufferable(m_respBufferable);
         m_initiator.deliver(response);
@@ -255,7 +255,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     // Make sure the response has at least 1 result with a valid DependencyId
                     currentFragResponse.addDependency(new
                             DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
+                                    RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                 }
                 break;
             } catch (final SQLException e) {
@@ -266,7 +266,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     // Make sure the response has at least 1 result with a valid DependencyId
                     currentFragResponse.addDependency(new
                             DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
+                                    RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                 }
                 break;
             } catch (final ReplicatedTableException e) {
@@ -277,7 +277,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     // Make sure the response has at least 1 result with a valid DependencyId
                     currentFragResponse.addDependency(new
                             DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
+                                    RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                 }
                 break;
             }
@@ -295,7 +295,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     // Make sure the response has at least 1 result with a valid DependencyId
                     currentFragResponse.addDependency(new
                             DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
+                                    RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                 }
             }
             catch (final VoltAbortException e) {
@@ -306,7 +306,7 @@ public class SysprocFragmentTask extends FragmentTaskBase
                     // Make sure the response has at least 1 result with a valid DependencyId
                     currentFragResponse.addDependency(new
                             DependencyPair.BufferDependencyPair(m_fragmentMsg.getOutputDepId(0),
-                                    m_rawDummyResult, 0, m_rawDummyResult.length));
+                                    RAW_DUMMY_RESULT, 0, RAW_DUMMY_RESULT.length));
                 }
                 break;
             }

--- a/src/frontend/org/voltdb/iv2/TransactionTask.java
+++ b/src/frontend/org/voltdb/iv2/TransactionTask.java
@@ -24,6 +24,7 @@ import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.dtxn.TransactionState;
+import org.voltdb.utils.VoltTableUtil;
 
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 
@@ -31,12 +32,14 @@ public abstract class TransactionTask extends SiteTasker
 {
     protected static final VoltLogger execLog = new VoltLogger("EXEC");
     protected static final VoltLogger hostLog = new VoltLogger("HOST");
-
-    protected static final byte[] m_rawDummyResult;
+    public static VoltTable DUMMAY_RESULT_TABLE;
+    protected static final byte[] RAW_DUMMY_RESULT;
 
     static {
         VoltTable dummyResult = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
-        m_rawDummyResult = dummyResult.buildReusableDependenyResult();
+        dummyResult.setStatusCode(VoltTableUtil.DUMMY_DEPENDENCY_STATUS);
+        RAW_DUMMY_RESULT = dummyResult.buildReusableDependenyResult();
+        DUMMAY_RESULT_TABLE = new VoltTable(new ColumnInfo("UNUSED", VoltType.INTEGER));
     }
 
     final protected TransactionState m_txnState;

--- a/src/frontend/org/voltdb/utils/VoltTableUtil.java
+++ b/src/frontend/org/voltdb/utils/VoltTableUtil.java
@@ -59,7 +59,7 @@ public class VoltTableUtil {
     // VoltTable status code to indicate null dependency table. Joining SPI replies to fragment
     // task messages with this.
     public static byte NULL_DEPENDENCY_STATUS = -1;
-
+    public static byte DUMMY_DEPENDENCY_STATUS = -2;
     private static final ThreadLocal<SimpleDateFormat> m_sdf = new ThreadLocal<SimpleDateFormat>() {
         @Override
         public SimpleDateFormat initialValue() {


### PR DESCRIPTION
…rom replicas. When transactions hits failure on executing fragments, a dummy response is added to its dependency. A partition leader could receive various responses. A successful response has dependency tables with one schema while a failed response has dependency tables with another schema. When a transaction tries to combine the responses, schema mismatch will be encountered, which will crash cluster.