### PR TITLE
KO-241, when database is snapshotting, print "in_progress" instead of "success" in SNAPSHOTSUMMARY.

### DIFF
--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -32,6 +32,13 @@ import org.voltdb.sysprocs.SnapshotRegistry.Snapshot.Table;
 
 public class SnapshotStatus extends StatsSource {
 
+    // Item order matters, SnapshotSummary manipulates the result by checking the ordinal
+    public enum SnapshotResult {
+        FAILURE,
+        IN_PROGRESS,
+        SUCCESS;
+    }
+
     enum SNAPSHOT_TYPE {
         AUTO,
         MANUAL,
@@ -147,7 +154,14 @@ public class SnapshotStatus extends StatsSource {
         rowValues[columnNameToIndex.get("SIZE")] = t.size;
         rowValues[columnNameToIndex.get("DURATION")] = duration;
         rowValues[columnNameToIndex.get("THROUGHPUT")] = throughput;
-        rowValues[columnNameToIndex.get("RESULT")] = t.error == null ? "SUCCESS" : "FAILURE";
+        String result;
+        if (t.error == null && t.size == 0) {
+            // still in progress
+            result = SnapshotResult.IN_PROGRESS.toString();
+        } else {
+            result = t.error == null ? SnapshotResult.SUCCESS.toString() : SnapshotResult.FAILURE.toString();
+        }
+        rowValues[columnNameToIndex.get("RESULT")] = result;
         rowValues[columnNameToIndex.get("TYPE")] = m_typeChecker.getSnapshotType(s.path);
         super.updateStatsRow(rowKey, rowValues);
     }


### PR DESCRIPTION
SnapshotSummary returns one row per snapshot about the progress and result of 10 most recent CommandLog, AUTO or MANUAL snapshots.

But it starts to show SUCCESS result as early as snapshot initiation finishes, it rewrites the result if the snapshot failed later. I would rather to keep result column empty until the snapshot is actually finished. 

Now looks better?

```
exec @Statistics SNAPSHOTSUMMARY 0;
NONCE                TXNID             TYPE        START_TIME     END_TIME       DURATION  PROGRESS_PCT  RESULT
-------------------- ----------------- ----------- -------------- -------------- --------- ------------- ------------
1589861877645         3619631923445759 COMMANDLOG   1589861877731  1589861880452         2         100.0 SUCCESS
MANUAL1589861949114   3619631923462143 AUTO         1589861949181              0         0          81.8 IN_PROGRESS

(Returned 2 rows in 0.02s)
yanglu-local:test_env$ sqlcmd --query="exec @Statistics SNAPSHOTSUMMARY 0"

exec @Statistics SNAPSHOTSUMMARY 0;
NONCE                TXNID             TYPE        START_TIME     END_TIME       DURATION  PROGRESS_PCT  RESULT
-------------------- ----------------- ----------- -------------- -------------- --------- ------------- --------
1589861877645         3619631923445759 COMMANDLOG   1589861877731  1589861880452         2         100.0 SUCCESS
MANUAL1589861949114   3619631923462143 AUTO         1589861949181  1589861952168         2         100.0 SUCCESS
```
