### PR TITLE
Snapshotsummary more fixes

### DIFF
--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -42,7 +42,8 @@ public class SnapshotStatus extends StatsSource {
     enum SNAPSHOT_TYPE {
         AUTO,
         MANUAL,
-        COMMANDLOG
+        COMMANDLOG,
+        REJOIN;
     };
 
     static class SnapshotTypeChecker {
@@ -61,6 +62,9 @@ public class SnapshotStatus extends StatsSource {
             }
             else if (m_autoSnapshotPath.equals(thisSnapshotPath)) {
                 return SNAPSHOT_TYPE.AUTO.name();
+            }
+            else if (path.startsWith("Rejoin")) {
+                return SNAPSHOT_TYPE.REJOIN.name();
             }
             return SNAPSHOT_TYPE.MANUAL.name();
         }

--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -39,11 +39,12 @@ public class SnapshotStatus extends StatsSource {
         SUCCESS;
     }
 
-    enum SNAPSHOT_TYPE {
+    enum SnapshotType {
         AUTO,
         MANUAL,
         COMMANDLOG,
-        REJOIN;
+        REJOIN,
+        ELASTIC;
     };
 
     static class SnapshotTypeChecker {
@@ -55,18 +56,20 @@ public class SnapshotStatus extends StatsSource {
             m_autoSnapshotPath = new File(autoSnapshotPathStr);
         }
 
-        String getSnapshotType(String path) {
+        SnapshotType getSnapshotType(String path, String nonce) {
             File thisSnapshotPath = new File(path);
             if (m_truncationSnapshotPath.equals(thisSnapshotPath)) {
-                return SNAPSHOT_TYPE.COMMANDLOG.name();
+                if (nonce.startsWith("JOIN")) {
+                    return SnapshotType.ELASTIC;
+                } else {
+                    return SnapshotType.COMMANDLOG;
+                }
+            } else if (m_autoSnapshotPath.equals(thisSnapshotPath)) {
+                return SnapshotType.AUTO;
+            } else if (path.equals("") && nonce.startsWith("Rejoin")) {
+                return SnapshotType.REJOIN;
             }
-            else if (m_autoSnapshotPath.equals(thisSnapshotPath)) {
-                return SNAPSHOT_TYPE.AUTO.name();
-            }
-            else if (path.startsWith("Rejoin")) {
-                return SNAPSHOT_TYPE.REJOIN.name();
-            }
-            return SNAPSHOT_TYPE.MANUAL.name();
+            return SnapshotType.MANUAL;
         }
     }
     SnapshotTypeChecker m_typeChecker = new SnapshotTypeChecker();
@@ -166,7 +169,7 @@ public class SnapshotStatus extends StatsSource {
             result = t.error == null ? SnapshotResult.SUCCESS.toString() : SnapshotResult.FAILURE.toString();
         }
         rowValues[columnNameToIndex.get("RESULT")] = result;
-        rowValues[columnNameToIndex.get("TYPE")] = m_typeChecker.getSnapshotType(s.path);
+        rowValues[columnNameToIndex.get("TYPE")] = m_typeChecker.getSnapshotType(s.path, s.nonce).name();
         super.updateStatsRow(rowKey, rowValues);
     }
 

--- a/src/frontend/org/voltdb/SnapshotSummary.java
+++ b/src/frontend/org/voltdb/SnapshotSummary.java
@@ -72,9 +72,9 @@ public class SnapshotSummary extends StatsSource {
         Map<String, List<StatsRow>> snapshotMap = new TreeMap<>();
         perHostStats.resetRowPosition();
         while (perHostStats.advanceRow()) {
-            String nonce = perHostStats.getString(ColumnName.NONCE.toString());
-            String result = perHostStats.getString(ColumnName.RESULT.toString());
-            float progressPct = (float)perHostStats.getDouble(ColumnName.PROGRESS_PCT.toString());
+            String nonce = perHostStats.getString(ColumnName.NONCE.name());
+            String result = perHostStats.getString(ColumnName.RESULT.name());
+            float progressPct = (float)perHostStats.getDouble(ColumnName.PROGRESS_PCT.name());
             List<StatsRow> statsRows = snapshotMap.get(nonce);
             if (statsRows == null) {
                 statsRows = new ArrayList<StatsRow>();
@@ -98,11 +98,11 @@ public class SnapshotSummary extends StatsSource {
                 avgProgress += row.progressPct;
                 sr = SnapshotResult.valueOf(row.result);
                 lowestOrdinal = Math.min(sr.ordinal(), lowestOrdinal);
-                long tmpStartTime = row.statsRow.getLong(ColumnName.START_TIME.toString());
+                long tmpStartTime = row.statsRow.getLong(ColumnName.START_TIME.name());
                 if (tmpStartTime < startTime) {
                     startTime = tmpStartTime;
                 }
-                long tmpEndTime = row.statsRow.getLong(ColumnName.END_TIME.toString());
+                long tmpEndTime = row.statsRow.getLong(ColumnName.END_TIME.name());
                 if (tmpEndTime > endTime) {
                     endTime = tmpEndTime;
                 }
@@ -112,28 +112,28 @@ public class SnapshotSummary extends StatsSource {
             if (endTime != 0) {
                 duration = (endTime - startTime) / 1000.0; // in seconds
             }
-            resultTable.addRow(lastRow.statsRow.getString(ColumnName.NONCE.toString()),
-                    lastRow.statsRow.getLong(ColumnName.TXNID.toString()),
-                    lastRow.statsRow.getString(ColumnName.TYPE.toString()),
+            resultTable.addRow(lastRow.statsRow.getString(ColumnName.NONCE.name()),
+                    lastRow.statsRow.getLong(ColumnName.TXNID.name()),
+                    lastRow.statsRow.getString(ColumnName.TYPE.name()),
                     startTime,
                     endTime,
                     duration,
                     Math.round(avgProgress * 10.0) / 10.0, // round to 1 decimal places
-                    SnapshotResult.values()[lowestOrdinal].toString());
+                    SnapshotResult.values()[lowestOrdinal].name());
         }
         return new VoltTable[] { resultTable };
     }
 
     @Override
     protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
-        columns.add(new ColumnInfo(ColumnName.NONCE.toString(), VoltType.STRING));
-        columns.add(new ColumnInfo(ColumnName.TXNID.toString(), VoltType.BIGINT));
-        columns.add(new ColumnInfo(ColumnName.TYPE.toString(), VoltType.STRING));
-        columns.add(new ColumnInfo(ColumnName.START_TIME.toString(), VoltType.BIGINT));
-        columns.add(new ColumnInfo(ColumnName.END_TIME.toString(), VoltType.BIGINT));
-        columns.add(new ColumnInfo(ColumnName.DURATION.toString(), VoltType.BIGINT));
-        columns.add(new ColumnInfo(ColumnName.PROGRESS_PCT.toString(), VoltType.FLOAT));
-        columns.add(new ColumnInfo(ColumnName.RESULT.toString(), VoltType.STRING));
+        columns.add(new ColumnInfo(ColumnName.NONCE.name(), VoltType.STRING));
+        columns.add(new ColumnInfo(ColumnName.TXNID.name(), VoltType.BIGINT));
+        columns.add(new ColumnInfo(ColumnName.TYPE.name(), VoltType.STRING));
+        columns.add(new ColumnInfo(ColumnName.START_TIME.name(), VoltType.BIGINT));
+        columns.add(new ColumnInfo(ColumnName.END_TIME.name(), VoltType.BIGINT));
+        columns.add(new ColumnInfo(ColumnName.DURATION.name(), VoltType.BIGINT));
+        columns.add(new ColumnInfo(ColumnName.PROGRESS_PCT.name(), VoltType.FLOAT));
+        columns.add(new ColumnInfo(ColumnName.RESULT.name(), VoltType.STRING));
     }
 
     @SuppressWarnings("unchecked")
@@ -143,13 +143,13 @@ public class SnapshotSummary extends StatsSource {
         Snapshot s = p.getFirst();
         SnapshotResult sr = p.getSecond();
 
-        rowValues[columnNameToIndex.get(ColumnName.NONCE.toString())] = s.nonce;
-        rowValues[columnNameToIndex.get(ColumnName.TXNID.toString())] = s.txnId;
-        rowValues[columnNameToIndex.get(ColumnName.TYPE.toString())] = m_typeChecker.getSnapshotType(s.path);
-        rowValues[columnNameToIndex.get(ColumnName.START_TIME.toString())] = s.timeStarted;
-        rowValues[columnNameToIndex.get(ColumnName.END_TIME.toString())] = s.timeFinished;
-        rowValues[columnNameToIndex.get(ColumnName.PROGRESS_PCT.toString())] = (float)s.progress();
-        rowValues[columnNameToIndex.get(ColumnName.RESULT.toString())] = sr.toString();
+        rowValues[columnNameToIndex.get(ColumnName.NONCE.name())] = s.nonce;
+        rowValues[columnNameToIndex.get(ColumnName.TXNID.name())] = s.txnId;
+        rowValues[columnNameToIndex.get(ColumnName.TYPE.name())] = m_typeChecker.getSnapshotType(s.path);
+        rowValues[columnNameToIndex.get(ColumnName.START_TIME.name())] = s.timeStarted;
+        rowValues[columnNameToIndex.get(ColumnName.END_TIME.name())] = s.timeFinished;
+        rowValues[columnNameToIndex.get(ColumnName.PROGRESS_PCT.name())] = (float)s.progress();
+        rowValues[columnNameToIndex.get(ColumnName.RESULT.name())] = sr.name();
     }
 
     @Override

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -102,6 +102,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
 
     int m_blockIndex = 0;
     private final AtomicReference<Runnable> m_onCloseHandler = new AtomicReference<Runnable>(null);
+    private Runnable m_progressHandler = null;
 
     private final AtomicBoolean m_closed = new AtomicBoolean(false);
 
@@ -770,9 +771,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         return m_schemas.get(tableId).getSecond();
     }
 
-    // No in use
-    public void setInProgressHandler(Runnable inProgress) {}
+    public void setInProgressHandler(Runnable handler) {
+        m_progressHandler = handler;
+    }
 
-    // No need to track stream snapshot progress
-    public void trackProgress() {}
+    public void trackProgress() {
+        m_progressHandler.run();
+    }
 }

--- a/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/IndexSnapshotWritePlan.java
@@ -143,7 +143,7 @@ public class IndexSnapshotWritePlan extends SnapshotWritePlan<IndexSnapshotReque
         // create a null data target
         final DevNullSnapshotTarget dataTarget = new DevNullSnapshotTarget();
         final Runnable onClose = new TargetStatsClosure(dataTarget,
-                table.getName(),
+                                                        Arrays.asList(table.getName()),
                                                         numTables,
                                                         snapshotRecord);
         dataTarget.setOnCloseHandler(onClose);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/NativeSnapshotWritePlan.java
@@ -20,6 +20,7 @@ package org.voltdb.sysprocs.saverestore;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -303,7 +304,7 @@ public class NativeSnapshotWritePlan extends SnapshotWritePlan<SnapshotRequestCo
                 timestamp);
 
         m_targets.add(sdt);
-        final Runnable onClose = new TargetStatsClosure(sdt, table.getName(), numTables, snapshotRecord);
+        final Runnable onClose = new TargetStatsClosure(sdt, Arrays.asList(table.getName()), numTables, snapshotRecord);
         sdt.setOnCloseHandler(onClose);
         final Runnable inProgress = new TargetStatsProgress(snapshotRecord);
         sdt.setInProgressHandler(inProgress);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
@@ -100,16 +100,15 @@ public abstract class SnapshotWritePlan<C extends SnapshotRequestConfig>
         public void run() {
             for (String tableName : m_tableNames) {
                 m_snapshotRecord.updateTable(tableName,
-                        new SnapshotRegistry.Snapshot.TableUpdater() {
-                            @Override
-                            public SnapshotRegistry.Snapshot.Table update(
-                                SnapshotRegistry.Snapshot.Table registryTable) {
-                                return m_snapshotRecord.new Table(
-                                    registryTable,
-                                    m_sdt.getBytesWritten(), /* number is bloated for stream snapshot target */
-                                    m_sdt.getLastWriteException());
-                                }
-                        });
+                    new SnapshotRegistry.Snapshot.TableUpdater() {
+                        @Override
+                        public SnapshotRegistry.Snapshot.Table update(SnapshotRegistry.Snapshot.Table registryTable) {
+                            return m_snapshotRecord.new Table(
+                                registryTable,
+                                m_sdt.getBytesWritten(), /* Bytes written is shared between multiple stream snapshot tables */
+                                m_sdt.getLastWriteException());
+                            }
+                    });
                 int tablesLeft = m_numTables.decrementAndGet();
                 if (tablesLeft == 0) {
                     final SnapshotRegistry.Snapshot completed =

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
@@ -19,6 +19,7 @@ package org.voltdb.sysprocs.saverestore;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
@@ -80,44 +81,46 @@ public abstract class SnapshotWritePlan<C extends SnapshotRequestConfig>
 
     static class TargetStatsClosure implements Runnable
     {
-        final private String m_tableName;
+        final private List<String> m_tableNames;
         final private SnapshotDataTarget m_sdt;
         final private AtomicInteger m_numTables;
         final private SnapshotRegistry.Snapshot m_snapshotRecord;
 
-        TargetStatsClosure(SnapshotDataTarget sdt, String tableName,
+        TargetStatsClosure(SnapshotDataTarget sdt, List<String> tableNames,
                 AtomicInteger numTables,
                 SnapshotRegistry.Snapshot snapshotRecord)
         {
             m_sdt = sdt;
-            m_tableName = tableName;
+            m_tableNames = tableNames;
             m_numTables = numTables;
             m_snapshotRecord = snapshotRecord;
         }
 
         @Override
         public void run() {
-            m_snapshotRecord.updateTable(m_tableName,
-                    new SnapshotRegistry.Snapshot.TableUpdater() {
-                        @Override
-                        public SnapshotRegistry.Snapshot.Table update(
-                            SnapshotRegistry.Snapshot.Table registryTable) {
-                            return m_snapshotRecord.new Table(
-                                registryTable,
-                                m_sdt.getBytesWritten(),
-                                m_sdt.getLastWriteException());
-                            }
-                    });
-            int tablesLeft = m_numTables.decrementAndGet();
-            if (tablesLeft == 0) {
-                final SnapshotRegistry.Snapshot completed =
-                    SnapshotRegistry.finishSnapshot(m_snapshotRecord);
-                final double duration =
-                    (completed.timeFinished - completed.timeStarted) / 1000.0;
-                SNAP_LOG.info(
-                        "Snapshot " + m_snapshotRecord.nonce + " finished at " +
-                        completed.timeFinished + " and took " + duration
-                        + " seconds ");
+            for (String tableName : m_tableNames) {
+                m_snapshotRecord.updateTable(tableName,
+                        new SnapshotRegistry.Snapshot.TableUpdater() {
+                            @Override
+                            public SnapshotRegistry.Snapshot.Table update(
+                                SnapshotRegistry.Snapshot.Table registryTable) {
+                                return m_snapshotRecord.new Table(
+                                    registryTable,
+                                    m_sdt.getBytesWritten(), /* number is bloated for stream snapshot target */
+                                    m_sdt.getLastWriteException());
+                                }
+                        });
+                int tablesLeft = m_numTables.decrementAndGet();
+                if (tablesLeft == 0) {
+                    final SnapshotRegistry.Snapshot completed =
+                        SnapshotRegistry.finishSnapshot(m_snapshotRecord);
+                    final double duration =
+                        (completed.timeFinished - completed.timeStarted) / 1000.0;
+                    SNAP_LOG.info(
+                            "Snapshot " + m_snapshotRecord.nonce + " finished at " +
+                            completed.timeFinished + " and took " + duration
+                            + " seconds ");
+                }
             }
         }
     }
@@ -209,7 +212,7 @@ public abstract class SnapshotWritePlan<C extends SnapshotRequestConfig>
                 if (target == null) {
                     target = new DevNullSnapshotTarget(lastWriteException);
                     final Runnable onClose = new TargetStatsClosure(target,
-                            task.m_tableInfo.getName(),
+                            Arrays.asList(task.m_tableInfo.getName()),
                             numTargets,
                             m_snapshotRecord);
                     target.setOnCloseHandler(onClose);

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -29,12 +29,14 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.json_voltpatches.JSONObject;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
 import org.voltdb.ExtensibleSnapshotDigestData;
 import org.voltdb.SnapshotDataFilter;
+import org.voltdb.SnapshotDataTarget;
 import org.voltdb.SnapshotFormat;
 import org.voltdb.SnapshotSiteProcessor;
 import org.voltdb.SnapshotTableInfo;
@@ -117,7 +119,6 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
         }
 
         // Mark snapshot start in registry
-        final AtomicInteger numTables = new AtomicInteger(m_config.tables.size());
         m_snapshotRecord =
             SnapshotRegistry.startSnapshot(
                     txnId,
@@ -135,10 +136,19 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
         // For each table, create tasks where each task has a data target.
         // reset siteId to 0 for placing replicated Task from site 0
         m_siteIndex = 0;
+        int totalTaskNum = 0;
+        Multimap<DataTargetInfo, SnapshotTableTask> tasks = ArrayListMultimap.create();
         for (final SnapshotTableInfo table : m_config.tables) {
-            createTasksForTable(table, sdts, numTables, m_snapshotRecord, tracker.getSitesForHost(context.getHostId()));
+            List<Long> hsIds = tracker.getSitesForHost(context.getHostId());
+            createTasksForTable(table, sdts, hsIds, tasks);
+            // Replicated table tasks are placed on the lowest site,
+            // partitioned table tasks are placed on every site.
+            totalTaskNum += table.isReplicated() ? 1 : hsIds.size();
             result.addRow(context.getHostId(), CoreUtils.getHostnameOrAddress(), table.getName(), "SUCCESS", "");
         }
+
+        // Register stats close handler and progress tracker
+        registerOnCloseHandler(tasks, m_snapshotRecord, totalTaskNum);
 
         return deferredSetup;
     }
@@ -289,15 +299,7 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
     }
 
     private SnapshotTableTask createSingleTableTask(SnapshotTableInfo table,
-                                                    DataTargetInfo targetInfo,
-                                                    AtomicInteger numTables,
-                                                    SnapshotRegistry.Snapshot snapshotRecord) {
-        final Runnable onClose = new TargetStatsClosure(targetInfo.dataTarget,
-                table.getName(),
-                numTables,
-                snapshotRecord);
-        targetInfo.dataTarget.setOnCloseHandler(onClose);
-
+                                                    DataTargetInfo targetInfo) {
         final SnapshotTableTask task =
                 new SnapshotTableTask(table,
                                       new SnapshotDataFilter[0], // This task no longer needs partition filtering
@@ -313,12 +315,11 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
      */
     private void createTasksForTable(SnapshotTableInfo table,
                                      List<DataTargetInfo> dataTargets,
-                                     AtomicInteger numTables,
-                                     SnapshotRegistry.Snapshot snapshotRecord,
-                                     List<Long> hsids)
+                                     List<Long> hsids,
+                                     Multimap<DataTargetInfo, SnapshotTableTask> taskTables)
     {
         // srcHSId -> tasks
-        Multimap<Long, SnapshotTableTask> tasks = ArrayListMultimap.create();
+        Multimap<DataTargetInfo, SnapshotTableTask> tasks = ArrayListMultimap.create();
         for (DataTargetInfo targetInfo : dataTargets) {
             if (table.isReplicated() && !targetInfo.dataTarget.isReplicatedTableTarget()) {
                 // For replicated tables only the lowest site's dataTarget actually does any work.
@@ -326,27 +327,45 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
                 m_targets.add(targetInfo.dataTarget);
                 continue;
             }
-            final SnapshotTableTask task = createSingleTableTask(table, targetInfo, numTables, snapshotRecord);
-
+            final SnapshotTableTask task = createSingleTableTask(table, targetInfo);
             SNAP_LOG.debug("ADDING TASK for streamSnapshot: " + task);
-            tasks.put(targetInfo.srcHSId, task);
+            tasks.put(targetInfo, task);
         }
 
         placeTasksForTable(table, tasks, hsids);
+        taskTables.putAll(tasks);
     }
 
-    private void placeTasksForTable(SnapshotTableInfo table, Multimap<Long, SnapshotTableTask> tasks,
+    private void placeTasksForTable(SnapshotTableInfo table, Multimap<DataTargetInfo, SnapshotTableTask> tasks,
             List<Long> hsids)
     {
-        for (Entry<Long, Collection<SnapshotTableTask>> tasksEntry : tasks.asMap().entrySet()) {
+        for (Entry<DataTargetInfo, Collection<SnapshotTableTask>> tasksEntry : tasks.asMap().entrySet()) {
             // Stream snapshots need to write all partitioned tables to all selected partitions
             // and all replicated tables to across all the sites on every host
             if (table.isReplicated()) {
                 placeReplicatedTasks(tasksEntry.getValue(), hsids);
             } else {
-                placePartitionedTasks(tasksEntry.getValue(), Arrays.asList(tasksEntry.getKey()));
+                placePartitionedTasks(tasksEntry.getValue(), Arrays.asList(tasksEntry.getKey().srcHSId));
             }
         }
+    }
+
+    private void registerOnCloseHandler(Multimap<DataTargetInfo, SnapshotTableTask> tasks,
+                                      SnapshotRegistry.Snapshot snapshotRecord,
+                                      int totalTaskNum) {
+        final AtomicInteger numTables = new AtomicInteger(totalTaskNum);
+        for (Entry<DataTargetInfo, Collection<SnapshotTableTask>> tasksEntry : tasks.asMap().entrySet()) {
+            SnapshotDataTarget dataTarget = tasksEntry.getKey().dataTarget;
+            List<String> tables = tasksEntry.getValue().stream()
+                                                       .map(task -> task.m_tableInfo.getName())
+                                                       .collect(Collectors.toList());
+            final Runnable onClose = new TargetStatsClosure(dataTarget, tables, numTables, snapshotRecord);
+            dataTarget.setOnCloseHandler(onClose);
+            final Runnable inProgress = new TargetStatsProgress(snapshotRecord);
+            dataTarget.setInProgressHandler(inProgress);
+        }
+        // Update the total task count, which used in snapshot progress tracking
+        snapshotRecord.setTotalTasks(totalTaskNum);
     }
 
     /**


### PR DESCRIPTION
Covers more types of snapshot, index snapshot (used by elastic) is intentionally ignored because it can't be used in restore.
Stream snapshot tracking is incorrect in master because each snapshot data target covers multiple tables, unlike the native snapshot which is one to one mapping. So onClose handler is always triggered from the last registered table.