### PR TITLE
ENG-19627: Remove m_subqueryNodeId

### DIFF
--- a/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/RowSubqueryExpression.java
@@ -49,7 +49,7 @@ public class RowSubqueryExpression extends AbstractSubqueryExpression {
             collectParameterValueExpressions(expr, pves);
         }
         String tableName = AbstractParsedStmt.TEMP_TABLE_NAME + "_" + m_subqueryId;
-        m_subqueryNode = new TupleScanPlanNode(tableName, pves);
+        setSubqueryNode(new TupleScanPlanNode(tableName, pves));
     }
 
     @Override

--- a/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
+++ b/src/frontend/org/voltdb/expressions/SelectSubqueryExpression.java
@@ -30,7 +30,6 @@ import org.json_voltpatches.JSONStringer;
 import org.voltdb.VoltType;
 import org.voltdb.exceptions.ValidationError;
 import org.voltdb.planner.AbstractParsedStmt;
-import org.voltdb.planner.CompiledPlan;
 import org.voltdb.planner.parseinfo.StmtSubqueryScan;
 import org.voltdb.plannodes.AbstractPlanNode;
 import org.voltdb.types.ExpressionType;
@@ -73,8 +72,7 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
         assert(m_subquery.getSubqueryStmt() != null);
         m_subqueryId = m_subquery.getSubqueryStmt().getStmtId();
         if (m_subquery.getBestCostPlan() != null && m_subquery.getBestCostPlan().rootPlanGraph != null) {
-            m_subqueryNode = m_subquery.getBestCostPlan().rootPlanGraph;
-            m_subqueryNodeId = m_subqueryNode.getPlanNodeId();
+            super.setSubqueryNode(m_subquery.getBestCostPlan().rootPlanGraph);
         }
         m_args = new ArrayList<>();
         resolveCorrelations();
@@ -109,11 +107,6 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
     }
 
     @Override
-    public int getSubqueryNodeId() {
-        return m_subqueryNodeId;
-    }
-
-    @Override
     public AbstractPlanNode getSubqueryNode() {
         return m_subqueryNode;
     }
@@ -132,11 +125,10 @@ public class SelectSubqueryExpression extends AbstractSubqueryExpression {
     @Override
     public void setSubqueryNode(AbstractPlanNode subqueryNode) {
         assert(subqueryNode != null);
-        m_subqueryNode = subqueryNode;
+        super.setSubqueryNode(subqueryNode);
         if (m_subquery != null && m_subquery.getBestCostPlan() != null) {
             m_subquery.getBestCostPlan().rootPlanGraph = m_subqueryNode;
         }
-        resetSubqueryNodeId();
     }
 
     @Override


### PR DESCRIPTION
The m_subqueryNodeId value was only really being used for validate().
The getter actually returned m_subqueryNode.getPlanNodeId(). Since the
id can always be retrieved from m_subqueryNode just use that as the
authoritative location.