### PR TITLE
ENG-15827:

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -52,7 +52,6 @@ public class VoltZK {
 
     public static final String buildstring = "/db/buildstring";
     public static final String catalogbytes = "/db/catalogbytes";
-    public static final String catalogbytesPrevious = "/db/catalogbytes_previous";
     //This node doesn't mean as much as it used to, it is accurate at startup
     //but isn't updated after elastic join. We use the cartographer for most things
     //now

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -126,7 +126,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
                 // Otherwise, deploymentString has the right contents, don't need to touch it
             }
             else if ("@UpdateClasses".equals(invocationName)) {
-                compilerLog.info("@UpdateClasses is invoked, modifying catalog classes.");
+                compilerLog.info("@UpdateClasses is invoked, modifying catalog classes. Current catalog version: " + context.catalogVersion);
                 // provided operationString is really a String with class patterns to delete,
                 // provided newCatalogJar is the jarfile with the new classes
                 if (operationBytes != null) {
@@ -542,20 +542,6 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         if (errMsg != null) {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             return makeQuickResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
-        }
-
-        // only copy the current catalog when @UpdateCore could fail
-        if (ccr.tablesThatMustBeEmpty.length != 0) {
-            try {
-                // read the current catalog bytes
-                byte[] data = zk.getData(VoltZK.catalogbytes, false, null);
-                // write to the previous catalog bytes place holder
-                zk.setData(VoltZK.catalogbytesPrevious, data, -1);
-            } catch (KeeperException | InterruptedException e) {
-                VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
-                errMsg = "error copying catalog bytes or write catalog bytes on ZK";
-                return makeQuickResponse(ClientResponseImpl.GRACEFUL_FAILURE, errMsg);
-            }
         }
 
         // ENG-14511 on assertion failures in test environment, ensure removal of action blocker

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -479,14 +479,6 @@ public class UpdateCore extends VoltSystemProcedure {
             }
         }
 
-        try {
-            CatalogUtil.updateCatalogToZK(zk, expectedCatalogVersion + 1, genId,
-                    catalogBytes, catalogHash, deploymentBytes);
-        } catch (KeeperException | InterruptedException e) {
-            log.error("error writing catalog bytes on ZK during @UpdateCore");
-            throw e;
-        }
-
         // log the start of UpdateCore
         log.info("New catalog update from: " + VoltDB.instance().getCatalogContext().getCatalogLogString());
         log.info("To: catalog hash: " + Encoder.hexEncode(catalogHash).substring(0, 10) +
@@ -502,18 +494,15 @@ public class UpdateCore extends VoltSystemProcedure {
         }
         catch (VoltAbortException vae) {
             log.info("Catalog verification failed: " + vae.getMessage());
-            // revert the catalog node on ZK
-            try {
-                // read the current catalog bytes
-                byte[] data = zk.getData(VoltZK.catalogbytesPrevious, false, null);
-                assert(data != null);
-                // write to the previous catalog bytes place holder
-                zk.setData(VoltZK.catalogbytes, data, -1);
-            } catch (KeeperException | InterruptedException e) {
-                log.error("error read/write catalog bytes on zookeeper: " + e.getMessage());
-                throw e;
-            }
             throw vae;
+        }
+
+        try {
+            CatalogUtil.updateCatalogToZK(zk, expectedCatalogVersion + 1, genId,
+                    catalogBytes, catalogHash, deploymentBytes);
+        } catch (KeeperException | InterruptedException e) {
+            log.error("error writing catalog bytes on ZK during @UpdateCore");
+            throw e;
         }
 
         performCatalogUpdateWork(

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -2488,10 +2488,6 @@ public abstract class CatalogUtil {
                 catalogBytes, catalogHash, deploymentBytes);
         zk.create(VoltZK.catalogbytes,
                 versionAndBytes.array(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-
-        // create the previous catalog bytes zk node
-        zk.create(VoltZK.catalogbytesPrevious,
-                versionAndBytes.array(), Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
 
     /**


### PR DESCRIPTION
Rejoining node was getting a newer catalog than the rest of the clusters. It looks like
the cluster started UpdateClasses NTProc, which called UpdateCore sysproc as the final step.
UpdateCore wrote the new catalog to ZK node, but the MPI node failed before any fragments were run.
Node rejoined a few seconds later and picked up the new catalog from ZK, while the
rest of the cluster stayed on the old catalog. To avoid this, write new catalog bytes
to ZK node, only after the first fragment of UpdateCore completes, thus ensuring that UpdateCore
will be restarted on the new MPI even on an MPI node failure.