### PR TITLE
ENG-19626:

### DIFF
--- a/src/frontend/org/voltdb/UserDefinedFunctionManager.java
+++ b/src/frontend/org/voltdb/UserDefinedFunctionManager.java
@@ -51,7 +51,9 @@ public class UserDefinedFunctionManager {
     }
 
     // Load all the UDFs recorded in the catalog. Instantiate and register them in the system.
-    public void loadFunctions(CatalogContext catalogContext) {
+    // WARNING: This is called from all sites in parallel but updates a shared static
+    //          data structure in FunctionForVoltDB
+    public synchronized void loadFunctions(CatalogContext catalogContext) {
         final CatalogMap<Function> catalogFunctions = catalogContext.database.getFunctions();
         // Remove obsolete tokens (scalar)
         for (UserDefinedScalarFunctionRunner runner : m_udfs.values()) {


### PR DESCRIPTION
On every Catalog Update the set of UDFs and UDAFs is removed and reinstalled on every partition. However, a shared list of names is also updated without being protected from race conditions that could cause the underlying shared data structures to become corrupted. Adding some synchronization to the path protects against this scenario.