### PR TITLE
Eng 19517 empty blocks pending snapshot

### DIFF
--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -1115,14 +1115,14 @@ inline void PersistentTable::deleteTupleStorage(TableTuple& tuple, TBPtr block, 
         }
     }
 
-    // XXX REMOVEME XXX
-    if (block->isEmpty() && m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end()) {
-        VOLT_ERROR("XXX BLOCK %p PENDING SNAPSHOT XXX", block->address());
+    bool isPendingSnapshot = m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end();
+    if (isPendingSnapshot) {
+        vassert(m_tableStreamer != NULL && m_tableStreamer->hasStreamType(TABLE_STREAM_SNAPSHOT));
     }
 
     // if the block is empty, release it, unless it is pending snapshot in which case let
     // the streamer do it
-    if (block->isEmpty() && m_blocksPendingSnapshot.find(block) == m_blocksPendingSnapshot.end()) {
+    if (block->isEmpty() && !isPendingSnapshot) {
         if (m_data.size() > 1 || deleteLastEmptyBlock) {
             // Release the empty block unless it's the only remaining block and caller has requested not to do so.
             // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -1139,31 +1139,6 @@ inline void PersistentTable::deleteTupleStorage(TableTuple& tuple, TBPtr block, 
     } else if (transitioningToBlockWithSpace) {
         m_blocksWithSpace.insert(block);
     }
-
-
-    bool isPendingSnapshot = m_blocksPendingSnapshot.find(block) != m_blocksPendingSnapshot.end();
-    if (isPendingSnapshot) {
-        vassert(m_tableStreamer != NULL && m_tableStreamer->hasStreamType(TABLE_STREAM_SNAPSHOT));
-    }
-
-    // if the block is empty, release it, unless it is pending snapshot in which case let
-    // the streamer walk over it and snapshot scan take care of it.
-    if (block->isEmpty() && !isPendingSnapshot) {
-        if (m_data.size() > 1 || deleteLastEmptyBlock) {
-            // Release the empty block unless it's the only remaining block and caller has requested not to do so.
-            // The intent of doing so is to avoid block allocation cost at time tuple insertion into the table
-            m_data.erase(block->address());
-            m_blocksWithSpace.erase(block);
-        } else if (transitioningToBlockWithSpace) {
-           // In the unlikely event that tuplesPerBlock == 1
-           m_blocksWithSpace.insert(block);
-        }
-        m_blocksNotPendingSnapshot.erase(block);
-        //Eliminates circular reference
-        block->swapToBucket(TBBucketPtr());
-    } else if (transitioningToBlockWithSpace) {
-        m_blocksWithSpace.insert(block);
-    }
 }
 
 inline TBPtr PersistentTable::findBlock(char* tuple, TBMap& blocks, int blockSize) {


### PR DESCRIPTION
When deleting the last tuple of a block pending snapshot, and removing the block from the PersistentTable, notify the table streamer that the block was "compacted away".