### PR TITLE
ENG-19502: Backport: Reset throughput on initialization

### DIFF
--- a/src/frontend/org/voltdb/join/BalancePartitionsStatistics.java
+++ b/src/frontend/org/voltdb/join/BalancePartitionsStatistics.java
@@ -78,6 +78,7 @@ public class BalancePartitionsStatistics extends StatsSource {
         this.totalRangeSize = totalRangeSize;
         this.lastReportTime = overallStats.getStartTimeNanos();
         this.lastBalanceDuration = 0;
+        this.throughput = 0;
 
         startInterval();
 


### PR DESCRIPTION
[ backport 7b66e37b109101b15e0a1197a69b5ac12a00666e ]

Throughput is used to calculate sleep between rebalance calls. When it
is not reset it can accumulate between runs forcing future elastic
operaitons to slow down.