### PR TITLE
Eng 19204 dynamic license update

### DIFF
--- a/lib/python/voltcli/voltadmin.d/license.py
+++ b/lib/python/voltcli/voltadmin.d/license.py
@@ -1,0 +1,39 @@
+# This file is part of VoltDB.
+# Copyright (C) 2008-2020 VoltDB Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from voltcli import utility
+
+@VOLT.Command(
+    bundles=VOLT.AdminBundle(),
+    description='Update the license of a running database.',
+    #description2='A valid VoltDB license file (extension .xml) must be provided.',
+    arguments=(
+        VOLT.StringArgument(
+            'license',
+            'VoltDB license file (extension .xml)',
+            min_count=1, max_count=1),
+    )
+)
+def license(runner):
+    columns = [VOLT.FastSerializer.VOLTTYPE_NULL, VOLT.FastSerializer.VOLTTYPE_NULL]
+    licensePath = runner.opts.license
+    licenseBytes = VOLT.utility.File(licensePath).read()
+    columns[1] = VOLT.FastSerializer.VOLTTYPE_STRING
+    params = [licenseBytes]
+    # call_proc() aborts with an error if the update failed.
+    runner.call_proc('@UpdateLicense', columns, params)
+    runner.info('The configuration update succeeded.')

--- a/lib/python/voltcli/voltadmin.d/license.py
+++ b/lib/python/voltcli/voltadmin.d/license.py
@@ -19,21 +19,23 @@ from voltcli import utility
 
 @VOLT.Command(
     bundles=VOLT.AdminBundle(),
-    description='Update the license of a running database.',
-    #description2='A valid VoltDB license file (extension .xml) must be provided.',
+    description='Update the license of a running VoltDB database.',
     arguments=(
         VOLT.StringArgument(
             'license',
-            'VoltDB license file (extension .xml)',
+            'VoltDB_license_file (extension .xml)',
             min_count=1, max_count=1),
     )
 )
 def license(runner):
-    columns = [VOLT.FastSerializer.VOLTTYPE_NULL, VOLT.FastSerializer.VOLTTYPE_NULL]
-    licensePath = runner.opts.license
-    licenseBytes = VOLT.utility.File(licensePath).read()
-    columns[1] = VOLT.FastSerializer.VOLTTYPE_STRING
-    params = [licenseBytes]
-    # call_proc() aborts with an error if the update failed.
-    runner.call_proc('@UpdateLicense', columns, params)
-    runner.info('The configuration update succeeded.')
+    license_file = VOLT.utility.File(runner.opts.license);
+    try:
+        licenseBytes = license_file.read()
+        # call_proc() aborts with an error if the update failed.
+        response = runner.call_proc('@UpdateLicense', [VOLT.FastSerializer.VOLTTYPE_STRING], [licenseBytes])
+        if response.status() != 1:
+            runner.abort('The license update failed with status: %d' % response.response.statusString)
+        else:
+            runner.info('The license is updated successfully.')
+    finally:
+        license_file.close();

--- a/lib/python/voltcli/voltadmin.d/license.py
+++ b/lib/python/voltcli/voltadmin.d/license.py
@@ -1,5 +1,5 @@
 # This file is part of VoltDB.
-# Copyright (C) 2008-2020 VoltDB Inc.
+# Copyright (C) 2020 VoltDB Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -39,7 +39,7 @@ def license(runner):
             runner.abort('Failed to update the license. Response status: %d' % response.response.statusString)
         for row in response.table(0).tuples():
             procStatus, errStr = row[0], row[1]
-            # 0-Failure, 1-Success
+            # 0-Success, 1-Failure
             if procStatus != 0:
                 runner.abort("Failed to update the license: %s" % errStr)
         runner.info("The license is updated successfully.")

--- a/lib/python/voltcli/voltadmin.d/license.py
+++ b/lib/python/voltcli/voltadmin.d/license.py
@@ -27,12 +27,15 @@ from voltcli import utility
             min_count=1, max_count=1),
     )
 )
+
+# get proper error message from the procedure call
 def license(runner):
     license_file = VOLT.utility.File(runner.opts.license);
     try:
-        licenseBytes = license_file.read()
+        licenseBytes = license_file.read_hex()
         # call_proc() aborts with an error if the update failed.
         response = runner.call_proc('@UpdateLicense', [VOLT.FastSerializer.VOLTTYPE_STRING], [licenseBytes])
+        print response
         if response.status() != 1:
             runner.abort('The license update failed with status: %d' % response.response.statusString)
         else:

--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -42,7 +42,8 @@ def _listOfGlobsToFiles(pathGlobs):
         VOLT.StringListOption('-s', '--schema', 'schemas',
                            'Specifies a list of schema files or paths with wildcards, comma separated, containing the data definition (as SQL statements) to be loaded when starting the database.'),
         VOLT.StringListOption('-j', '--classes', 'classes_jarfiles',
-                          'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.')
+                          'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.'),
+        VOLT.StringOption('-l', '--license', 'license', 'specify the location of the license file')
     ),
     description = 'Initializes a new, empty database.'
 )
@@ -61,6 +62,8 @@ def init(runner):
     if runner.opts.classes_jarfiles:
         runner.args.append('classes')
         runner.args.append(_listOfGlobsToFiles(runner.opts.classes_jarfiles))
+    if runner.opts.license:
+        runner.args.extend(['license', runner.opts.license])
 
     args = runner.args
     runner.java_execute(VoltDB, None, *args)

--- a/lib/python/voltcli/voltdb.d/init.py
+++ b/lib/python/voltcli/voltdb.d/init.py
@@ -43,7 +43,7 @@ def _listOfGlobsToFiles(pathGlobs):
                            'Specifies a list of schema files or paths with wildcards, comma separated, containing the data definition (as SQL statements) to be loaded when starting the database.'),
         VOLT.StringListOption('-j', '--classes', 'classes_jarfiles',
                           'Specifies a list of .jar files or paths with wildcards, comma separated, containing classes used to declare stored procedures. The classes are loaded automatically from a saved copy when the database starts.'),
-        VOLT.StringOption('-l', '--license', 'license', 'specify the location of the license file')
+        VOLT.StringOption('-l', '--license', 'license', 'Specifies the path for the VoltDB license file')
     ),
     description = 'Initializes a new, empty database.'
 )

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -520,6 +520,11 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     }
 
     @Override
+    public void updateLicenseApi(LicenseApi newLicenseApi) {
+        m_licenseApi = newLicenseApi;
+    }
+
+    @Override
     public String getLicenseInformation() {
         return m_licenseInformation;
     }

--- a/src/frontend/org/voltdb/ServerThread.java
+++ b/src/frontend/org/voltdb/ServerThread.java
@@ -190,6 +190,12 @@ public class ServerThread extends Thread {
         }
     }
 
+    // For TestStartActionWithLicenseOption only, that test want to validate given
+    // license file instead of the default file.
+    public void ignoreDefaultLicense() {
+        m_config.m_pathToLicense = null;
+    }
+
     /**
      * For tests only, mostly with ServerThread or LocalCluster:
      *

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -488,6 +488,11 @@ public class SystemProcedureCatalog {
                         false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.DURABLE,
                         false, true, Restartability.RESTARTABLE));
+        builder.put("@UpdateLicense",
+                new Config("org.voltdb.sysprocs.UpdateLicense",
+                        false, false, false, 0, VoltType.INVALID,
+                        false, false, true, Durability.DURABLE,
+                        false, true, Restartability.RESTARTABLE));
         builder.put("@Ping",
                 new Config(null,
                         false, true,  false, 0, VoltType.INVALID,

--- a/src/frontend/org/voltdb/SystemProcedureCatalog.java
+++ b/src/frontend/org/voltdb/SystemProcedureCatalog.java
@@ -488,11 +488,6 @@ public class SystemProcedureCatalog {
                         false, false, false, 0, VoltType.INVALID,
                         false, false, true, Durability.DURABLE,
                         false, true, Restartability.RESTARTABLE));
-        builder.put("@UpdateLicense",
-                new Config("org.voltdb.sysprocs.UpdateLicense",
-                        false, false, false, 0, VoltType.INVALID,
-                        false, false, true, Durability.DURABLE,
-                        false, true, Restartability.RESTARTABLE));
         builder.put("@Ping",
                 new Config(null,
                         false, true,  false, 0, VoltType.INVALID,
@@ -701,6 +696,12 @@ public class SystemProcedureCatalog {
         builder.put("@DeleteExpiredKiplingOffsets",
                 Builder.createSp("org.voltdb.sysprocs.KiplingProcedures$DeleteExpiredOffsets", -1, VoltType.INVALID)
                         .commercial().build());
+        builder.put("@UpdateLicense",
+                Builder.createNp("org.voltdb.sysprocs.UpdateLicense").commercial().allowedInReplica().build());
+        builder.put("@LicenseValidation",
+                Builder.createNp("org.voltdb.sysprocs.UpdateLicense$LicenseValidation").commercial().allowedInReplica().build());
+        builder.put("@LiveLicenseUpdate",
+                Builder.createNp("org.voltdb.sysprocs.UpdateLicense$LiveLicenseUpdate").commercial().allowedInReplica().build());
 
         listing = builder.build();
     }

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -330,6 +330,8 @@ public interface VoltDBInterface
      * @return License API based on edition.
      */
     public LicenseApi getLicenseApi();
+    public void updateLicenseApi(LicenseApi newLicense);
+
     //Return JSON string represenation of license information.
     public String getLicenseInformation();
 

--- a/src/frontend/org/voltdb/common/Constants.java
+++ b/src/frontend/org/voltdb/common/Constants.java
@@ -85,4 +85,5 @@ public class Constants
 
     public static final String DBROOT = "voltdbroot";
     public static final String CONFIG_DIR = "config";
+    public static final String LICENSE_FILE_NAME = "license.xml";
 }

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -283,12 +283,6 @@ public class SysProcFragmentId
     public static final int PF_topicControl = 410;
     public static final int PF_topicControlAggregate = 411;
 
-    // @UpdateLicense
-    public static final int PF_updateLicenseBarrier = 415;
-    public static final int PF_updateLicenseBarrierAggregate = 416;
-    public static final int PF_updateLicense = 417;
-    public static final int PF_updateLicenseAggregate = 418;
-
     public static boolean isEnableScoreboardFragment(byte[] planHash) {
         long fragId = VoltSystemProcedure.hashToFragId(planHash);
 

--- a/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
+++ b/src/frontend/org/voltdb/sysprocs/SysProcFragmentId.java
@@ -275,7 +275,6 @@ public class SysProcFragmentId
     public static final int PF_collectDrTrackers = 400;
     public static final int PF_collectDrTrackersAgg = 401;
 
-
     // @StopReplicas
     public static final int PF_stopReplicas = 402;
     public static final int PF_stopReplicasAggregate = 403;
@@ -283,6 +282,12 @@ public class SysProcFragmentId
     // @TopicControl
     public static final int PF_topicControl = 410;
     public static final int PF_topicControlAggregate = 411;
+
+    // @UpdateLicense
+    public static final int PF_updateLicenseBarrier = 415;
+    public static final int PF_updateLicenseBarrierAggregate = 416;
+    public static final int PF_updateLicense = 417;
+    public static final int PF_updateLicenseAggregate = 418;
 
     public static boolean isEnableScoreboardFragment(byte[] planHash) {
         long fragId = VoltSystemProcedure.hashToFragId(planHash);

--- a/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
@@ -1,0 +1,151 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.sysprocs;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.zookeeper_voltpatches.KeeperException;
+import org.apache.zookeeper_voltpatches.ZooKeeper;
+import org.apache.zookeeper_voltpatches.data.Stat;
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.CoreUtils;
+import org.voltdb.CatalogContext;
+import org.voltdb.DependencyPair;
+import org.voltdb.ParameterSet;
+import org.voltdb.SystemProcedureExecutionContext;
+import org.voltdb.VoltDB;
+import org.voltdb.VoltSystemProcedure;
+import org.voltdb.VoltTable;
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
+import org.voltdb.VoltZK;
+import org.voltdb.settings.ClusterSettings;
+import org.voltdb.settings.SettingsException;
+import org.voltdb.utils.VoltTableUtil;
+
+public class UpdateLicense extends VoltSystemProcedure {
+
+    private final static VoltLogger log = new VoltLogger("HOST");
+
+    @Override
+    public long[] getPlanFragmentIds() {
+        return new long[]{
+            SysProcFragmentId.PF_updateSettingsBarrier,
+            SysProcFragmentId.PF_updateSettingsBarrierAggregate,
+            SysProcFragmentId.PF_updateSettings,
+            SysProcFragmentId.PF_updateSettingsAggregate
+        };
+    }
+
+    private VoltTable getVersionResponse(int version) {
+        VoltTable table = new VoltTable(new ColumnInfo[] { new ColumnInfo("VERSION", VoltType.INTEGER) });
+        table.addRow(version);
+        return table;
+    }
+
+    @Override
+    public DependencyPair executePlanFragment(
+            Map<Integer, List<VoltTable>> dependencies, long fragmentId,
+            ParameterSet params, SystemProcedureExecutionContext context) {
+
+        if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrier) {
+            DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsBarrier,
+                    new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
+            if (log.isInfoEnabled()) {
+                log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
+                        " reached settings update barrier.");
+            }
+            return success;
+
+        } else if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrierAggregate) {
+
+            Object [] paramarr = params.toArray();
+            byte [] settingsBytes = (byte[])paramarr[0];
+            int version = ((Integer)paramarr[1]).intValue();
+            ZooKeeper zk = getHostMessenger().getZK();
+            Stat stat = null;
+            try {
+                stat = zk.setData(VoltZK.cluster_settings, settingsBytes, version);
+            } catch (KeeperException | InterruptedException e) {
+                String msg = "Failed to update cluster settings";
+                log.error(msg,e);
+                throw new SettingsException(msg, e);
+            }
+            log.info("Saved new cluster settings state");
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsBarrierAggregate,
+                    getVersionResponse(stat.getVersion()));
+
+        } else if (fragmentId == SysProcFragmentId.PF_updateSettings) {
+
+            Object [] paramarr = params.toArray();
+            byte [] settingsBytes = (byte[])paramarr[0];
+            int version = ((Integer)paramarr[1]).intValue();
+            ClusterSettings settings = ClusterSettings.create(settingsBytes);
+            CatalogContext catalogContext =
+                    getVoltDB().settingsUpdate(settings, version);
+
+            context.updateSettings(catalogContext);
+
+            VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
+            result.addRow(VoltSystemProcedure.STATUS_OK);
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettings, result);
+
+        } else if (fragmentId == SysProcFragmentId.PF_updateSettingsAggregate) {
+            VoltTable result = VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_updateSettings));
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsAggregate, result);
+
+        } else {
+            VoltDB.crashLocalVoltDB(
+                    "Received unrecognized plan fragment id " + fragmentId + " in UpdateSettings",
+                    false,
+                    null);
+        }
+        throw new RuntimeException("Should not reach this code");
+    }
+
+    private SynthesizedPlanFragment[] createBarrierFragment(byte[] settingsBytes, int version) {
+
+        SynthesizedPlanFragment pfs[] = new SynthesizedPlanFragment[2];
+
+        pfs[0] = new SynthesizedPlanFragment(SysProcFragmentId.PF_updateSettingsBarrier, true,
+                ParameterSet.emptyParameterSet());
+
+        pfs[1] = new SynthesizedPlanFragment(SysProcFragmentId.PF_updateSettingsBarrierAggregate, false,
+                ParameterSet.fromArrayNoCopy(settingsBytes, version));
+
+        return pfs;
+    }
+
+    public VoltTable[] run(SystemProcedureExecutionContext ctx, byte[] settingsBytes) {
+        ZooKeeper zk = getHostMessenger().getZK();
+        Stat stat = null;
+        try {
+            stat = zk.exists(VoltZK.cluster_settings, false);
+        } catch (KeeperException | InterruptedException e) {
+            String msg = "Failed to stat cluster settings zookeeper node";
+            log.error(msg, e);
+            throw new VoltAbortException(msg);
+        }
+        final int version = stat.getVersion();
+
+        executeSysProcPlanFragments(
+                createBarrierFragment(settingsBytes, version), SysProcFragmentId.PF_updateSettingsBarrierAggregate);
+        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateSettings,  SysProcFragmentId.PF_updateSettingsAggregate, settingsBytes, version);
+    }
+}

--- a/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
@@ -19,9 +19,11 @@ package org.voltdb.sysprocs;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.DependencyPair;
@@ -30,12 +32,12 @@ import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
-import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
 import org.voltdb.licensetool.LicenseApi;
 import org.voltdb.utils.MiscUtils;
 import org.voltdb.utils.VoltTableUtil;
 
+import com.google_voltpatches.common.collect.Maps;
 import com.google_voltpatches.common.io.Files;
 
 public class UpdateLicense extends VoltSystemProcedure {
@@ -52,59 +54,104 @@ public class UpdateLicense extends VoltSystemProcedure {
         };
     }
 
+    private VoltTable constructResultTable() {
+       return new VoltTable(
+                new VoltTable.ColumnInfo("HOST_ID", VoltType.BIGINT),
+                new VoltTable.ColumnInfo("STATUS", VoltType.BIGINT),
+                new VoltTable.ColumnInfo("ERR_MSG", VoltType.STRING));
+    }
+
+    // return error message if found error
+    private String checkError(VoltTable fragmentResponse) {
+        Map<String, Set<Integer>> errorReport = Maps.newHashMap();
+        while (fragmentResponse.advanceRow()) {
+            // generate error report, unique error
+            if (fragmentResponse.getLong("STATUS") != VoltSystemProcedure.STATUS_OK) {
+                String errMsg = fragmentResponse.getString("ERR_MSG");
+                int hostId = (int)fragmentResponse.getLong("HOST_ID");
+                Set<Integer> reporters = errorReport.get(errMsg);
+                if (reporters == null) {
+                    reporters = new HashSet<Integer>();
+                }
+                reporters.add(hostId);
+                errorReport.put(errMsg, reporters);
+            }
+        }
+        if (!errorReport.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            for (Entry<String, Set<Integer>> e : errorReport.entrySet()) {
+                sb.append("Host ").append(e.getValue()).append(" report: ").append(e.getKey()).append("\n");
+            }
+            return sb.toString();
+        }
+        return null;
+    }
+
     @Override
     public DependencyPair executePlanFragment(
             Map<Integer, List<VoltTable>> dependencies, long fragmentId,
             ParameterSet params, SystemProcedureExecutionContext context) {
         // The purpose of first fragment is to sync all sites across database to the same position.
-        // So far we only update expiration date and/or max host count allowed, but in the future if
-        // feature enable/disable is included, the first fragment can also do
         if (fragmentId == SysProcFragmentId.PF_updateLicenseBarrier) {
-            DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicenseBarrier,
-                    new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
-            return success;
+            VoltTable result = constructResultTable();
+            // The lowest site validate the new license, other sites return empty table
+            if (context.isLowestSiteId()) {
+                Object [] paramarr = params.toArray();
+                byte [] licenseBytes = (byte[])paramarr[0];
+                // Write the bytes into a temporary file in voltdb root
+                File tempLicense = new File(VoltDB.instance().getVoltDBRootPath(), ".temp_content");
+                try {
+                    Files.write(licenseBytes, tempLicense);
+                    result.addRow(VoltDB.instance().getHostMessenger().getHostId(),
+                            VoltSystemProcedure.STATUS_OK, "");
+                } catch (IOException e) {
+                    String errMsg = "Failed to write the new license to disk: " + e.getMessage();
+                    log.info(errMsg);
+                    result.addRow(VoltDB.instance().getHostMessenger().getHostId(),
+                            VoltSystemProcedure.STATUS_FAILURE,
+                            errMsg);
+                }
+            }
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicenseBarrier, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_updateLicenseBarrierAggregate) {
             return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicenseBarrierAggregate,
                     VoltTableUtil.unionTables(dependencies.get(SysProcFragmentId.PF_updateLicenseBarrier)));
 
         } else if (fragmentId == SysProcFragmentId.PF_updateLicense) {
-            Object [] paramarr = params.toArray();
-            byte [] licenseBytes = (byte[])paramarr[0];
-            VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
-
+            VoltTable result = constructResultTable();
             if (context.isLowestSiteId()) {
-                // write file to disk (some temp directory)
+                // validate the license format and signature
                 File tempLicense = new File(VoltDB.instance().getVoltDBRootPath(), ".temp_content");
-                try {
-                    Files.write(licenseBytes, tempLicense);
-                } catch (IOException e) {
-                    log.info("Failed to write the new license to disk: " + e.getMessage());
-                    result.addRow(VoltSystemProcedure.STATUS_FAILURE);
-                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicense, result);
-                }
-                // validate the license
                 LicenseApi newLicense = MiscUtils.licenseApiFactory(tempLicense.getAbsolutePath());
                 if (newLicense == null) {
-                    log.info("New license is invalid.");
                     tempLicense.delete();
-                    result.addRow(VoltSystemProcedure.STATUS_FAILURE);
-                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicense, result);
+                    String errMsg = "The license we try to update to is invalid";
+                    log.info(errMsg);
+                    result.addRow(VoltDB.instance().getHostMessenger().getHostId(),
+                            VoltSystemProcedure.STATUS_FAILURE,
+                            errMsg);
                 }
+                // Does the new license expire?
+
+                // Are the license changes allowed?
                 LicenseApi currentLicense = VoltDB.instance().getLicenseApi();
-                if (MiscUtils.isLicenseChangeAllowed(newLicense, currentLicense)) {
-                    // replace the staged license file in voltdb root
+                String error = MiscUtils.isLicenseChangeAllowed(newLicense, currentLicense);
+                if (error == null) {
+                    // ok to update, rename temporary file to canonical name
                     tempLicense.renameTo(new File(VoltDB.instance().getVoltDBRootPath(), "license.xml"));
                     VoltDB.instance().updateLicenseApi(newLicense);
+
+                    result.addRow(VoltDB.instance().getHostMessenger().getHostId(),
+                            VoltSystemProcedure.STATUS_OK, "");
                 } else {
-                    log.info("Failed to update the license, changes include license type, hard/soft expiration "
-                            + "and/or features enabled are not allowed to live-update.");
+                    log.info(error);
                     tempLicense.delete();
-                    result.addRow(VoltSystemProcedure.STATUS_FAILURE);
-                    return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicense, result);
+                    result.addRow(VoltDB.instance().getHostMessenger().getHostId(),
+                            VoltSystemProcedure.STATUS_FAILURE,
+                            error);
                 }
             }
-            result.addRow(VoltSystemProcedure.STATUS_OK);
             return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateLicense, result);
 
         } else if (fragmentId == SysProcFragmentId.PF_updateLicenseAggregate) {
@@ -120,18 +167,36 @@ public class UpdateLicense extends VoltSystemProcedure {
         throw new RuntimeException("Should not reach this code");
     }
 
-    public VoltTable[] run(SystemProcedureExecutionContext ctx, String license) {
-        byte[] licenseBytes;
-        try {
-            licenseBytes = license.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            String errMsg = "Failed to encode the license: " + e.getMessage();
-            log.error(errMsg);
-            VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
-            result.addRow(VoltSystemProcedure.STATUS_FAILURE);
-            return new VoltTable[] {result};
+    public VoltTable[] run(SystemProcedureExecutionContext ctx, byte[] licenseBytes) {
+        VoltTable result = new VoltTable(VoltSystemProcedure.STATUS_SCHEMA);
+
+        log.info("Received user request to update database license.");
+        // community is not allowed to live-update license.
+        LicenseApi api = VoltDB.instance().getLicenseApi();
+        if (MiscUtils.isCommunity(api)) {
+            String errMsg = "License update command is not allowed in community version.";
+            log.info(errMsg);
+            throw new VoltAbortException(errMsg);
         }
-        createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateLicenseBarrier, SysProcFragmentId.PF_updateLicenseBarrierAggregate);
-        return createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateLicense,  SysProcFragmentId.PF_updateLicenseAggregate, licenseBytes);
+        VoltTable[] fragmentResult =
+                createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateLicenseBarrier,
+                        SysProcFragmentId.PF_updateLicenseBarrierAggregate, licenseBytes);
+        String errMsg = checkError(fragmentResult[0]);
+        if (errMsg != null) {
+            log.info(errMsg);
+            throw new VoltAbortException(errMsg);
+        }
+
+        fragmentResult = createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateLicense,
+                SysProcFragmentId.PF_updateLicenseAggregate);
+        errMsg = checkError(fragmentResult[0]);
+        if (errMsg != null) {
+            log.info(errMsg);
+            throw new VoltAbortException(errMsg);
+        }
+        log.info("License is updated successfully.");
+        result.addRow(VoltSystemProcedure.STATUS_OK);
+        return new VoltTable[] { result };
+
     }
 }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -460,6 +460,30 @@ public class MiscUtils {
     }
 
     /**
+     * Compare the new and current license, see if the difference is allowed to be updated in live database.
+     * <p>Currently only following types of change is allowed in live cluster:
+     * <li>expiration date, and</li>
+     * <li>max host count</li>
+     * </p>
+     * <p>Ignore differences like license version/scheme, issuer information and licensee name.</p>
+     * @param newLicense
+     * @param currentLicense
+     * @return true if the change is allowed, otherwise false.
+     */
+    public static boolean isLicenseChangeAllowed(LicenseApi newLicense, LicenseApi currentLicense) {
+        if (!newLicense.getLicenseType().equalsIgnoreCase(currentLicense.getLicenseType()) &&
+            newLicense.isCommandLoggingAllowed() != currentLicense.isCommandLoggingAllowed() &&
+            newLicense.isDrActiveActiveAllowed() != currentLicense.isDrActiveActiveAllowed() &&
+            newLicense.isDrReplicationAllowed() != currentLicense.isDrReplicationAllowed() &&
+            newLicense.hardExpiration() != currentLicense.hardExpiration() &&
+            newLicense.isUnrestricted() != currentLicense.isUnrestricted()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Check that RevisionStrings are properly formatted.
      * @param fullBuildString
      * @return build revision # (SVN), build hash (git) or null

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -472,12 +472,21 @@ public class MiscUtils {
      */
     public static String isLicenseChangeAllowed(LicenseApi newLicense, LicenseApi currentLicense) {
         if ( !newLicense.getLicenseType().equalsIgnoreCase(currentLicense.getLicenseType()) ) {
-            return "Can not change " + currentLicense.getLicenseType() + " to " + newLicense.getLicenseType();
+            return "Change license type from " + currentLicense.getLicenseType() + " to " + newLicense.getLicenseType() + " is disallowed. " +
+                    "A maintenance window is needed to do that change.";
         }
-        if ( newLicense.isCommandLoggingAllowed() != currentLicense.isCommandLoggingAllowed() ||
-             newLicense.isDrActiveActiveAllowed() != currentLicense.isDrActiveActiveAllowed() ||
-             newLicense.isDrReplicationAllowed() != currentLicense.isDrReplicationAllowed() ) {
-            return "Can not change allowed features in license update.";
+        // Commandlogging is always allowed in enterprise/trail/pro license, check for extra caution
+        if (newLicense.isCommandLoggingAllowed() != currentLicense.isCommandLoggingAllowed()) {
+            return (newLicense.isCommandLoggingAllowed() ? "add" : "remove") + " feature command logging is disallowed. " +
+                    "A maintenance window is needed to do that change.";
+        }
+        if ( newLicense.isDrActiveActiveAllowed() != currentLicense.isDrActiveActiveAllowed()) {
+            return (newLicense.isDrActiveActiveAllowed() ? "add" : "remove") + " feature XDCR is disallowed. " +
+                    "A maintenance window is needed to do that change.";
+        }
+        if (newLicense.isDrReplicationAllowed() != currentLicense.isDrReplicationAllowed() ) {
+            return (newLicense.isDrReplicationAllowed() ? "add" : "remove") + " feature DR is disallowed. " +
+                    "A maintenance window is needed to do that change.";
         }
         if ( newLicense.hardExpiration() != currentLicense.hardExpiration() ) {
             return "Can not change license from " +

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -468,19 +468,32 @@ public class MiscUtils {
      * <p>Ignore differences like license version/scheme, issuer information and licensee name.</p>
      * @param newLicense
      * @param currentLicense
-     * @return true if the change is allowed, otherwise false.
+     * @return error message if change is disallowed, null string if change is allowed.
      */
-    public static boolean isLicenseChangeAllowed(LicenseApi newLicense, LicenseApi currentLicense) {
-        if (!newLicense.getLicenseType().equalsIgnoreCase(currentLicense.getLicenseType()) &&
-            newLicense.isCommandLoggingAllowed() != currentLicense.isCommandLoggingAllowed() &&
-            newLicense.isDrActiveActiveAllowed() != currentLicense.isDrActiveActiveAllowed() &&
-            newLicense.isDrReplicationAllowed() != currentLicense.isDrReplicationAllowed() &&
-            newLicense.hardExpiration() != currentLicense.hardExpiration() &&
-            newLicense.isUnrestricted() != currentLicense.isUnrestricted()) {
-            return false;
-        } else {
-            return true;
+    public static String isLicenseChangeAllowed(LicenseApi newLicense, LicenseApi currentLicense) {
+        if ( !newLicense.getLicenseType().equalsIgnoreCase(currentLicense.getLicenseType()) ) {
+            return "Can not change " + currentLicense.getLicenseType() + " to " + newLicense.getLicenseType();
         }
+        if ( newLicense.isCommandLoggingAllowed() != currentLicense.isCommandLoggingAllowed() ||
+             newLicense.isDrActiveActiveAllowed() != currentLicense.isDrActiveActiveAllowed() ||
+             newLicense.isDrReplicationAllowed() != currentLicense.isDrReplicationAllowed() ) {
+            return "Can not change allowed features in license update.";
+        }
+        if ( newLicense.hardExpiration() != currentLicense.hardExpiration() ) {
+            return "Can not change license from " +
+                    (currentLicense.hardExpiration() ? "hard expiration" : "soft expiration") +
+                    " to " + (newLicense.hardExpiration() ? "hard expiration" : "soft expiration");
+        }
+        if ( newLicense.isUnrestricted() != currentLicense.isUnrestricted()) {
+            return "Can not change license from " +
+                    (currentLicense.isUnrestricted() ? "unrestricted" : "restricted") +
+                    " to " + (newLicense.isUnrestricted() ? "unrestricted" : "restricted");
+        }
+        return null;
+    }
+
+    public static boolean isCommunity(LicenseApi api) {
+        return !api.isEnterprise() && !api.isPro() && !api.isAnyKindOfTrial() && !api.isAWSMarketplace();
     }
 
     /**

--- a/src/frontend/org/voltdb/utils/SQLCommand.java
+++ b/src/frontend/org/voltdb/utils/SQLCommand.java
@@ -1221,6 +1221,8 @@ public class SQLCommand {
                 ImmutableMap.<Integer, List<String>>builder().put( 2, Arrays.asList("varchar", "varchar")).build());
         Procedures.put("@UpdateLogging",
                 ImmutableMap.<Integer, List<String>>builder().put( 1, Arrays.asList("varchar")).build());
+        Procedures.put("@UpdateLicense",
+                ImmutableMap.<Integer, List<String>>builder().put( 1, Arrays.asList("varchar")).build());
         Procedures.put("@Ping",
                 ImmutableMap.<Integer, List<String>>builder().put( 0, new ArrayList<>()).build());
         Procedures.put("@Promote",

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -871,6 +871,9 @@ public class MockVoltDB implements VoltDBInterface
     }
 
     @Override
+    public void updateLicenseApi(LicenseApi newLicense) { }
+
+    @Override
     public String getLicenseInformation() {
         return "";
     }

--- a/tests/frontend/org/voltdb/TestInitStartAction.java
+++ b/tests/frontend/org/voltdb/TestInitStartAction.java
@@ -57,12 +57,12 @@ import org.voltdb.compiler.VoltProjectBuilder;
 import org.voltdb.utils.CatalogUtil;
 import org.voltdb.utils.InMemoryJarfile;
 import org.voltdb.utils.VoltFile;
+import org.voltdb_testprocs.fakeusecase.greetings.GetGreetingBase;
 
 import com.google_voltpatches.common.base.Joiner;
 import com.google_voltpatches.common.io.CharStreams;
 import com.google_voltpatches.common.reflect.ClassPath;
 import com.google_voltpatches.common.reflect.ClassPath.ClassInfo;
-import org.voltdb_testprocs.fakeusecase.greetings.GetGreetingBase;
 
 /** Tests starting the server with init + start without a schema,
  * and 'init --schema --classes'.


### PR DESCRIPTION
This pull request includes 3 parts:
1) a new `voltadmin license` command to update the database license dynamically. There're some restrictions for changes allowed, see MiscUtil.isLicenseChangeAllowed().
2) move `--license` option to `voltdb init` step. `voltdb start` will continue supporting `--license` option to avoid disruption for existing customers and our unit/system tests.
3) a new system procedure `UpdateLicense` to distribute the license file across cluster, to validate the format of license, do proper checks and update the license api on each node. 

Cluster license consistency check when cluster startup, node rejoin or join will be added in a separate PR.

Pro PR: https://github.com/VoltDB/pro/pull/3174