### PR TITLE
ENG-19599: Only deserialize DR trackers for recover

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotRestore.java
@@ -1763,11 +1763,10 @@ public class SnapshotRestore extends VoltSystemProcedure {
                 }
 
                 /*
-                 * Extract last seen unique ids from remote data centers into a map
-                 * for each DC and return in the result. This will merge and return
-                 * the largest ID for each DC and partition
+                 * For recover, extract last seen unique ids from remote data centers into a map for each DC and return
+                 * in the result. This will merge and return the largest ID for each DC and partition
                  */
-                if (digest.has("drMixedClusterSizeConsumerState")) {
+                if (isRecover && digest.has("drMixedClusterSizeConsumerState")) {
                     JSONObject consumerPartitions = digest.getJSONObject("drMixedClusterSizeConsumerState");
                     Iterator<String> cpKeys = consumerPartitions.keys();
                     while (cpKeys.hasNext()) {


### PR DESCRIPTION
[ backport 7e47d30300aa8a8d6eadbfd9e2857ff90bc7c7e1 ]

DRConsumerDrIdTracker only are used during recover so do not try to
deserialize DRConsumerDrIdTracker for restore.