### PR TITLE
ENG-19226:

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/Shutdown.java
+++ b/src/frontend/org/voltdb/sysprocs/Shutdown.java
@@ -42,17 +42,36 @@ import org.voltdb.VoltType;
  */
 public class Shutdown extends VoltSystemProcedure {
 
+    static void shutdownWork() {
+        VoltLogger voltLogger = new VoltLogger("HOST");
+        String msg = "VoltDB shutting down as requested by @Shutdown command.";
+        CoreUtils.printAsciiArtLog(voltLogger, msg, Level.INFO);
+        if (VoltDB.instanceOnServerThread()) {
+            // Using shutdown from the localServerThread requires
+            // the statics to be reinitialized for their next use
+            m_failsafeArmed = new AtomicBoolean(false);
+            m_failsafe = new Thread() {
+                @Override
+                public void run() {
+                    delayedShutdownWork();
+                }
+            };
+        }
+        System.exit(0);
+    }
+
+    static void delayedShutdownWork() {
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {}
+        shutdownWork();
+    }
+
     private static AtomicBoolean m_failsafeArmed = new AtomicBoolean(false);
     private static Thread m_failsafe = new Thread() {
         @Override
         public void run() {
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException e) {}
-            VoltLogger voltLogger = new VoltLogger("HOST");
-            String msg = "VoltDB shutting down as requested by @Shutdown command.";
-            CoreUtils.printAsciiArtLog(voltLogger, msg, Level.INFO);
-            System.exit(0);
+            delayedShutdownWork();
         }
     };
 
@@ -75,7 +94,6 @@ public class Shutdown extends VoltSystemProcedure {
         if (fragmentId == SysProcFragmentId.PF_shutdownSync) {
             VoltDB.instance().getHostMessenger().prepareForShutdown();
             // If this is executed on the LocalServerThread, the static will cause problems for subsequent tests.
-            assert(!VoltDB.instanceOnServerThread());
             if (!m_failsafeArmed.getAndSet(true)) {
                 m_failsafe.start();
                 VoltLogger voltLogger = new VoltLogger("HOST");
@@ -102,10 +120,7 @@ public class Shutdown extends VoltSystemProcedure {
                                 e);
                     }
                     if (die) {
-                        VoltLogger voltLogger = new VoltLogger("HOST");
-                        String msg = "VoltDB shutting down as requested by @Shutdown command.";
-                        CoreUtils.printAsciiArtLog(voltLogger, msg, Level.INFO);
-                        System.exit(0);
+                        shutdownWork();
                     }
                     else {
                         try {

--- a/tests/frontend/org/voltdb/TestMidRejoinDeath.java
+++ b/tests/frontend/org/voltdb/TestMidRejoinDeath.java
@@ -55,7 +55,10 @@ public class TestMidRejoinDeath extends RejoinTestBase {
             boolean success = cluster.compile(builder);
             assertTrue(success);
             MiscUtils.copyFile(builder.getPathToDeployment(), Configuration.getPathToCatalogForTest("rejoin.xml"));
-            cluster.setHasLocalServer(false);
+
+            // WARNING: This may never be set to true or it will trigger an assert in StreamSnapshotDataTarget
+            final boolean DONT_USE_LOCAL_SERVER_THREAD = false;
+            cluster.setHasLocalServer(DONT_USE_LOCAL_SERVER_THREAD);
 
             cluster.startUp();
 


### PR DESCRIPTION
As part of the Junit Singleton Isolation branch, an assert was added to verify that Shutdown (which has it's own singletons) was never called from ServerLocalThread. However, some Junit tests do call it which means that for those tests, the Shutdown Singletons need to be reinitialized before Shutdown completes.