### PR TITLE
ENG-13836: Detect nan in geography point

### DIFF
--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -46,13 +46,13 @@ public class GeographyPointValue {
     //   10. Some optional space.
     //   11. The end of the string.
     //
-    private static final Pattern wktPattern
-        = Pattern.compile("^\\s*point\\s*[(]\\s*([-]?\\d+)(?:[.](\\d*))?\\s+([-]?\\d+)(?:[.](\\d*))?\\s*[)]\\s*\\z",
-                          Pattern.CASE_INSENSITIVE);
+    private static final Pattern wktPattern = Pattern.compile(
+            "^\\s*point\\s*\\(\\s*(-?\\d+(?:\\.\\d*)?)?\\s+(-?\\d+(?:\\.\\d*)?)\\s*\\)\\s*\\z",
+            Pattern.CASE_INSENSITIVE);
     private final double m_latitude;
     private final double m_longitude;
 
-    private static final int BYTES_IN_A_COORD = Double.SIZE / 8;
+    private static final int BYTES_IN_A_COORD = Double.BYTES;
     static final double EPSILON = 1.0e-12;
 
     // We use this value to represent a null point.
@@ -81,9 +81,6 @@ public class GeographyPointValue {
         }
     }
 
-    private static double toDouble(String aInt, String aFrac) {
-        return Double.parseDouble(aInt + "." + (aFrac == null ? "0" : aFrac));
-    }
     /**
      * Create a GeographyPointValue from a well-known text string.
      * @param param  A well-known text string.
@@ -95,9 +92,8 @@ public class GeographyPointValue {
         }
         Matcher m = wktPattern.matcher(param);
         if (m.find()) {
-            // Add 0.0 to avoid -0.0.
-            double longitude = toDouble(m.group(1), m.group(2)) + 0.0;
-            double latitude  = toDouble(m.group(3), m.group(4)) + 0.0;
+            double longitude = Double.parseDouble(m.group(1));
+            double latitude = Double.parseDouble(m.group(2));
             return new GeographyPointValue(longitude, latitude);
         } else {
             throw new IllegalArgumentException("Cannot construct GeographyPointValue value from \"" + param + "\"");

--- a/src/frontend/org/voltdb/types/GeographyPointValue.java
+++ b/src/frontend/org/voltdb/types/GeographyPointValue.java
@@ -71,12 +71,13 @@ public class GeographyPointValue {
         m_latitude = latitude + 0.0;
         m_longitude = longitude + 0.0;
 
-        if (m_latitude < -90.0 || m_latitude > 90.0) {
-            throw new IllegalArgumentException("Latitude out of range in GeographyPointValue constructor");
+        // Use this style check to implicitly catch NaN values
+        if (!(m_latitude >= -90.0 && m_latitude <= 90.0)) {
+            throw new IllegalArgumentException("Latitude out of bounds: " + m_latitude);
         }
 
-        if (m_longitude < -180.0 || m_longitude > 180.0) {
-            throw new IllegalArgumentException("Longitude out of range in GeographyPointValue constructor");
+        if (!(m_longitude >= -180.0 && m_longitude <= 180.0)) {
+            throw new IllegalArgumentException("Longitude out of bounds: " + m_longitude);
         }
     }
 
@@ -97,12 +98,6 @@ public class GeographyPointValue {
             // Add 0.0 to avoid -0.0.
             double longitude = toDouble(m.group(1), m.group(2)) + 0.0;
             double latitude  = toDouble(m.group(3), m.group(4)) + 0.0;
-            if (Math.abs(latitude) > 90.0) {
-                throw new IllegalArgumentException(String.format("Latitude \"%f\" out of bounds.", latitude));
-            }
-            if (Math.abs(longitude) > 180.0) {
-                throw new IllegalArgumentException(String.format("Longitude \"%f\" out of bounds.", longitude));
-            }
             return new GeographyPointValue(longitude, latitude);
         } else {
             throw new IllegalArgumentException("Cannot construct GeographyPointValue value from \"" + param + "\"");

--- a/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
+++ b/tests/frontend/org/voltdb/types/TestGeographyPointValue.java
@@ -54,10 +54,12 @@ public class TestGeographyPointValue extends TestCase {
 
         // Make sure that it's not possible to create points
         // with bogus latitude or longitude.
-        assertConstructorThrows("Latitude out of range",   100,  -91.0);
-        assertConstructorThrows("Latitude out of range",   100,   91.0);
-        assertConstructorThrows("Longitude out of range",  181.0, 45.0);
-        assertConstructorThrows("Longitude out of range", -181.0, 45.0);
+        assertConstructorThrows("Latitude out of bounds", 100, -91.0);
+        assertConstructorThrows("Latitude out of bounds", 100, 91.0);
+        assertConstructorThrows("Latitude out of bounds", 100, Double.NaN);
+        assertConstructorThrows("Longitude out of bounds", 181.0, 45.0);
+        assertConstructorThrows("Longitude out of bounds", -181.0, 45.0);
+        assertConstructorThrows("Longitude out of bounds", Double.NaN, 45.0);
     }
 
     public void testPointEquals() {
@@ -203,24 +205,24 @@ public class TestGeographyPointValue extends TestCase {
         testOnePointFromFactory("  point  (-10.333   -20.666)    ",            -20.666,        -10.333,        EPSILON, null);
         testOnePointFromFactory("point(10 10)",                                 10.0,           10.0,          EPSILON, null);
         // Test latitude/longitude ranges.
-        testOnePointFromFactory("point( 100.0   100.0)", 100.0, 100.0, EPSILON, "Latitude \"100.0+\" out of bounds.");
-        testOnePointFromFactory("point( 360.0    45.0)", 360.0,  45.0, EPSILON, "Longitude \"360.0+\" out of bounds.");
-        testOnePointFromFactory("point( 270.0    45.0)", 360.0,  45.0, EPSILON, "Longitude \"270.0+\" out of bounds.");
+        testOnePointFromFactory("point( 100.0   100.0)", 100.0, 100.0, EPSILON, "Latitude out of bounds: 100.0");
+        testOnePointFromFactory("point( 360.0    45.0)", 360.0, 45.0, EPSILON, "Longitude out of bounds: 360.0");
+        testOnePointFromFactory("point( 270.0    45.0)", 360.0, 45.0, EPSILON, "Longitude out of bounds: 270.0");
         testOnePointFromFactory("point(-100.0  -100.0)",
                                 -100.0,
                                 -100.0,
                                 EPSILON,
-                                "Latitude \"-100.0+\" out of bounds.");
+                                "Latitude out of bounds: -100.0");
         testOnePointFromFactory("point(-360.0  -45.0)",
                                 -45.0,
                                 -360.0,
                                 EPSILON,
-                                "Longitude \"-360.0+\" out of bounds.");
+                                "Longitude out of bounds: -360.0");
         testOnePointFromFactory("point(-270.0  -45.0)",
                                 -45.0,
                                 -360.0,
                                 EPSILON,
-                                "Longitude \"-270.0+\" out of bounds.");
+                                "Longitude out of bounds: -270.0");
         // Syntax errors
         //   Comma separating the coordinates.
         testOnePointFromFactory("point(0.0, 0.0)",

--- a/tests/sqlcmd/baselines/geospatial/points.errbaseline
+++ b/tests/sqlcmd/baselines/geospatial/points.errbaseline
@@ -1,7 +1,7 @@
-Latitude "100.000000" out of bounds.
-Longitude "360.000000" out of bounds.
-Longitude "270.000000" out of bounds.
-Latitude "-100.000000" out of bounds.
-Longitude "-360.000000" out of bounds.
-Longitude "-270.000000" out of bounds.
+Latitude out of bounds: 100.0
+Longitude out of bounds: 360.0
+Longitude out of bounds: 270.0
+Latitude out of bounds: -100.0
+Longitude out of bounds: -360.0
+Longitude out of bounds: -270.0
 Cannot construct GeographyPointValue value from "point(0.0, 0.0)"


### PR DESCRIPTION
In the GeographyPointValue use a conditional check which will fail for
NaN values and throw an IllegalArgumentException.

Use one check in the constructor instead of one in the factory method
and also in the constructor.