### PR TITLE
Backport: Add support for gcc 8 and 9 and simplify version handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,9 +317,8 @@ ExternalProject_Add(crypto
   DOWNLOAD_DIR ${VOLTDB_OPENSSL_BUILD_PREFIX}/src
   URL ${VOLTDB_OPENSSL_TARBALL}
   CONFIGURE_COMMAND ${VOLTDB_OPENSSL_SRC}/Configure --prefix=${VOLTDB_3PTY_INSTALL_PREFIX} ${VOLTDB_OPENSSL_TOKEN}
-  BUILD_COMMAND $(MAKE)
   BUILD_IN_SOURCE 1
-  INSTALL_COMMAND $(MAKE) install
+  INSTALL_COMMAND make install_sw
   )
 ExternalProject_get_property(crypto INSTALL_DIR)
 SET(VOLTDB_CRYPTO_INSTALL_DIR ${INSTALL_DIR})
@@ -362,8 +361,6 @@ ExternalProject_Add(pcre2
   DOWNLOAD_DIR ${VOLTDB_PCRE2_BUILD_PREFIX}/src
   URL ${VOLTDB_PCRE2_TARBALL}
   CONFIGURE_COMMAND ${VOLTDB_PCRE2_SRC}/configure --disable-shared --with-pic --prefix=${VOLTDB_3PTY_INSTALL_PREFIX}
-  BUILD_COMMAND $(MAKE)
-  INSTALL_COMMAND $(MAKE) install
   )
 
 ########################################################################
@@ -395,8 +392,6 @@ ExternalProject_Add(s2geo
   BINARY_DIR ${VOLTDB_S2GEO_OBJ}
   CMAKE_ARGS ${VOLTDB_S2GEO_CMAKE_CONFIG}
   CMAKE_GENERATOR ${CMAKE_GENERATOR}
-  BUILD_COMMAND $(MAKE) all
-  INSTALL_COMMAND $(MAKE) install
   )
 ADD_DEPENDENCIES(s2geo crypto)
 ########################################################################

--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -234,7 +234,12 @@ class NValue {
     /* Create a default NValue */
     NValue();
 
-        // todo: free() should not really be const
+    // todo: free() should not really be const
+
+    bool operator==(NValue const& rhs) const;
+    bool operator!=(NValue const& rhs) const {
+        return ! operator==(rhs);
+    }
 
     /* Release memory associated to object type NValues */
     void free() const;

--- a/src/ee/executors/OptimizedProjector.cpp
+++ b/src/ee/executors/OptimizedProjector.cpp
@@ -187,7 +187,7 @@ private:
 // for ordering: fields in source tuple may be referenced more
 // than once, or projection expression may not be a TVE.
 struct StepComparator {
-    bool operator() (const ProjectStep& lhs, const ProjectStep& rhs) {
+    bool operator() (const ProjectStep& lhs, const ProjectStep& rhs) const {
         return lhs.dstFieldIndex() < rhs.dstFieldIndex();
     }
 };

--- a/src/ee/storage/CopyOnWriteContext.cpp
+++ b/src/ee/storage/CopyOnWriteContext.cpp
@@ -213,8 +213,8 @@ int64_t CopyOnWriteContext::handleStreamMore(TupleOutputStreamProcessor &outputS
             size_t pendingLoadCnt = m_surgeon.getSnapshotPendingLoadBlockCount();
             if (m_tuplesRemaining > 0 || allPendingCnt > 0 || pendingLoadCnt > 0) {
 
-                char message[1024 * 16];
-                snprintf(message, 1024 * 16,
+                char message[1024 * 8];
+                snprintf(message, sizeof(message),
                          "serializeMore(): tuple count > 0 after streaming:\n"
                          "Table name: %s\n"
                          "Table type: %s\n"

--- a/src/ee/storage/ElasticIndex.h
+++ b/src/ee/storage/ElasticIndex.h
@@ -204,11 +204,6 @@ public:
     ElasticIndexHashRange();
 
     /**
-     * Copy constructor.
-     */
-    ElasticIndexHashRange(const ElasticIndexHashRange &other);
-
-    /**
      * From hash accessor.
      */
     ElasticHash getLowerBound() const;
@@ -506,13 +501,6 @@ inline ElasticIndexHashRange::ElasticIndexHashRange(ElasticHash from, ElasticHas
 inline ElasticIndexHashRange::ElasticIndexHashRange() :
     // min->min covers all possible values, min->max would not.
     m_from(std::numeric_limits<int32_t>::min()), m_to(std::numeric_limits<int32_t>::max())
-{}
-
-/**
- * Copy constructor.
- */
-inline ElasticIndexHashRange::ElasticIndexHashRange(const ElasticIndexHashRange &other) :
-    m_from(other.m_from), m_to(other.m_to)
 {}
 
 /**

--- a/src/ee/storage/ElasticIndexReadContext.cpp
+++ b/src/ee/storage/ElasticIndexReadContext.cpp
@@ -209,7 +209,7 @@ bool ElasticIndexReadContext::parseHashRange(
                                                  boost::lexical_cast<int32_t>(rangeStrings[1]));
                 success = true;
             }
-            catch(boost::bad_lexical_cast) {
+            catch(const boost::bad_lexical_cast &) {
                 char errMsg[1024 * 16];
                 snprintf(errMsg, 1024 * 16,
                          "Unable to parse ElasticIndexReadContext predicate \"%s\".",

--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -141,7 +141,6 @@ bool TableCatalogDelegate::getIndexScheme(catalog::Table const& catalogTable,
                                           TupleSchema const* schema,
                                           TableIndexScheme* scheme) {
     std::vector<int> index_columns;
-    std::vector<ValueType> column_types;
 
     // The catalog::Index object now has a list of columns that are to be
     // used

--- a/src/ee/structures/CompactingHashTable.h
+++ b/src/ee/structures/CompactingHashTable.h
@@ -139,7 +139,6 @@ namespace voltdb {
 
         public:
             iterator() : m_node(NULL) {}
-            iterator(const iterator &iter) : m_node(iter.m_node) {}
 
             Key &key() const { return m_node->key; }
             Data &value() const { return m_node->value; }

--- a/src/ee/structures/CompactingMap.h
+++ b/src/ee/structures/CompactingMap.h
@@ -177,7 +177,6 @@ public:
         const KeyValuePair &pair() { return m_node->kv; }
     public:
         iterator() : m_map(NULL), m_node(NULL) {}
-        iterator(const iterator &iter) : m_map(iter.m_map), m_node(iter.m_node) {}
         const Key &key() const { return m_node->key(); }
         const Data &value() const { return m_node->value(); }
         void setValue(const Data &value) { m_node->kv.setValue(value); }

--- a/tools/VoltDBCompilation.cmake
+++ b/tools/VoltDBCompilation.cmake
@@ -103,42 +103,18 @@ SET (VOLTDB_LINK_FLAGS ${VOLTDB_LINK_FLAGS} ${VOLTDB_LDFLAGS})
 # for each of them. These are the versions of gcc and cmake for
 # each version of Linux we support.
 # OS Ver.        gcc vers     cmake ver.   Clang version
-# Centos6:          4.4.7     2.8.12.2
-# Ubuntu 10.04      N.A.      N.A.
-# Ubuntu 10.10      N.A.      N.A.
-# Ubuntu 12.04      4.6.3     2.8.7
-# Ubuntu 12.10      N.A.      N.A.
 # Ubuntu 14.04      4.8.4     2.8.12.2
 # Centos7:          4.8.5     2.8.12.2
-# Ubuntu 14.10      N.A.      N.A.
-# Ubuntu 15.04      4.9.2     3.0.2
-# Ubunty 15.10      5.2.1     3.2.2
 # Ubuntu 16.04      5.4.0     3.5.1
-# Ubuntu 16.10      6.2.0     3.5.2
-# Ubuntu 17.04      6.3.0     3.7.2
-# Ubuntu 17.10      7.2.0     3.9.1
+# Ubuntu 18.04      7.3.0     3.10.2
+# Centos8:          7.6.4     3.11.4
 #
 # We should have a similar table for the mac, but apparently we
 # don't.  We do have some empirical evidence that some configurations
 # will build and run correctly.
 #
 ########################################################################
-SET (VOLTDB_COMPILER_U18p04 "7.3.0")
-SET (VOLTDB_COMPILER_U17p10 "7.2.0")
-SET (VOLTDB_COMPILER_U17p04 "6.3.0")
-SET (VOLTDB_COMPILER_U16p10 "6.2.0")
-SET (VOLTDB_COMPILER_U16p04 "5.4.0")
-SET (VOLTDB_COMPILER_U15p10 "5.2.1")
-SET (VOLTDB_COMPILER_U15p04 "4.9.2")
 SET (VOLTDB_COMPILER_U14p04 "4.8.4")
-SET (VOLTDB_COMPILER_C7     "4.8.5")
-SET (VOLTDB_COMPILER_12p04  "4.6.3")
-SET (VOLTDB_COMPILER_C6     "4.4.7")
-SET (VOLTDB_COMPILER_OLDE   "4.4.0")
-#
-# Note: Update this when adding a new compiler support.
-#
-SET (VOLTDB_COMPILER_NEWEST ${VOLTDB_COMPILER_U18p04})
 #
 #
 #
@@ -146,62 +122,29 @@ MESSAGE("Using compiler ${CMAKE_CXX_COMPILER_ID}")
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   SET (VOLTDB_LINK_FLAGS ${VOLTDB_LINK_FLAGS} -pthread)
   SET (VOLTDB_IPC_LINK_FLAGS ${VOLTDB_LIB_LINK_FLAGS} -rdynamic)
-  VOLTDB_ADD_COMPILE_OPTIONS(-pthread -Wno-deprecated-declarations  -Wno-unknown-pragmas)
-  # It turns out to be easier to go from a higher version to a lower
-  # version, since we can't easily test <= and >=.
-  IF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_NEWEST )
-    # COMPILER_VERSION > 7.3.0
-    MESSAGE ("GCC Version ${CMAKE_CXX_COMPILER_VERSION} is not verified for building VoltDB.")
-    MESSAGE ("We're using the options for ${CMAKE_COMPILER_NEWEST}, which is the newest one we've tried.  Good Luck.")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds)
+  VOLTDB_ADD_COMPILE_OPTIONS(-pthread -Wno-deprecated-declarations  -Wno-unknown-pragmas -Wno-unused-local-typedefs)
+
+  # Some supported versions of cmake do not support VERSION_GREATER_EQUAL so use NOT ... VERSION_LESS
+  IF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS VOLTDB_COMPILER_U14p04)
+    message(FATAL_ERROR "GNU Compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old to build VoltdB.  Try at least ${VOLTDB_COMPILER_U14p04}.")
+  ELSEIF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5")
+    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-but-set-variable -Wno-float-conversion -Wno-conversion)
     SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U17p10 )
-    # 7.2.0 < COMPILER_VERSION <= 7.3.0
-    MESSAGE("Using the Ubuntu 17.10 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds)
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U17p04 )
-    # < 6.3.0 COMPILER_VERSION <= 7.2.0
-    MESSAGE("Using the Ubuntu 17.10 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds)
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U16p10)
-    # 6.2.0 < COMPILER_VERSION and COMPILER_VERSION <= 6.3.0
-    MESSAGE("Using the Ubuntu 17.04 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs)
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U16p04 )
-    # 5.4.0 < COMPILER_VERSION and COMPILER_VERSION <= 6.2.0
-    MESSAGE("Using the Ubuntu 16.10 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-local-typedefs -Wno-array-bounds)
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U15p10 )
-    # 5.2.1 < COMPILER_VERSION and COMPILER_VERSION <= 5.4.0
-    MESSAGE("Using the Ubuntu 16.04 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS( -Wno-unused-local-typedefs )
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U15p04  )
-    # 4.9.2 < COMPILER_VERSION and COMPILER_VERSION <= 5.2.1
-    MESSAGE("Using the Ubuntu 15.10 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS( -Wno-unused-local-typedefs )
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_U14p04 )
-    # 4.8.4 < COMPILER_VERSION and COMPILER_VERSION <= 4.9.2
-    # Note that U14.04 and C7 are different versions, but equivalent
-    # for our needs here.
-    # Nothing special added to the compile flags.
-    MESSAGE("Using the Ubuntu 15.04 compiler settings for gcc ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-but-set-variable -Wno-unused-local-typedefs -Wno-float-conversion -Wno-conversion)
-    SET (CXX_VERSION_FLAG -std=c++11)
-  ELSEIF ( CMAKE_CXX_COMPILER_VERSION VERSION_GREATER VOLTDB_COMPILER_CXX0X)
-    # 4.6.0 < COMPILER_VERSION and COMPILER_VERSION <= 4.8.4
-    # Use -std=c++0x.  This is in GCC's experimental C++11 compiler
-    # support version, which is sufficient for our use.
-    MESSAGE("Using the Centos 6 settings for ${CMAKE_CXX_COMPILER_VERSION}")
-    VOLTDB_ADD_COMPILE_OPTIONS(-Wno-unused-but-set-variable -Wno-unused-local-typedefs -Wno-float-conversion -Wno-conversion)
-    SET (CXX_VERSION_FLAG -std=c++0x)
   ELSE()
-    message(FATAL_ERROR "GNU Compiler version ${CMAKE_CXX_COMPILER_VERSION} is too old to build VoltdB.  Try at least ${VOLTDB_COMPILER_CXX0X}.")
+    SET (CXX_VERSION_FLAG -std=c++14)
+
+    IF (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6")
+      VOLTDB_ADD_COMPILE_OPTIONS(-Wno-array-bounds)
+
+      IF (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "7")
+        SET (CXX_VERSION_FLAG -std=c++17)
+
+        IF (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8")
+          MESSAGE ("GCC Version ${CMAKE_CXX_COMPILER_VERSION} is not verified for building VoltDB.")
+          VOLTDB_ADD_COMPILE_OPTIONS(-Wno-error=class-memaccess -Wno-parentheses -Wno-deprecated-copy)
+        ENDIF()
+      ENDIF()
+    ENDIF()
   ENDIF()
 ELSEIF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # All versions of clang use C++11.


### PR DESCRIPTION
Instead of using OS releases as the boundries for compiler options use the
major version of gcc to determine which options are appropriate for that
compiler.

A few classes defined either a copy constructor or assignment opperator but not
both. With newer versions of gcc that causes a warning. In all of those
locations the custom implementation was not necessary so it was removed to
allow the default implementations to be used.