### PR TITLE
Eng 19654 backport 8.4.x

### DIFF
--- a/src/frontend/org/voltcore/messaging/BinaryPayloadMessage.java
+++ b/src/frontend/org/voltcore/messaging/BinaryPayloadMessage.java
@@ -41,7 +41,7 @@ public class BinaryPayloadMessage extends VoltMessage {
         if (metadata == null || metadata.length > Short.MAX_VALUE) {
             throw new IllegalArgumentException();
         }
-        if (payload != null && length > m_payload.length) {
+        if (payload != null && length > payload.length) {
             throw new IllegalArgumentException();
         }
         m_payload = payload;


### PR DESCRIPTION
Backport: break >50MB (compressed size) ZK snapshot into small chunks to complete the rejoin. 