### PR TITLE
ENG-18081 stop stream snapshot watcher if destination is not available

### DIFF
--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -343,8 +343,8 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                     clearOutstanding(); // idempotent
                 }
                 if (bytesSentSinceLastCheck > 0) {
-                    m_lastDataSent = System.currentTimeMillis();
-                } else if (TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - m_lastDataSent) > 1) {
+                    m_lastDataSent = System.nanoTime();
+                } else if (TimeUnit.MINUTES.convert((System.nanoTime() - m_lastDataSent), TimeUnit.NANOSECONDS) > 1) {
                     // No data sent for one long minute and destination host is not alive, stop watching
                     Set<Integer> liveHosts = VoltDB.instance().getHostMessenger().getLiveHostIds();
                     if (!liveHosts.contains(CoreUtils.getHostIdFromHSId(m_destHSId))) {

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -105,6 +105,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     private Runnable m_progressHandler = null;
 
     private final AtomicBoolean m_closed = new AtomicBoolean(false);
+    private long m_lastDataSent;
 
     public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
             byte[] hashinatorConfig, List<SnapshotTableInfo> tables, SnapshotSender sender,
@@ -340,11 +341,22 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                 if (m_writeFailed.get() != null) {
                     clearOutstanding(); // idempotent
                 }
+                if (bytesWritten > 0) {
+                    m_lastDataSent = System.currentTimeMillis();
+                } else if (TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - m_lastDataSent) > 1) {
+                    // No data sent for one long minute and destination host is not alive, stop watching
+                    Set<Integer> liveHosts = VoltDB.instance().getHostMessenger().getLiveHostIds();
+                    if (!liveHosts.contains(CoreUtils.getHostIdFromHSId(m_destHSId))) {
+                        m_closed.set(true);
+                    }
+                }
             } catch (Throwable t) {
                 rejoinLog.error("Stream snapshot watchdog thread threw an exception", t);
             } finally {
                 // schedule to run again
-                VoltDB.instance().scheduleWork(new Watchdog(bytesWritten, m_writeTimeout), WATCHDOG_PERIOS_S, -1, TimeUnit.SECONDS);
+                if (!m_closed.get()) {
+                    VoltDB.instance().scheduleWork(new Watchdog(bytesWritten, m_writeTimeout), WATCHDOG_PERIOS_S, -1, TimeUnit.SECONDS);
+                }
             }
         }
     }

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -334,14 +334,15 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
             long bytesWritten = 0;
             try {
                 bytesWritten = m_sender.m_bytesSent.get(m_targetId).get();
+                long bytesSentSinceLastCheck = bytesWritten - m_bytesWrittenSinceConstruction;
                 rejoinLog.info(String.format("While sending rejoin data to site %s, %d bytes have been sent in the past %s seconds.",
-                        CoreUtils.hsIdToString(m_destHSId), bytesWritten - m_bytesWrittenSinceConstruction, WATCHDOG_PERIOS_S));
+                        CoreUtils.hsIdToString(m_destHSId), bytesSentSinceLastCheck, WATCHDOG_PERIOS_S));
 
                 checkTimeout(m_writeTimeout);
                 if (m_writeFailed.get() != null) {
                     clearOutstanding(); // idempotent
                 }
-                if (bytesWritten > 0) {
+                if (bytesSentSinceLastCheck > 0) {
                     m_lastDataSent = System.currentTimeMillis();
                 } else if (TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - m_lastDataSent) > 1) {
                     // No data sent for one long minute and destination host is not alive, stop watching


### PR DESCRIPTION
When a host fails before rejoining is completed, the host of stream snapshot sources will log the message every 5 seconds, non-stop:  "While sending rejoin data to site X:X, 0 bytes have been sent in the past 5 seconds."   if not data are sent in 1 minute and destination host is down, stop logging the message.