### PR TITLE
Eng 19204 post merge fix 2

### DIFF
--- a/src/frontend/org/voltdb/VoltZK.java
+++ b/src/frontend/org/voltdb/VoltZK.java
@@ -55,13 +55,14 @@ import com.google_voltpatches.common.collect.Sets;
 public class VoltZK {
 
     static final VoltLogger tmLog = new VoltLogger("TM");
-    private final static String ERROR_DECOMMISSION = "while decommissioning replicas is progress";
+    private final static String ERROR_DECOMMISSION = "while decommissioning replicas is in progress";
     private final static String ERROR_REDUCEDCLUSTERSAFETY = "while cluster is in reduced safety mode";
-    private final static String ERROR_REJOIN = "while node rejoin is progress";
-    private final static String ERROR_LEADER_MIGRATION = "while leader migration is progress";
-    private final static String ERROR_CATALOG_UPDATE = "while catalog update is progress";
-    private final static String ERROR_ELASTIC_OPERATION = "while elastic operation is progress";
+    private final static String ERROR_REJOIN = "while node rejoin is in progress";
+    private final static String ERROR_LEADER_MIGRATION = "while leader migration is in progress";
+    private final static String ERROR_CATALOG_UPDATE = "while catalog update is in progress";
+    private final static String ERROR_ELASTIC_OPERATION = "while elastic operation is in progress";
     private final static String ERROR_MP_REPAIR = "while leader promotion or transaction repair are in progress";
+    private final static String ERROR_LICENSE_UPDATE = "while live license update is in progress";
 
     public static final String root = "/db";
 
@@ -206,6 +207,9 @@ public class VoltZK {
     public static final String rejoinInProgress = actionBlockers + "/" + leafNodeRejoinInProgress;
     private static final String leafNodeCatalogUpdateInProgress = "uac_nt_blocker";
     public static final String catalogUpdateInProgress = actionBlockers + "/" + leafNodeCatalogUpdateInProgress;
+
+    private static final String leafNodeLicenseUpdateInProgress = "license_update_blocker";
+    public static final String licenseUpdateInProgress = actionBlockers + "/" + leafNodeLicenseUpdateInProgress;
 
     //register partition while the partition elects a new leader upon node failure
     private static final String mpRepairBlocker = "mp_repair_blocker";
@@ -512,6 +516,8 @@ public class VoltZK {
                     errorMsg = ERROR_DECOMMISSION;
                 } else if (blockers.contains(leafReducedClusterSafety)){
                     errorMsg = ERROR_REDUCEDCLUSTERSAFETY;
+                } else if (blockers.contains(leafNodeLicenseUpdateInProgress)) {
+                    errorMsg = ERROR_LICENSE_UPDATE;
                 }
                 break;
             case elasticOperationInProgress:
@@ -566,6 +572,11 @@ public class VoltZK {
             case snapshotSetupInProgress:
                 if (blockers.contains(decommissionReplicas)) {
                     errorMsg = ERROR_DECOMMISSION;
+                }
+                break;
+            case licenseUpdateInProgress:
+                if (blockers.contains(leafNodeRejoinInProgress)) {
+                    errorMsg = ERROR_REJOIN;
                 }
                 break;
             default:

--- a/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -74,7 +73,7 @@ public class UpdateLicense extends VoltNTSystemProcedure {
                 return constructFailureResponse(vt, "Invalid license format", tmpLicense);
             }
             // Has the new license expired already?
-            Date today = Calendar.getInstance().getTime();
+            Calendar today = Calendar.getInstance();
             if (newLicense.expires().before(today)) {
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
                 return constructFailureResponse(vt,

--- a/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateLicense.java
@@ -28,12 +28,15 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.zookeeper_voltpatches.CreateMode;
+import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.logging.VoltLogger;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltNTSystemProcedure;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltType;
+import org.voltdb.VoltZK;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.common.Constants;
 import org.voltdb.licensetool.LicenseApi;
@@ -172,26 +175,39 @@ public class UpdateLicense extends VoltNTSystemProcedure {
         log.info("Received user request to update database license.");
         VoltTable vt = constructResultTable();
 
-        // validate the new license on every host
-        Map<Integer, ClientResponse> result;
-        result = callNTProcedureOnAllHosts("@LicenseValidation", licenseBytes).get();
-        String err = checkResult(result);
-        if (err != null) {
-            vt.addRow(VoltSystemProcedure.STATUS_FAILURE, err);
+        final ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
+        String errMsg = VoltZK.createActionBlocker(zk, VoltZK.licenseUpdateInProgress, CreateMode.EPHEMERAL,
+                log, "live license update" );
+        if (errMsg != null) {
+            log.info(errMsg);
+            vt.addRow(VoltSystemProcedure.STATUS_FAILURE, errMsg);
             return new VoltTable[] { vt };
         }
 
-        // update the new license on every host
-        result = callNTProcedureOnAllHosts("@LiveLicenseUpdate").get();
-        err = checkResult(result);
-        if (err != null) {
-            vt.addRow(VoltSystemProcedure.STATUS_FAILURE, err);
-            return new VoltTable[] { vt };
-        }
+        try {
+            // validate the new license on every host
+            Map<Integer, ClientResponse> result;
+            result = callNTProcedureOnAllHosts("@LicenseValidation", licenseBytes).get();
+            String err = checkResult(result);
+            if (err != null) {
+                vt.addRow(VoltSystemProcedure.STATUS_FAILURE, err);
+                return new VoltTable[] { vt };
+            }
 
-        log.info("License updated successfully.");
-        vt.addRow(VoltSystemProcedure.STATUS_OK, "SUCCESS");
-        return new VoltTable[] { vt };
+            // update the new license on every host
+            result = callNTProcedureOnAllHosts("@LiveLicenseUpdate").get();
+            err = checkResult(result);
+            if (err != null) {
+                vt.addRow(VoltSystemProcedure.STATUS_FAILURE, err);
+                return new VoltTable[] { vt };
+            }
+
+            log.info("License updated successfully.");
+            vt.addRow(VoltSystemProcedure.STATUS_OK, "SUCCESS");
+            return new VoltTable[] { vt };
+        } finally {
+            VoltZK.removeActionBlocker(zk, VoltZK.licenseUpdateInProgress, log);
+        }
 
     }
 }

--- a/src/frontend/org/voltdb/utils/MiscUtils.java
+++ b/src/frontend/org/voltdb/utils/MiscUtils.java
@@ -277,8 +277,6 @@ public class MiscUtils {
             return null;
         }
 
-        hostLog.info("Found VoltDB license file at path: " + pathToLicense);
-
         // Initialize the API. This parses the file but does NOT verify signatures.
         if (licenseApi.initializeFromFile(licenseFile) == false) {
             hostLog.fatal("Unable to load license file: could not parse license.");


### PR DESCRIPTION
Fix an issue that in some cases license file is staged on top of itself. For example, `voltdb init` staged license.xml, `voltdb start` found the license in voltdbroot, it doesn't need to stage it again.

Fix a race condition as @zeemanhe mentioned when live license update coexists with node rejoin, now two operations are mutually exclusive.

Test case update: https://github.com/VoltDB/pro/pull/3181