### PR TITLE
Create asynchronous version of shutdown

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -2075,7 +2075,7 @@ public class SynchronizedStatesManager {
     }
 
     public void shutdownSynchronizedStatesManager() throws InterruptedException {
-        ListenableFuture<?> disableComplete = s_sharedEs.submit(disableInstances);
+        ListenableFuture<?> disableComplete = shutdownSynchronizedStatesManagerAsync();
         try {
             disableComplete.get();
         }
@@ -2084,6 +2084,10 @@ public class SynchronizedStatesManager {
             throw new RuntimeException(e.getCause());
         }
 
+    }
+
+    public ListenableFuture<?> shutdownSynchronizedStatesManagerAsync() {
+        return s_sharedEs.submit(disableInstances);
     }
 
     boolean isRunning() {


### PR DESCRIPTION
For ENG-19050 we refactor SSM shutdown to speed up completion of coordinator shutdown sequence: we no longer want to wait for the actual SSM shutdown given that re-creating the coordinator for the same topic/partition will use a different SSM nonce.