### PR TITLE
Eng 19332 cat ver in replay

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -274,6 +274,7 @@ public class CatalogContext {
     public CatalogContext update(
             boolean isForReplay,
             Catalog newCatalog,
+            int nextCatalogVersion,
             long genId,
             CatalogInfo catalogInfo,
             HostMessenger messenger,
@@ -290,7 +291,7 @@ public class CatalogContext {
             new CatalogContext(
                     newCatalog,
                     this.m_dbSettings,
-                    catalogVersion + 1, // version increment
+                    nextCatalogVersion, // version increment
                     genId,
                     catalogInfo,
                     m_defaultProcs,

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4030,6 +4030,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public CatalogContext catalogUpdate(
             String diffCommands,
             int expectedCatalogVersion,
+            int nextCatalogVersion,
             long genId,
             boolean isForReplay,
             boolean requireCatalogDiffCmdsApplyToEE,
@@ -4056,7 +4057,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                                 "commands generated for an out-of date catalog. Expected catalog version: " +
                                 expectedCatalogVersion + " does not match actual version: " + m_catalogContext.catalogVersion);
                     }
-                    assert(m_catalogContext.catalogVersion == expectedCatalogVersion + 1);
+                    assert(m_catalogContext.catalogVersion == nextCatalogVersion);
                     return m_catalogContext;
                 }
 
@@ -4101,6 +4102,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 // 0. A new catalog! Update the global context and the context tracker
                 m_catalogContext = m_catalogContext.update(isForReplay,
                                                            newCatalog,
+                                                           nextCatalogVersion,
                                                            genId,
                                                            catalogInfo,
                                                            m_messenger,

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -156,6 +156,7 @@ public interface VoltDBInterface
      *
      * @param diffCommands The commands to update the current catalog to the new one.
      * @param expectedCatalogVersion The version of the catalog the commands are targeted for.
+     * @param nextCatalogVersion The version of the catalog the commands are updated to.
      * @param genId stream table catalog generation id
      * @param currentTxnId  The transaction ID at which this method is called
      * @param deploymentBytes  The deployment file bytes
@@ -163,6 +164,7 @@ public interface VoltDBInterface
     public CatalogContext catalogUpdate(
             String diffCommands,
             int expectedCatalogVersion,
+            int nextCatalogVersion,
             long genId,
             boolean isForReplay,
             boolean requireCatalogDiffCmdsApplyToEE,

--- a/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
+++ b/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
@@ -42,6 +42,8 @@ public class CatalogChangeResult {
     // mark it false for UpdateClasses, in future may be marked false for deployment changes
     public boolean hasSchemaChange;
     public int expectedCatalogVersion = -1;
+    // In CL replay the catalog version may not strictly increase by 1, because failed UAC also consumes a version number.
+    public int nextCatalogVersion = -1;
     // This is set to true if schema change involves stream or connector changes or a view on stream is created or dropped.
     public boolean requiresNewExportGeneration;
     // This is true if there are security user changes.

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -161,7 +161,7 @@ public class AdHoc extends AdHocNTBase {
                 logCatalogUpdateInvocation("@AdHoc");
                 return updateApplication("@AdHoc", null, /* operationBytes */
                         null, sqlStatements.toArray(new String[0]), /* adhocDDLStmts */
-                        sqlNodes, null, false);
+                        sqlNodes, false);
             }
         }
     }

--- a/src/frontend/org/voltdb/sysprocs/Promote.java
+++ b/src/frontend/org/voltdb/sysprocs/Promote.java
@@ -47,7 +47,6 @@ public class Promote extends UpdateApplicationBase {
                                 null,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 true /* isPromotion */
                                 );
     }

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -483,8 +483,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
     CompletableFuture<ClientResponse> updateApplication(
             String invocationName, final byte[] operationBytes, final String operationString,
-            final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
-            final boolean isPromotion) {
+            final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final boolean isPromotion) {
         final ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
         final CatalogChangeResult ccr;
 
@@ -499,7 +498,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             int nextCataVer = VoltDB.instance().getCatalogContext().catalogVersion + 1;
             ccr = prepareApplicationCatalogDiff(
                     invocationName, operationBytes, operationString, adhocDDLStmts, sqlNodes,
-                    replayHashOverride, isPromotion, getUsername(), nextCataVer);
+                    null, isPromotion, getUsername(), nextCataVer);
         } catch (Exception e) {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             errMsg = "Unexpected error during preparing catalog diffs: " + e.getMessage();

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -93,7 +93,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
     public static CatalogChangeResult prepareApplicationCatalogDiff(
             String invocationName, final byte[] operationBytes, final String operationString,
             final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
-            final boolean isPromotion, String user) {
+            final boolean isPromotion, String user, int nextCatVer) {
         final DrRoleType drRole = DrRoleType.fromValue(VoltDB.instance().getCatalogContext().getCluster().getDrrole());
 
         // create the change result and set up all the boiler plate
@@ -263,6 +263,11 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             // verified when / if the update procedure runs in order to verify
             // catalogs only move forward
             retval.expectedCatalogVersion = context.catalogVersion;
+
+            // In C/L replay path the next catalog version may not be the expected version plus 1,
+            // because C/L reinitiator may queue multiple UACs before any of those get executed,
+            // failed UAC also consumes a version number.
+            retval.nextCatalogVersion = nextCatVer;
 
             // compute the diff in StringBuilder
             CatalogDiffEngine diff = new CatalogDiffEngine(context.catalog, newCatalog);
@@ -491,9 +496,10 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         // Now we holds the UAC blocker lock
         try {
+            int nextCataVer = VoltDB.instance().getCatalogContext().catalogVersion + 1;
             ccr = prepareApplicationCatalogDiff(
                     invocationName, operationBytes, operationString, adhocDDLStmts, sqlNodes,
-                    replayHashOverride, isPromotion, getUsername());
+                    replayHashOverride, isPromotion, getUsername(), nextCataVer);
         } catch (Exception e) {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             errMsg = "Unexpected error during preparing catalog diffs: " + e.getMessage();
@@ -538,7 +544,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         hostLog.info("About to call @UpdateCore");
         try {
-            CatalogUtil.stageCatalogToZK(zk, ccr.expectedCatalogVersion + 1, genId, -1,
+            CatalogUtil.stageCatalogToZK(zk, ccr.nextCatalogVersion, genId, -1,
                     SegmentedCatalog.create(ccr.catalogBytes, ccr.catalogHash, ccr.deploymentBytes));
         } catch (KeeperException | InterruptedException e) {
             errMsg = "error writing stage catalog bytes on ZK during " + invocationName;
@@ -555,7 +561,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         // update the catalog jar
         CompletableFuture<ClientResponse> first = callProcedure(
                 "@UpdateCore", ccr.encodedDiffCommands, ccr.expectedCatalogVersion,
-                genId, ccr.catalogHash, ccr.deploymentHash,
+                ccr.nextCatalogVersion, genId, ccr.catalogHash, ccr.deploymentHash,
                 ccr.worksWithElastic ? 1 : 0, ccr.tablesThatMustBeEmpty, ccr.reasonsForEmptyTables,
                 ccr.requiresSnapshotIsolation ? 1 : 0, ccr.requireCatalogDiffCmdsApplyToEE ? 1 : 0,
                 ccr.hasSchemaChange ?  1 : 0, ccr.requiresNewExportGeneration ? 1 : 0,

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
@@ -61,7 +61,6 @@ public class UpdateApplicationCatalog extends UpdateApplicationBase {
                                 deploymentString,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 false /* isPromotion */
                                 );
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
@@ -52,7 +52,6 @@ public class UpdateClasses extends UpdateApplicationBase {
                                 classesToDeleteSelector,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 false /* isPromotion */
                                 );
     }

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -267,16 +267,17 @@ public class UpdateCore extends VoltSystemProcedure {
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalog) {
-            String catalogDiffCommands = (String)params.toArray()[0];
+            Object[] paramsList = params.toArray();
+            String catalogDiffCommands = (String)paramsList[0];
             String commands = CompressionService.decodeBase64AndDecompress(catalogDiffCommands);
-            int expectedCatalogVersion = (Integer)params.toArray()[1];
-            int nextCatalogVersion = (Integer)params.toArray()[2];
-            boolean requiresSnapshotIsolation = ((Byte) params.toArray()[3]) != 0;
-            boolean requireCatalogDiffCmdsApplyToEE = ((Byte) params.toArray()[4]) != 0;
-            boolean hasSchemaChange = ((Byte) params.toArray()[5]) != 0;
-            boolean requiresNewExportGeneration = ((Byte) params.toArray()[6]) != 0;
-            long genId = (Long) params.toArray()[7];
-            boolean hasSecurityUserChange = ((Byte) params.toArray()[8]) != 0;
+            int expectedCatalogVersion = (Integer)paramsList[1];
+            int nextCatalogVersion = (Integer)paramsList[2];
+            boolean requiresSnapshotIsolation = ((Byte) paramsList[3]) != 0;
+            boolean requireCatalogDiffCmdsApplyToEE = ((Byte) paramsList[4]) != 0;
+            boolean hasSchemaChange = ((Byte) paramsList[5]) != 0;
+            boolean requiresNewExportGeneration = ((Byte) paramsList[6]) != 0;
+            long genId = (Long) paramsList[7];
+            boolean hasSecurityUserChange = ((Byte) paramsList[8]) != 0;
 
             boolean isForReplay = m_runner.getTxnState().isForReplay();
 

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -3217,19 +3217,20 @@ public abstract class CatalogUtil {
         }
         invocation.setParams(params[0],             // diff commands
                              params[1],             // expected catalog version
-                             params[2],             // gen id
+                             params[2],             // next catalog version
+                             params[3],             // gen id
                              cad.catalogBytes,
-                             params[3],             // catalog hash
+                             params[4],             // catalog hash
                              cad.deploymentBytes,
-                             params[4],             // deployment hash
-                             params[5],             // work with elastic
-                             params[6],             // tables must be empty
-                             params[7],             // reasons for empty tables
-                             params[8],             // requiresSnapshotIsolation
-                             params[9],             // requireCatalogDiffCmdsApplyToEE
-                             params[10],            // hasSchemaChange
-                             params[11],            // requiresNewExportGeneration
-                             params[12]);           // hasSecurityUserChange
+                             params[5],             // deployment hash
+                             params[6],             // work with elastic
+                             params[7],             // tables must be empty
+                             params[8],             // reasons for empty tables
+                             params[9],             // requiresSnapshotIsolation
+                             params[10],             // requireCatalogDiffCmdsApplyToEE
+                             params[11],            // hasSchemaChange
+                             params[12],            // requiresNewExportGeneration
+                             params[13]);           // hasSecurityUserChange
     }
 
     public static int getZKCatalogVersion(ZooKeeper zk, long txnId) {

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -510,7 +510,7 @@ public class MockVoltDB implements VoltDBInterface
 
     @Override
     public CatalogContext catalogUpdate(String diffCommands,
-            int expectedCatalogVersion, long genId,
+            int expectedCatalogVersion, int nextCatalogVersion, long genId,
             boolean isForReplay, boolean requireCatalogDiffCmdsApplyToEE,
             boolean hasSchemaChange, boolean requiresNewExportGeneration,  boolean hasSecurityUserChange)
     {


### PR DESCRIPTION
In C/L replay path the next catalog version may not be the expected version plus 1, because C/L reinitiator may queue multiple UACs before any of those get executed, failed UAC also consumes a version number. Catalog update runs in non-replay time is unchanged.

Pro change: https://github.com/VoltDB/pro/pull/3210