### PR TITLE
ENG-19497: Backport: Guarantee that catalog update happens after quiesce

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -63,9 +63,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -351,11 +353,12 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     // Synchronize initialize and shutdown
     private final Object m_startAndStopLock = new Object();
 
-    // Synchronize updates of catalog contexts across the multiple sites on this host.
-    // Ensure that the first site to reach catalogUpdate() does all the work and that no
-    // others enter until that's finished.  CatalogContext is immutable and volatile, accessors
-    // should be able to always get a valid context without needing this lock.
-    private final Object m_catalogUpdateLock = new Object();
+    /*
+     * Synchronize updates of catalog contexts across the multiple sites on this host. Ensure that catalogUpdate() is
+     * only performed after all sites reach catalogUpdate(). Once all sites have reached this point the first site to
+     * execute will perform the actual update while the others wait.
+     */
+    private final UpdateBarrier m_catalogUpdateBarrier = new UpdateBarrier();
 
     // add a random number to the sampler output to make it likely to be unique for this process.
     private final VoltSampler m_sampler = new VoltSampler(10, "sample" + String.valueOf(new Random().nextInt() % 10000) + ".txt");
@@ -920,6 +923,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             }
 
             ReadDeploymentResults readDepl = readPrimedDeployment(config);
+            m_catalogUpdateBarrier.setPartyCount(m_nodeSettings.getLocalSitesCount());
 
             if (config.m_startAction == StartAction.INITIALIZE) {
                 if (config.m_forceVoltdbCreate && m_nodeSettings.clean()) {
@@ -3767,7 +3771,9 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             boolean hasSecurityUserChange)
     {
         try {
-            synchronized(m_catalogUpdateLock) {
+            m_catalogUpdateBarrier.await();
+
+            synchronized (m_catalogUpdateBarrier) {
                 final ReplicationRole oldRole = getReplicationRole();
 
                 m_statusTracker.set(NodeState.UPDATING);
@@ -3940,6 +3946,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
                 return m_catalogContext;
             }
+        } catch (InterruptedException | BrokenBarrierException e) {
+            throw VoltDB.crashLocalVoltDB("Error waiting for barrier", true, e);
         } finally {
             //Set state back to UP
             m_statusTracker.set(NodeState.UP);
@@ -3950,7 +3958,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public CatalogContext settingsUpdate(
             ClusterSettings settings, final int expectedVersionId)
     {
-        synchronized(m_catalogUpdateLock) {
+        synchronized (m_catalogUpdateBarrier) {
             int stamp [] = new int[]{0};
             ClusterSettings expect = m_clusterSettings.get(stamp);
             if (   stamp[0] == expectedVersionId
@@ -5060,6 +5068,27 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
 
     public Initiator getInitiator(int partition) {
         return m_iv2Initiators.get(partition);
+    }
+
+    /**
+     * Small wrapper class around a {@link CyclicBarrier}. This is used so that operations can synchronize on this
+     * instance and still be able to change the participant count in the barrier
+     */
+    private static final class UpdateBarrier {
+        private CyclicBarrier m_barrier;
+
+        UpdateBarrier() {}
+
+        synchronized void setPartyCount(int parties) {
+            if (m_barrier != null && m_barrier.getNumberWaiting() != 0) {
+                throw new IllegalStateException("Cannot change participant count while parties are waiting");
+            }
+            m_barrier = new CyclicBarrier(parties);
+        }
+
+        void await() throws InterruptedException, BrokenBarrierException {
+            m_barrier.await();
+        }
     }
 }
 

--- a/src/frontend/org/voltdb/VoltDB.java
+++ b/src/frontend/org/voltdb/VoltDB.java
@@ -1197,8 +1197,8 @@ public class VoltDB {
         }
     }
 
-    public static void crashLocalVoltDB(String errMsg) {
-        crashLocalVoltDB(errMsg, false, null);
+    public static RuntimeException crashLocalVoltDB(String errMsg) {
+        return crashLocalVoltDB(errMsg, false, null);
     }
 
     /**
@@ -1244,13 +1244,14 @@ public class VoltDB {
     /**
      * Exit the process with an error message, optionally with a stack trace.
      */
-    public static void crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown) {
-        crashLocalVoltDB(errMsg, stackTrace, thrown, true);
+    public static RuntimeException crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown) {
+        return crashLocalVoltDB(errMsg, stackTrace, thrown, true);
     }
     /**
      * Exit the process with an error message, optionally with a stack trace.
      */
-    public static void crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown, boolean logFatal) {
+    public static RuntimeException crashLocalVoltDB(String errMsg, boolean stackTrace, Throwable thrown,
+            boolean logFatal) {
 
         if (exitAfterMessage) {
             System.err.println(errMsg);
@@ -1290,7 +1291,7 @@ public class VoltDB {
                 // turn off client interface as fast as possible
                 // we don't expect this to ever fail, but if it does, skip to dying immediately
                 if (!turnOffClientInterface()) {
-                    return; // this will jump to the finally block and die faster
+                    return null; // this will jump to the finally block and die faster
                 }
 
                 // Flush trace files
@@ -1389,6 +1390,7 @@ public class VoltDB {
             ShutdownHooks.useOnlyCrashHooks();
             System.exit(-1);
         }
+        return null;
     }
 
     /*

--- a/src/frontend/org/voltdb/exportclient/ExportRow.java
+++ b/src/frontend/org/voltdb/exportclient/ExportRow.java
@@ -104,15 +104,22 @@ public class ExportRow {
      * @throws IOException
      */
     public static ExportRow decodeRow(ExportRow previous, int partition, long startTS, ByteBuffer bb) throws IOException {
-        final int partitionColIndex = bb.getInt();
-        final int columnCount = bb.getInt();
-        assert(columnCount <= DDLCompiler.MAX_COLUMNS);
-        boolean[] is_null = extractNullFlags(bb, columnCount);
-
-        assert(previous != null);
+        assert (previous != null);
         if (previous == null) {
             throw new IOException("Export block with no schema found without prior block with schema.");
         }
+
+        final int partitionColIndex = bb.getInt();
+        final int columnCount = bb.getInt();
+        assert(columnCount <= DDLCompiler.MAX_COLUMNS);
+        if (columnCount != previous.names.size()) {
+            throw new IOException(
+                    String.format("Read %d columns from row but expected %d columns: %s", columnCount,
+                            previous.names.size(), previous));
+        }
+
+        boolean[] is_null = extractNullFlags(bb, columnCount);
+
         final long generation = previous.generation;
         final String tableName = previous.tableName;
         final List<String> colNames = previous.names;


### PR DESCRIPTION
[ backport cd496ad ]

Catalog update is an MP procedure which occurs concurrently on all
hosts. The order of operations is all sites call quiesce and then
RealVoltDB.updateCatalog(). The first site on each host to call
updateCatalog() performs the actual work. This can be an issue because
the other sites on the host might still be performing the quiesce. When
this happens the schema can be updated in export and DR before the
buffers with the data from the previous schema are processed.

This results in the new schema being attached to the old rows.