### PR TITLE
ENG-19500: Backport: Add a way to stop an ack receiver

### DIFF
--- a/src/frontend/org/voltcore/utils/Pair.java
+++ b/src/frontend/org/voltcore/utils/Pair.java
@@ -17,6 +17,8 @@
 
 package org.voltcore.utils;
 
+import java.util.Objects;
+
 /**
  * Class representing a pair of generic-ized types. Supports equality, hashing
  * and all that other nice Java stuff. Based on STL's pair class in C++.
@@ -44,17 +46,22 @@ public class Pair<T, U> implements java.io.Serializable {
         this(first, second, true);
     }
 
+    @Override
     public String toString() {
-        return "<" + m_first.toString() + ", " + m_second.toString() + ">";
+        return "<" + m_first + ", " + m_second + ">";
     }
 
+    @Override
     public int hashCode() {
         return m_hash;
     }
 
     public Object get(int idx) {
-        if (idx == 0) return m_first;
-        else if (idx == 1) return m_second;
+        if (idx == 0) {
+            return m_first;
+        } else if (idx == 1) {
+            return m_second;
+        }
         return null;
     }
 
@@ -63,12 +70,10 @@ public class Pair<T, U> implements java.io.Serializable {
      * @return Is the object equal to a value in the pair.
      */
     public boolean contains(Object o) {
-        if ((m_first != null) && (m_first.equals(o))) return true;
-        if ((m_second != null) && (m_second.equals(o))) return true;
-        if (o != null) return false;
-        return ((m_first == null) || (m_second == null));
+        return Objects.equals(o, m_first) || Objects.equals(o, m_second);
     }
 
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -46,6 +46,7 @@ import org.voltdb.VoltDB;
 import org.voltdb.utils.CompressionService;
 
 import com.google_voltpatches.common.base.Preconditions;
+import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.primitives.Longs;
 import com.google_voltpatches.common.util.concurrent.Futures;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
@@ -84,7 +85,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     private final StreamSnapshotAckReceiver m_ackReceiver;
 
     // Skip all subsequent writes if one fails
-    private final AtomicReference<IOException> m_writeFailed = new AtomicReference<IOException>();
+    private final AtomicReference<Exception> m_writeFailed = new AtomicReference<>();
     // true if the failure is already reported to the SnapshotSiteProcessor, prevent throwing
     // the same exception multiple times.
     private boolean m_failureReported = false;
@@ -414,6 +415,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         }
     }
 
+    @Override
+    public synchronized void receiveError(Exception exception) {
+        setWriteFailed(exception);
+    }
+
     /**
      * Thread that runs send work (sending snapshot blocks). One per node
      */
@@ -677,8 +683,10 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         }
         // If there was an error during close(), throw it so that the snapshot
         // can be marked as failed.
-        if (m_writeFailed.get() != null) {
-            throw m_writeFailed.get();
+        Exception e = m_writeFailed.get();
+        if (e != null) {
+            Throwables.propagateIfPossible(e, IOException.class);
+            throw new IOException(e);
         }
     }
 
@@ -742,10 +750,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         if (exception != null) {
             return exception;
         }
-        exception = m_ackReceiver.m_lastException;
-        if (exception != null) {
-            return exception;
-        }
+
         return m_writeFailed.get();
     }
 
@@ -771,6 +776,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     }
 
     private synchronized void setWriteFailed(Exception exception) {
+        m_ackReceiver.forceStop();
         if (m_writeFailed.compareAndSet(null, exception)) {
             notifyAll();
         }

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -358,7 +358,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                                         "Node rejoin may need to be retried",
                                 (now - work.m_ts) / 1000));
                 rejoinLog.error(exception.getMessage());
-                m_writeFailed.compareAndSet(null, exception);
+                setWriteFailed(exception);
             }
         }
     }
@@ -381,6 +381,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         }
         m_outstandingWork.clear();
         m_outstandingWorkCount.set(0);
+        notifyAll();
     }
 
     /**
@@ -401,7 +402,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         if (work.receiveAck()) {
             rejoinLog.trace("Received ack for targetId " + m_targetId +
                     " removes block for index " + String.valueOf(blockIndex));
-            m_outstandingWorkCount.decrementAndGet();
+            if (m_outstandingWorkCount.decrementAndGet() == 0) {
+                notifyAll();
+            }
             m_outstandingWork.remove(blockIndex);
             work.discard();
         }
@@ -547,7 +550,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                     chunkC.discard();
                     IOException e = new IOException("Trying to write snapshot data " +
                             "after the stream is closed");
-                    m_writeFailed.set(e);
+                    setWriteFailed(e);
                     return Futures.immediateFailedFuture(e);
                 }
 
@@ -605,9 +608,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
      */
     synchronized ListenableFuture<Boolean> send(StreamSnapshotMessageType type, int blockIndex, BBContainer chunk, boolean replicatedTable) {
         SettableFuture<Boolean> sendFuture = SettableFuture.create();
-        rejoinLog.trace("Sending block " + blockIndex + " of type " + (replicatedTable?"REPLICATED ":"PARTITIONED ") + type.name() +
-                " from targetId " + m_targetId + " to " + CoreUtils.hsIdToString(m_destHSId) +
-                (replicatedTable?", " + CoreUtils.hsIdCollectionToString(m_otherDestHostHSIds):""));
+        if (rejoinLog.isTraceEnabled()) {
+            rejoinLog.trace("Sending block " + blockIndex + " of type " + (replicatedTable?"REPLICATED ":"PARTITIONED ") + type.name() +
+                    " from targetId " + m_targetId + " to " + CoreUtils.hsIdToString(m_destHSId) +
+                    (replicatedTable?", " + CoreUtils.hsIdCollectionToString(m_otherDestHostHSIds):""));
+        }
         SendWork sendWork = new SendWork(type, m_targetId, m_destHSId,
                 replicatedTable?m_otherDestHostHSIds:null, chunk, sendFuture);
         m_outstandingWork.put(blockIndex, sendWork);
@@ -698,10 +703,18 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         waitForOutstandingWork();
     }
 
-    private void waitForOutstandingWork()
+    private synchronized void waitForOutstandingWork()
     {
+        boolean interrupted = false;
         while (m_writeFailed.get() == null && (m_outstandingWorkCount.get() > 0)) {
-            Thread.yield();
+            try {
+                wait();
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
 
         // if here because a write failed, cleanup outstanding work
@@ -755,5 +768,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         bb.getInt(); // skip first four (partition id)
 
         return bb.getInt();
+    }
+
+    private synchronized void setWriteFailed(Exception exception) {
+        if (m_writeFailed.compareAndSet(null, exception)) {
+            notifyAll();
+        }
     }
 }


### PR DESCRIPTION
[ backport 4ac1b68 ]

If a balance partitions starts but an error occurs and no EOS is
received the ack receiver keeps running. If balance partitions is
retried the previously running ack receiver could still be running which
means that it could intercept the messages and the retry will just
timeout. This will keep happening indefinently.

Add a mechanism to force stop the ack receiver. This stop is called by
StreamSnapshotDataTarget when it encounters a message or a timeout.
Also, add a way for the ack receiver to notify the data target if an
error is received so that everything can be shutdown faster instead of
waiting for the timeout.