### PR TITLE
ENG-19509: Backport: On rejoin always monitor snapshot

### DIFF
--- a/src/frontend/org/voltdb/iv2/RejoinProducer.java
+++ b/src/frontend/org/voltdb/iv2/RejoinProducer.java
@@ -320,8 +320,6 @@ public class RejoinProducer extends JoinProducerBase {
         }
         else {
             doFinishingTask(siteConnection);
-            // Remove the completion monitor for an empty (zero table) rejoin.
-            m_snapshotCompletionMonitor.set(null);
         }
     }
 
@@ -360,18 +358,16 @@ public class RejoinProducer extends JoinProducerBase {
                 long clusterCreateTime = -1;
                 try {
                     event = m_snapshotCompletionMonitor.get();
-                    if (!m_schemaHasNoTables) {
-                        REJOINLOG.debug(m_whoami + "waiting on snapshot completion monitor.");
-                        exportSequenceNumbers = event.exportSequenceNumbers;
-                        m_completionAction.setSnapshotTxnId(event.multipartTxnId);
+                    REJOINLOG.debug(m_whoami + " waiting on snapshot completion monitor.");
+                    exportSequenceNumbers = event.exportSequenceNumbers;
+                    m_completionAction.setSnapshotTxnId(event.multipartTxnId);
 
-                        drSequenceNumbers = event.drSequenceNumbers;
-                        allConsumerSiteTrackers = event.drMixedClusterSizeConsumerState;
-                        clusterCreateTime = event.clusterCreateTime;
+                    drSequenceNumbers = event.drSequenceNumbers;
+                    allConsumerSiteTrackers = event.drMixedClusterSizeConsumerState;
+                    clusterCreateTime = event.clusterCreateTime;
 
-                        // Tells EE which DR version going to use
-                        siteConnection.setDRProtocolVersion(event.drVersion);
-                    }
+                    // Tells EE which DR version going to use
+                    siteConnection.setDRProtocolVersion(event.drVersion);
 
                     REJOINLOG.debug(m_whoami + " monitor completed. Sending SNAPSHOT_FINISHED "
                             + "and handing off to site.");

--- a/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
+++ b/src/frontend/org/voltdb/rejoin/Iv2RejoinCoordinator.java
@@ -245,9 +245,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
         }
     }
 
-    private void onSiteInitialized(long HSId, long masterHSId, long dataSinkHSId,
-                                   boolean schemaHasNoTables)
-    {
+    private void onSiteInitialized(long HSId, long masterHSId, long dataSinkHSId) {
         String nonce = null;
         String data = null;
         synchronized(m_lock) {
@@ -273,7 +271,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             throw new RuntimeException("Received an INITIATION_RESPONSE for an HSID for which no nonce exists: " +
                     CoreUtils.hsIdToString(HSId));
         }
-        if (data != null && !schemaHasNoTables) {
+        if (data != null) {
             REJOINLOG.debug("Snapshot request: " + data);
             SnapshotUtil.requestSnapshot(0l, "", nonce, !m_liveRejoin, SnapshotFormat.STREAM, SnapshotPathType.SNAP_NO_PATH, data,
                     SnapshotUtil.fatalSnapshotResponseHandler, true);
@@ -297,8 +295,7 @@ public class Iv2RejoinCoordinator extends JoinCoordinator {
             assert(m_catalog != null);
             onReplayFinished(rm.m_sourceHSId);
         } else if (type == RejoinMessage.Type.INITIATION_RESPONSE) {
-            onSiteInitialized(rm.m_sourceHSId, rm.getMasterHSId(), rm.getSnapshotSinkHSId(),
-                              rm.schemaHasNoTables());
+            onSiteInitialized(rm.m_sourceHSId, rm.getMasterHSId(), rm.getSnapshotSinkHSId());
         } else {
             VoltDB.crashLocalVoltDB("Wrong rejoin message of type " + type +
                                     " sent to the rejoin coordinator", false, null);


### PR DESCRIPTION
[ backport 7a772a3035f25a150518ae0fdb089f5deca7766e ]

On rejoin without any persistent tables the snapshot completion event was
not being processed. When the system does not have persistent tables
only skip waiting for streams from other hosts but not processing the
snapshot completion.

Update rejoin with only stream tests to confirm that the sequence id
continues to increase.