### PR TITLE
Add next catalog version into UpdateCore's parameter list.

### DIFF
--- a/src/frontend/org/voltdb/CatalogContext.java
+++ b/src/frontend/org/voltdb/CatalogContext.java
@@ -274,6 +274,7 @@ public class CatalogContext {
     public CatalogContext update(
             boolean isForReplay,
             Catalog newCatalog,
+            int nextCatalogVersion,
             long genId,
             CatalogInfo catalogInfo,
             HostMessenger messenger,
@@ -290,7 +291,7 @@ public class CatalogContext {
             new CatalogContext(
                     newCatalog,
                     this.m_dbSettings,
-                    catalogVersion + 1, // version increment
+                    nextCatalogVersion, // version increment
                     genId,
                     catalogInfo,
                     m_defaultProcs,

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3901,6 +3901,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
     public CatalogContext catalogUpdate(
             String diffCommands,
             int expectedCatalogVersion,
+            int nextCatalogVersion,
             long genId,
             boolean isForReplay,
             boolean requireCatalogDiffCmdsApplyToEE,
@@ -3920,8 +3921,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         throw new RuntimeException("Trying to update main catalog context with diff " +
                                 "commands generated for an out-of date catalog. Expected catalog version: " +
                                 expectedCatalogVersion + " does not match actual version: " + m_catalogContext.catalogVersion);
-                    };
-                    assert(m_catalogContext.catalogVersion == expectedCatalogVersion + 1);
+                    }
+                    assert(m_catalogContext.catalogVersion == nextCatalogVersion);
                     return m_catalogContext;
                 }
 
@@ -3966,6 +3967,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 // 0. A new catalog! Update the global context and the context tracker
                 m_catalogContext = m_catalogContext.update(isForReplay,
                                                            newCatalog,
+                                                           nextCatalogVersion,
                                                            genId,
                                                            catalogInfo,
                                                            m_messenger,

--- a/src/frontend/org/voltdb/VoltDBInterface.java
+++ b/src/frontend/org/voltdb/VoltDBInterface.java
@@ -154,6 +154,7 @@ public interface VoltDBInterface
      *
      * @param diffCommands The commands to update the current catalog to the new one.
      * @param expectedCatalogVersion The version of the catalog the commands are targeted for.
+     * @param nextCatalogVersion The version of the catalog the commands are updated to.
      * @param genId stream table catalog generation id
      * @param currentTxnId  The transaction ID at which this method is called
      * @param deploymentBytes  The deployment file bytes
@@ -161,6 +162,7 @@ public interface VoltDBInterface
     public CatalogContext catalogUpdate(
             String diffCommands,
             int expectedCatalogVersion,
+            int nextCatalogVersion,
             long genId,
             boolean isForReplay,
             boolean requireCatalogDiffCmdsApplyToEE,

--- a/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
+++ b/src/frontend/org/voltdb/compiler/CatalogChangeResult.java
@@ -42,6 +42,8 @@ public class CatalogChangeResult {
     // mark it false for UpdateClasses, in future may be marked false for deployment changes
     public boolean hasSchemaChange;
     public int expectedCatalogVersion = -1;
+    // In CL replay the catalog version may not strictly increase by 1, because failed UAC also consumes a version number.
+    public int nextCatalogVersion = -1;
     // This is set to true if schema change involves stream or connector changes or a view on stream is created or dropped.
     public boolean requiresNewExportGeneration;
     // This is true if there are security user changes.

--- a/src/frontend/org/voltdb/sysprocs/AdHoc.java
+++ b/src/frontend/org/voltdb/sysprocs/AdHoc.java
@@ -161,7 +161,7 @@ public class AdHoc extends AdHocNTBase {
                 logCatalogUpdateInvocation("@AdHoc");
                 return updateApplication("@AdHoc", null, /* operationBytes */
                         null, sqlStatements.toArray(new String[0]), /* adhocDDLStmts */
-                        sqlNodes, null, false);
+                        sqlNodes, false);
             }
         }
     }

--- a/src/frontend/org/voltdb/sysprocs/Promote.java
+++ b/src/frontend/org/voltdb/sysprocs/Promote.java
@@ -47,7 +47,6 @@ public class Promote extends UpdateApplicationBase {
                                 null,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 true /* isPromotion */
                                 );
     }

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationBase.java
@@ -93,7 +93,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
     public static CatalogChangeResult prepareApplicationCatalogDiff(
             String invocationName, final byte[] operationBytes, final String operationString,
             final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
-            final boolean isPromotion, String user) {
+            final boolean isPromotion, String user, int nextCatVer) {
         final DrRoleType drRole = DrRoleType.fromValue(VoltDB.instance().getCatalogContext().getCluster().getDrrole());
 
         // create the change result and set up all the boiler plate
@@ -262,6 +262,11 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
             // verified when / if the update procedure runs in order to verify
             // catalogs only move forward
             retval.expectedCatalogVersion = context.catalogVersion;
+
+            // In C/L replay path the next catalog version may not be the expected version plus 1,
+            // because C/L reinitiator may queue multiple UACs before any of those get executed,
+            // failed UAC also consumes a version number.
+            retval.nextCatalogVersion = nextCatVer;
 
             // compute the diff in StringBuilder
             CatalogDiffEngine diff = new CatalogDiffEngine(context.catalog, newCatalog);
@@ -477,8 +482,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
     CompletableFuture<ClientResponse> updateApplication(
             String invocationName, final byte[] operationBytes, final String operationString,
-            final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final byte[] replayHashOverride,
-            final boolean isPromotion) {
+            final String[] adhocDDLStmts, final List<SqlNode> sqlNodes, final boolean isPromotion) {
         final ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
         final CatalogChangeResult ccr;
 
@@ -490,9 +494,10 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         // Now we holds the UAC blocker lock
         try {
+            int nextCataVer = VoltDB.instance().getCatalogContext().catalogVersion + 1;
             ccr = prepareApplicationCatalogDiff(
                     invocationName, operationBytes, operationString, adhocDDLStmts, sqlNodes,
-                    replayHashOverride, isPromotion, getUsername());
+                    null, isPromotion, getUsername(), nextCataVer);
         } catch (Exception e) {
             VoltZK.removeActionBlocker(zk, VoltZK.catalogUpdateInProgress, hostLog);
             errMsg = "Unexpected error during preparing catalog diffs: " + e.getMessage();
@@ -537,7 +542,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
 
         hostLog.info("About to call @UpdateCore");
         try {
-            CatalogUtil.stageCatalogToZK(zk, ccr.expectedCatalogVersion + 1, genId, -1,
+            CatalogUtil.stageCatalogToZK(zk, ccr.nextCatalogVersion, genId, -1,
                     SegmentedCatalog.create(ccr.catalogBytes, ccr.catalogHash, ccr.deploymentBytes));
         } catch (KeeperException | InterruptedException e) {
             errMsg = "error writing stage catalog bytes on ZK during " + invocationName;
@@ -554,7 +559,7 @@ public abstract class UpdateApplicationBase extends VoltNTSystemProcedure {
         // update the catalog jar
         CompletableFuture<ClientResponse> first = callProcedure(
                 "@UpdateCore", ccr.encodedDiffCommands, ccr.expectedCatalogVersion,
-                genId, ccr.catalogHash, ccr.deploymentHash,
+                ccr.nextCatalogVersion, genId, ccr.catalogHash, ccr.deploymentHash,
                 ccr.worksWithElastic ? 1 : 0, ccr.tablesThatMustBeEmpty, ccr.reasonsForEmptyTables,
                 ccr.requiresSnapshotIsolation ? 1 : 0, ccr.requireCatalogDiffCmdsApplyToEE ? 1 : 0,
                 ccr.hasSchemaChange ?  1 : 0, ccr.requiresNewExportGeneration ? 1 : 0,

--- a/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateApplicationCatalog.java
@@ -61,7 +61,6 @@ public class UpdateApplicationCatalog extends UpdateApplicationBase {
                                 deploymentString,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 false /* isPromotion */
                                 );
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateClasses.java
@@ -52,7 +52,6 @@ public class UpdateClasses extends UpdateApplicationBase {
                                 classesToDeleteSelector,
                                 new String[0],
                                 Collections.emptyList(),
-                                null,
                                 false /* isPromotion */
                                 );
     }

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -28,6 +28,7 @@ import org.apache.zookeeper_voltpatches.KeeperException;
 import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.utils.CoreUtils;
+import org.voltcore.zk.ZKUtil;
 import org.voltdb.CatalogContext;
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
@@ -267,15 +268,17 @@ public class UpdateCore extends VoltSystemProcedure {
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalog) {
-            String catalogDiffCommands = (String)params.toArray()[0];
+            Object[] paramsList = params.toArray();
+            String catalogDiffCommands = (String)paramsList[0];
             String commands = CompressionService.decodeBase64AndDecompress(catalogDiffCommands);
-            int expectedCatalogVersion = (Integer)params.toArray()[1];
-            boolean requiresSnapshotIsolation = ((Byte) params.toArray()[2]) != 0;
-            boolean requireCatalogDiffCmdsApplyToEE = ((Byte) params.toArray()[3]) != 0;
-            boolean hasSchemaChange = ((Byte) params.toArray()[4]) != 0;
-            boolean requiresNewExportGeneration = ((Byte) params.toArray()[5]) != 0;
-            long genId = (Long) params.toArray()[6];
-            boolean hasSecurityUserChange = ((Byte) params.toArray()[7]) != 0;
+            int expectedCatalogVersion = (Integer)paramsList[1];
+            int nextCatalogVersion = (Integer)paramsList[2];
+            boolean requiresSnapshotIsolation = ((Byte) paramsList[3]) != 0;
+            boolean requireCatalogDiffCmdsApplyToEE = ((Byte) paramsList[4]) != 0;
+            boolean hasSchemaChange = ((Byte) paramsList[5]) != 0;
+            boolean requiresNewExportGeneration = ((Byte) paramsList[6]) != 0;
+            long genId = (Long) paramsList[7];
+            boolean hasSecurityUserChange = ((Byte) paramsList[8]) != 0;
 
             boolean isForReplay = m_runner.getTxnState().isForReplay();
 
@@ -290,6 +293,7 @@ public class UpdateCore extends VoltSystemProcedure {
                         VoltDB.instance().catalogUpdate(
                                 commands,
                                 expectedCatalogVersion,
+                                nextCatalogVersion,
                                 genId,
                                 isForReplay,
                                 requireCatalogDiffCmdsApplyToEE,
@@ -314,7 +318,7 @@ public class UpdateCore extends VoltSystemProcedure {
                         requireCatalogDiffCmdsApplyToEE, requiresNewExportGeneration);
             }
             // if seen before by this code, then check to see if this is a restart
-            else if (context.getCatalogVersion() == (expectedCatalogVersion + 1)) {
+            else if (context.getCatalogVersion() == nextCatalogVersion) {
                 log.info(String.format("Site %s will NOT apply an assumed restarted and identical catalog update.",
                             CoreUtils.hsIdToString(m_site.getCorrespondingSiteId())));
             }
@@ -355,6 +359,7 @@ public class UpdateCore extends VoltSystemProcedure {
     private final VoltTable[] performCatalogUpdateWork(
             String catalogDiffCommands,
             int expectedCatalogVersion,
+            int nextCatalogVersion,
             byte requiresSnapshotIsolation,
             byte requireCatalogDiffCmdsApplyToEE,
             byte hasSchemaChange,
@@ -364,7 +369,7 @@ public class UpdateCore extends VoltSystemProcedure {
     {
         return createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateCatalog,
                 SysProcFragmentId.PF_updateCatalogAggregate, catalogDiffCommands, expectedCatalogVersion,
-                requiresSnapshotIsolation, requireCatalogDiffCmdsApplyToEE, hasSchemaChange,
+                nextCatalogVersion, requiresSnapshotIsolation, requireCatalogDiffCmdsApplyToEE, hasSchemaChange,
                 requiresNewExportGeneration, genId, hasSecurityUserChange);
     }
 
@@ -376,6 +381,7 @@ public class UpdateCore extends VoltSystemProcedure {
     public VoltTable[] run(SystemProcedureExecutionContext ctx,
                            String catalogDiffCommands,
                            int expectedCatalogVersion,
+                           int nextCatalogVersion,
                            long genId,
                            byte[] catalogHash,
                            byte[] deploymentHash,
@@ -405,12 +411,12 @@ public class UpdateCore extends VoltSystemProcedure {
                 throw new VoltAbortException("Concurrent catalog update detected, abort the current one");
             }
         } else {
-            if (context.catalogVersion == (expectedCatalogVersion + 1) &&
+            if (context.catalogVersion == nextCatalogVersion &&
                 Arrays.equals(context.getCatalogHash(), catalogHash) &&
                 Arrays.equals(context.getDeploymentHash(), deploymentHash)) {
                 log.info("Restarting catalog update");
                 // Catalog may have been published, reset the status to PENDING if COMPLETE
-                CatalogUtil.unPublishCatalog(zk, expectedCatalogVersion + 1);
+                CatalogUtil.unPublishCatalog(zk, nextCatalogVersion);
             } else {
                 // impossible to happen since we only allow catalog update sequentially
                 String errMsg = "Invalid catalog update.  Catalog or deployment change was planned " +
@@ -428,7 +434,7 @@ public class UpdateCore extends VoltSystemProcedure {
         log.info("New catalog update from: " + VoltDB.instance().getCatalogContext().getCatalogLogString());
         log.info("To: catalog hash: " + Encoder.hexEncode(catalogHash).substring(0, 10) +
                 ", deployment hash: " + Encoder.hexEncode(deploymentHash).substring(0, 10) +
-                ", version: " + (expectedCatalogVersion + 1));
+                ", version: " + nextCatalogVersion);
 
         start = System.nanoTime();
 
@@ -439,11 +445,12 @@ public class UpdateCore extends VoltSystemProcedure {
         }
         catch (VoltAbortException vae) {
             log.info("Catalog verification failed: " + vae.getMessage());
+            ZKUtil.deleteRecursively(zk, ZKUtil.joinZKPath(VoltZK.catalogbytes, String.valueOf(nextCatalogVersion)));
             throw vae;
         }
 
         try {
-            CatalogUtil.publishCatalog(zk, expectedCatalogVersion + 1);
+            CatalogUtil.publishCatalog(zk, nextCatalogVersion);
         } catch (KeeperException | InterruptedException e) {
             log.error("error writing catalog bytes on ZK during @UpdateCore");
             throw e;
@@ -452,6 +459,7 @@ public class UpdateCore extends VoltSystemProcedure {
         performCatalogUpdateWork(
                 catalogDiffCommands,
                 expectedCatalogVersion,
+                nextCatalogVersion,
                 requiresSnapshotIsolation,
                 requireCatalogDiffCmdsApplyToEE,
                 hasSchemaChange,

--- a/src/frontend/org/voltdb/utils/CatalogUtil.java
+++ b/src/frontend/org/voltdb/utils/CatalogUtil.java
@@ -3057,19 +3057,20 @@ public abstract class CatalogUtil {
         }
         invocation.setParams(params[0],             // diff commands
                              params[1],             // expected catalog version
-                             params[2],             // gen id
+                             params[2],             // next catalog version
+                             params[3],             // gen id
                              cad.catalogBytes,
-                             params[3],             // catalog hash
+                             params[4],             // catalog hash
                              cad.deploymentBytes,
-                             params[4],             // deployment hash
-                             params[5],             // work with elastic
-                             params[6],             // tables must be empty
-                             params[7],             // reasons for empty tables
-                             params[8],             // requiresSnapshotIsolation
-                             params[9],             // requireCatalogDiffCmdsApplyToEE
-                             params[10],            // hasSchemaChange
-                             params[11],            // requiresNewExportGeneration
-                             params[12]);           // hasSecurityUserChange
+                             params[5],             // deployment hash
+                             params[6],             // work with elastic
+                             params[7],             // tables must be empty
+                             params[8],             // reasons for empty tables
+                             params[9],             // requiresSnapshotIsolation
+                             params[10],             // requireCatalogDiffCmdsApplyToEE
+                             params[11],            // hasSchemaChange
+                             params[12],            // requiresNewExportGeneration
+                             params[13]);           // hasSecurityUserChange
     }
 
     public static int getZKCatalogVersion(ZooKeeper zk, long txnId) {

--- a/tests/frontend/org/voltdb/MockVoltDB.java
+++ b/tests/frontend/org/voltdb/MockVoltDB.java
@@ -498,7 +498,7 @@ public class MockVoltDB implements VoltDBInterface
 
     @Override
     public CatalogContext catalogUpdate(String diffCommands,
-            int expectedCatalogVersion, long genId,
+            int expectedCatalogVersion, int nextCatalogVersion, long genId,
             boolean isForReplay, boolean requireCatalogDiffCmdsApplyToEE,
             boolean hasSchemaChange, boolean requiresNewExportGeneration,  boolean hasSecurityUserChange)
     {


### PR DESCRIPTION
In C/L replay path the next catalog version may not be the expected version plus 1, because C/L reinitiator may queue multiple UACs before any of those get executed, failed UAC also consumes a version number. Catalog update runs in non-replay time is unchanged.

Got rid of unnecessary input parameter from updateApplication.

Get rid of the redundant toArray() calls.