### PR TITLE
ENG-19246-branch-cleanup-notest:

### DIFF
--- a/tools/git-remove-branches-script.py
+++ b/tools/git-remove-branches-script.py
@@ -20,7 +20,7 @@ import time
 import jiratools
 
 # set exclusions if there are any branches that should not be listed
-exclusions = ['^master','^release-[0-9.]+\.x$']
+exclusions = ['^master','^release-[1-9]?[0-9.]+\.x$']
 combined_regex= '(' + ')|('.join(exclusions) + ')'
 jira_url = 'https://issues.voltdb.com/'
 gitshowmap = \
@@ -34,30 +34,50 @@ DELIMITER='^'
 
 def run_cmd(cmd):
     proc = Popen(cmd.split(' '),stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-    #print cmd
     (out, err) = proc.communicate(input=None)
     return (proc.returncode, out, err)
 
-def get_branch_list(merged):
-    branches = []
-
-    git_cmd = 'git branch -r %s' % ('--merged' if merged else '--no-merged')
+def get_release_branches():
+    git_cmd = 'git branch -r'
     print ('#\n# git command: %s\n#' % git_cmd)
     (returncode, stdout, stderr) = run_cmd (git_cmd)
+    return [b.strip() for b in stdout.splitlines() if b.strip().find('origin/release-') == 0 and b.strip()[-2:] == '.x']
 
-    #only want branches at origin and don't want HEAD listed
-    branches = [b.strip() for b in stdout.splitlines()if b.strip().find('origin/') == 0 and b.find('HEAD') < 0]
+def get_branch_list(merged, base=None):
+    branches=[]
 
-    #Filter others from list
-    origin_exclusions = ['origin/' + b for b in exclusions]
+    if base:
+        basebranches=[base]
+    else:
+        basebranches = get_release_branches()
+
+    #If merged, check release branches and master
+
+    for b in basebranches:
+        git_cmd = 'git branch -r %s %s' % ('--merged' if merged else '--no-merged', b)
+        print ('#\n# git command: %s\n#' % git_cmd)
+        (returncode, stdout, stderr) = run_cmd (git_cmd)
+
+        #only want branches at origin and don't want HEAD listed
+        found_branches = [b.strip() for b in stdout.splitlines()if b.strip().find('origin/') == 0 and b.find('HEAD') < 0]
+        branches = list(set().union(branches, found_branches))
+
     return [b for b in branches if not re.match(combined_regex,b.split('origin/')[-1])]
 
-def make_delete_branches_script(branch_infos, dry_run):
+def make_delete_branches_script(branch_infos, olderthan, max_num_branches=10,
+                                dry_run=False):
     other_args = ''
     if dry_run:
         other_args = ' --dry-run'
 
+    num_branches=0
     for bi in branch_infos:
+        num_branches+=1
+        if num_branches > max_num_branches:
+            print '\n#\n# Stopping, reached maximum number of (merged) branches', \
+                  'to list (& delete): %d, out of %d older than %d days.\n#' % \
+                  (max_num_branches, len(branch_infos), olderthan)
+            return
         b = bi['name']
         cmd = 'git push origin --delete %s%s' % \
             (b, other_args)
@@ -65,6 +85,8 @@ def make_delete_branches_script(branch_infos, dry_run):
         print
         print comment.encode('utf-8')
         print cmd
+    print '\n#\n# Completed list of %d (merged) branches older than %d days, to be deleted.\n#' \
+          % (num_branches, olderthan)
 
 def make_comment(bi):
     comment = '#%-20s last checkin %s %s by %s' % \
@@ -97,11 +119,19 @@ def get_jira_info(b):
 
     return comment
 
-def make_archive_branches_script(branch_infos, dry_run):
+def make_archive_branches_script(branch_infos, olderthan, max_num_branches=10,
+                                 dry_run=False):
     other_args = ''
     if dry_run:
         other_args = ' --dry-run'
+    num_branches=0
     for bi in branch_infos:
+        num_branches+=1
+        if num_branches > max_num_branches:
+            print '\n#\n# Stopping, reached maximum number of (unmerged) branches', \
+                  'to list (& "archive"): %d, out of %d older than %d days.\n#' % \
+                  (max_num_branches, len(branch_infos), olderthan)
+            return
         comment = make_comment(bi)
         tagname = "archive/" + bi['name']
         print
@@ -110,6 +140,8 @@ def make_archive_branches_script(branch_infos, dry_run):
             (bi['name'], tagname, bi['name'])
         print 'git push origin %s' % (tagname)
         print 'git push origin --delete %s %s' % (other_args, bi['name'])
+    print '\n#\n# Completed list of %d (unmerged) branches older than %d days, to be archived.\n#' \
+          % (num_branches, olderthan)
 
 if __name__ == "__main__":
 
@@ -126,17 +158,24 @@ if __name__ == "__main__":
                       help = "find branches that are not merged to master",
                       default = True)
     parser.add_option('--older', dest = 'olderthan', action = 'store',
-                      help = "age of unmerged branches to list",
+                      help = "the age, in days, of unmerged branches to list",
                       type="int", default = 60);
+    parser.add_option('--max-num-branches', dest = 'max_num_branches', action = 'store',
+                      help = "the maximum number of branches to list (and to remove, potentially)",
+                      type="int", default = 100);
+    parser.add_option('--release', dest = 'release', action = 'store',
+                      help = "a release branch for checking merges, e.g. 'origin/release-8.4.x'");
 
     (options,args) = parser.parse_args()
+    if not options.merged and (options.release != 'master' and options.release != None):
+        parser.error('Unmerged branches can only be checked against master.')
 
     if options.use_jira:
         user = options.username
         password = options.password or getpass.getpass('Enter your Jira password: ')
 
     #Get the branch list
-    branch_names = get_branch_list(options.merged)
+    branch_names = get_branch_list(options.merged, options.release)
     format_string = DELIMITER.join([gitshowmap[key] for key in sorted(gitshowmap)])
     #Iterate over it and get a bunch of commit information using git log
     branch_infos = []
@@ -162,11 +201,13 @@ if __name__ == "__main__":
 
     now = time.time()
 
-    sorted_branch_infos = sorted(branch_infos, reverse = True, key=lambda bi:bi['unixtime'])
+    sorted_branch_infos = sorted(branch_infos, key=lambda bi:bi['unixtime'])
     old_branch_infos = [bi for bi in sorted_branch_infos if (now - bi['unixtime']) > options.olderthan * 60* 60* 24]
 
     if options.merged:
-        make_delete_branches_script(old_branch_infos, dry_run=False)
+        make_delete_branches_script(old_branch_infos, options.olderthan,
+                                    options.max_num_branches, dry_run=False)
     else:
-        make_archive_branches_script(old_branch_infos, dry_run=False)
+        make_archive_branches_script(old_branch_infos, options.olderthan,
+                                     options.max_num_branches, dry_run=False)
 


### PR DESCRIPTION
Updated the tools/git-remove-branches-script.py script, to include a new
--max-num-branches= option (e.g. =10), to limit the number of branches
listed (and removed, potentially) in one run; and a new --release=
option (e.g. =origin/release-8.4.x), from Ruth's old
notest-better-branch-removal branch, which allows you to specify a
specific branch to which other branches were merged.