### PR TITLE
ENG-19646: Always visit all chunks

### DIFF
--- a/src/frontend/org/voltdb/ClientResponseImpl.java
+++ b/src/frontend/org/voltdb/ClientResponseImpl.java
@@ -26,7 +26,6 @@ import org.json_voltpatches.JSONString;
 import org.json_voltpatches.JSONStringer;
 import org.voltcore.utils.Pair;
 import org.voltdb.client.ClientResponse;
-import org.voltdb.client.ClientUtils;
 import org.voltdb.common.Constants;
 import org.voltdb.utils.SerializationHelper;
 
@@ -374,22 +373,6 @@ public class ClientResponseImpl implements ClientResponse, JSONString {
             throw new RuntimeException("Failed to serialize a parameter set to JSON.", e);
         }
         return js.toString();
-    }
-
-    /**
-     * @return MD5 hash as int of the tables in the result. Only hashes first bits of big results.
-     */
-    public int getHashOfTableResults() {
-        try {
-            long cheesyChecksum = 0;
-            for (int i = 0; i < results.length; ++i) {
-                cheesyChecksum += ClientUtils.cheesyBufferCheckSum(results[i].m_buffer);
-            }
-            return (int)cheesyChecksum;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return 0;
-        }
     }
 
     public void dropResultTable() {

--- a/src/frontend/org/voltdb/client/ClientUtils.java
+++ b/src/frontend/org/voltdb/client/ClientUtils.java
@@ -20,7 +20,6 @@ package org.voltdb.client;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * Helper methods duplicated from MiscUtils to avoid linking with
@@ -28,57 +27,6 @@ import java.nio.ByteBuffer;
  *
  */
 public class ClientUtils {
-
-    /**
-     * I heart commutativity
-     * @param buffer ByteBuffer assumed position is at end of data
-     * @return the cheesy checksum of this VoltTable
-     */
-    public static final long cheesyBufferCheckSum(ByteBuffer buffer) {
-        return cheesyBufferCheckSum(buffer, false);
-    }
-    public static final long cheesyBufferCheckSum(ByteBuffer buffer, boolean skipHeader) {
-        final int mypos = buffer.position();
-        // row data start at buffer.getInt(0) + 4, with first 4 bit as row count
-        int startPosition = skipHeader ? buffer.getInt(0) + 8 : 0;
-        buffer.position(startPosition);
-        long checksum = 0;
-        if (buffer.hasArray()) {
-            final byte bytes[] = buffer.array();
-            final int end = buffer.arrayOffset() + mypos - startPosition;
-            for (int ii = buffer.arrayOffset(); ii < end; ii++) {
-                checksum += bytes[ii];
-            }
-        } else {
-            for (int ii = startPosition; ii < mypos; ii++) {
-                checksum += buffer.get();
-            }
-        }
-        buffer.position(mypos);
-        return checksum;
-    }
-
-    // rolling checksum with both position and value as input
-    // TODO: explore CRC or farmHash for more accurate checksum
-    public static final long cheesyBufferCheckSumWithOrder(ByteBuffer buffer) {
-        final int mypos = buffer.position();
-        buffer.position(0);
-        long checksum = 0;
-        if (buffer.hasArray()) {
-            final byte bytes[] = buffer.array();
-            final int end = buffer.arrayOffset() + mypos;
-            for (int ii = buffer.arrayOffset(); ii < end; ii++) {
-                checksum += bytes[ii] * (1+ii);
-            }
-        } else {
-            for (int ii = 0; ii < mypos; ii++) {
-                checksum += buffer.get() * (1+ii);
-            }
-        }
-        buffer.position(mypos);
-        return checksum;
-    }
-
     /**
      * Serialize a file into bytes. Used to serialize catalog and deployment
      * file for UpdateApplicationCatalog on the client.

--- a/src/frontend/org/voltdb/utils/SnapshotComparer.java
+++ b/src/frontend/org/voltdb/utils/SnapshotComparer.java
@@ -578,7 +578,7 @@ class SnapshotLoader {
                                     new FileInputStream(partitionToFiles.get(p).get(target)), 1, relevantPartition)) {
                         DBBPool.BBContainer cr = null, cc = null;
 
-                        while (referenceSaveFile.hasMoreChunks() && compareSaveFile.hasMoreChunks()) {
+                        while (referenceSaveFile.hasMoreChunks() || compareSaveFile.hasMoreChunks()) {
                             // skip chunk for irrelevant partition
                             cr = referenceSaveFile.getNextChunk();
                             cc = compareSaveFile.getNextChunk();
@@ -587,45 +587,57 @@ class SnapshotLoader {
                                 break;
                             }
                             try {
-                                // TODO: chunk not aligned?
-                                if (cr != null && cc == null) {
-                                    System.err.println("Reference file still contain chunks while comparing file does not");
-                                    break;
-                                }
-                                if (cr == null && cc != null) {
-                                    System.err.println("Comparing file still contain chunks while reference file does not");
-                                    break;
-                                }
-
-                                final VoltTable tr = PrivateVoltTableFactory.createVoltTableFromBuffer(cr.b(), true);
-                                final VoltTable tc = PrivateVoltTableFactory.createVoltTableFromBuffer(cc.b(), true);
                                 if (orderLevel >= 2) {
-                                    refCheckSum += tr.getTableCheckSum();
-                                    compCheckSum += tc.getTableCheckSum();
+                                    if (cr != null) {
+                                        refCheckSum += PrivateVoltTableFactory.createVoltTableFromBuffer(cr.b(), true)
+                                                .getTableCheckSum();
+                                    }
+                                    if (cc != null) {
+                                        compCheckSum += PrivateVoltTableFactory.createVoltTableFromBuffer(cc.b(), true)
+                                                .getTableCheckSum();
+                                    }
                                     if (CONSOLE_LOG.isDebugEnabled()) {
                                         CONSOLE_LOG.debug("Checksum for " + tableName + " partition " + partitionid + " on host" + baseHostId + " is " + refCheckSum + " on host" + compareHostId + " is " + compCheckSum);
                                     }
-                                } else if (!tr.hasSameContents(tc, orderLevel == 1)) {
-                                    // seek to find where discrepancy happened
-                                    if (SNAPSHOT_LOG.isDebugEnabled()) {
-                                        SNAPSHOT_LOG.debug(
-                                                "table from file: " + partitionToFiles.get(p).get(0) + " : " + tr);
-                                        SNAPSHOT_LOG.debug(
-                                                "table from file: " + partitionToFiles.get(p).get(target) + " : " + tc);
+                                } else {
+                                    if (cr != null && cc == null) {
+                                        System.err.println(
+                                                "Reference file still contains chunks while comparing file does not");
+                                        break;
+                                    }
+                                    if (cr == null && cc != null) {
+                                        System.err.println(
+                                                "Comparing file still contains chunks while reference file does not");
+                                        break;
                                     }
 
-                                    int trSize = tr.getRowCount(), tcSize = tc.getRowCount();
-                                    int[][] lookup = new int[trSize + 1][tcSize + 1];
-                                    // fill lookup table
-                                    lcsLength(tr, tc, trSize, tcSize, lookup);
-                                    // find difference
-                                    StringBuilder output = new StringBuilder().append("Diffs between file ")
-                                            .append(partitionToFiles.get(p).get(0)).append(" and file ")
-                                            .append(partitionToFiles.get(p).get(target)).append(" \n");
-                                    diff(tr, tc, trSize, tcSize, lookup, output);
-                                    CONSOLE_LOG.info(output.toString());
-                                    isConsistent = false;
-                                    break;
+                                    final VoltTable tr = PrivateVoltTableFactory.createVoltTableFromBuffer(cr.b(),
+                                            true);
+                                    final VoltTable tc = PrivateVoltTableFactory.createVoltTableFromBuffer(cc.b(),
+                                            true);
+
+                                    if (!tr.hasSameContents(tc, orderLevel == 1)) {
+                                        // seek to find where discrepancy happened
+                                        if (SNAPSHOT_LOG.isDebugEnabled()) {
+                                            SNAPSHOT_LOG.debug(
+                                                    "table from file: " + partitionToFiles.get(p).get(0) + " : " + tr);
+                                            SNAPSHOT_LOG.debug("table from file: " + partitionToFiles.get(p).get(target)
+                                                    + " : " + tc);
+                                        }
+
+                                        int trSize = tr.getRowCount(), tcSize = tc.getRowCount();
+                                        int[][] lookup = new int[trSize + 1][tcSize + 1];
+                                        // fill lookup table
+                                        lcsLength(tr, tc, trSize, tcSize, lookup);
+                                        // find difference
+                                        StringBuilder output = new StringBuilder().append("Diffs between file ")
+                                                .append(partitionToFiles.get(p).get(0)).append(" and file ")
+                                                .append(partitionToFiles.get(p).get(target)).append(" \n");
+                                        diff(tr, tc, trSize, tcSize, lookup, output);
+                                        CONSOLE_LOG.info(output.toString());
+                                        isConsistent = false;
+                                        break;
+                                    }
                                 }
                             } catch (Exception e) {
                                 e.printStackTrace();

--- a/src/frontend/org/voltdb/utils/SnapshotComparer.java
+++ b/src/frontend/org/voltdb/utils/SnapshotComparer.java
@@ -607,11 +607,11 @@ class SnapshotLoader {
                                 if (orderLevel >= 2) {
                                     if (cr != null) {
                                         refCheckSum += PrivateVoltTableFactory.createVoltTableFromBuffer(cr.b(), true)
-                                                .getTableCheckSum();
+                                                .getTableCheckSum(false);
                                     }
                                     if (cc != null) {
                                         compCheckSum += PrivateVoltTableFactory.createVoltTableFromBuffer(cc.b(), true)
-                                                .getTableCheckSum();
+                                                .getTableCheckSum(false);
                                     }
                                     if (CONSOLE_LOG.isDebugEnabled()) {
                                         CONSOLE_LOG.debug("Checksum for " + tableName + " partition " + partitionid

--- a/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
+++ b/tests/frontend/org/voltdb/test/utils/RandomTestRule.java
@@ -74,8 +74,12 @@ public class RandomTestRule extends Random implements TestRule {
 
     @Override
     public Statement apply(Statement base, Description description) {
-        m_name = description.getDisplayName();
+        setMethodName(description.getDisplayName());
         return base;
+    }
+
+    public void setMethodName(String name) {
+        m_name = name;
     }
 
     @Override


### PR DESCRIPTION
Make sure all chunks are visited so that in order mode 0 or 1 the
difference is always noticed or in 2 and greater all chunks are included
in the hash.

Use a single checksum algorithm which calculates a crc for each row and
the header and adds them together. This is a more robust checksum
mechanism than just adding the bytes together. Also, if performing an
exact comparison between tables just compare the buffers of the two
tables.