### PR TITLE
ENG-19246-branch-cleanup2-notest:

### DIFF
--- a/tools/git-remove-branches-script.py
+++ b/tools/git-remove-branches-script.py
@@ -8,16 +8,16 @@
 
 #TODO: Make it handle incorrect password the 1st time, then abort
 
-#from datetime import date, datetime, timedelta
 import getpass
+import jiratools
 from optparse import OptionParser
 import re
 from subprocess import Popen
 import subprocess
 import sys
 import time
+import traceback
 
-import jiratools
 
 # set exclusions if there are any branches that should not be listed
 exclusions = ['^master','^release-[1-9]?[0-9.]+\.x$']
@@ -64,33 +64,78 @@ def get_branch_list(merged, base=None):
 
     return [b for b in branches if not re.match(combined_regex,b.split('origin/')[-1])]
 
+
+def get_final_comment(num_listed_branches, num_total_branches, older_than_days,
+                      num_skipped_branches=0, merged=False, num_exceptions=0):
+    """Returns a final comment, including whether all branches were completed
+       or we stopped due to reaching the maximum number, whether they were
+       merged or unmerged branches, how old (minimum) the branches to be
+       deleted are, and how many branches were skipped. If the number of
+       exceptions is greater than 0, it prints the entire comment with an
+       additional part about the exceptions, and exits with an error code.
+    """
+    completed = (num_listed_branches == num_total_branches)
+    comment  = ('\n#\n# Completed list of %d ' if completed else
+                '\n#\n# Stopping, listed maximum number of %d ') \
+                % num_listed_branches
+
+    comment += ('(' if merged else '(un') + 'merged) branch'
+    comment += 'es' if (num_listed_branches != 1) else ''
+    if not completed:
+        comment += ', out of %d,' % num_total_branches
+
+    comment += ' older than %d days, to be deleted' % older_than_days
+    if num_skipped_branches > 0:
+        comment += ',\n# with %d branch' % num_skipped_branches    \
+                    + ('es' if (num_skipped_branches > 1) else '') \
+                    + ' skipped'
+
+    if num_exceptions:
+        print comment+'.\n#\n'
+        plural = 's' if num_exceptions > 1 else ''
+        print '# Failed due to %d exception%s (see above); exit with error code: %d\n' \
+                % (num_exceptions, plural, num_exceptions)
+        sys.exit(num_exceptions)
+
+    return comment+'.\n#\n'
+
+
 def make_delete_branches_script(branch_infos, olderthan, max_num_branches=10,
-                                dry_run=False):
+                                skip_branch_names=[], dry_run=False):
+    """Prints a script that can be used to delete merged branches that are older
+       than the specified number of days, up to a specified maximum number of
+       branches, and skipping those whose names contain any of several substrings.
+    """
     other_args = ''
     if dry_run:
         other_args = ' --dry-run'
 
     num_branches=0
+    num_skipped_branches=0
     for bi in branch_infos:
         num_branches+=1
         if num_branches > max_num_branches:
-            print '\n#\n# Stopping, reached maximum number of (merged) branches', \
-                  'to list (& delete): %d, out of %d older than %d days.\n#' % \
-                  (max_num_branches, len(branch_infos), olderthan)
+            print get_final_comment(max_num_branches, len(branch_infos)-num_skipped_branches,
+                                    olderthan, num_skipped_branches, merged=True)
             return
         b = bi['name']
-        cmd = 'git push origin --delete %s%s' % \
-            (b, other_args)
+        sbn = [bn for bn in skip_branch_names if bn in b]
+        if sbn:
+            num_branches-=1
+            num_skipped_branches+=1
+            print "\n# Skipping branch '%s', because its name contains '%s'" \
+                    % (b, "', '".join(sbn))
+            continue
+        cmd = 'git push origin --delete %s%s' % (b, other_args)
         comment = make_comment(bi)
-        print
-        print comment.encode('utf-8')
-        print cmd
-    print '\n#\n# Completed list of %d (merged) branches older than %d days, to be deleted.\n#' \
-          % (num_branches, olderthan)
+        print '\n' + comment.encode('utf-8') + '\n' + cmd
+
+    print get_final_comment(num_branches, num_branches, olderthan, num_skipped_branches, merged=True)
+
 
 def make_comment(bi):
-    comment = '#%-20s last checkin %s %s by %s' % \
-        (bi['name'],bi['datetime'],bi['humantime'],bi['email'])
+    comment = '# %-20s last checkin %s %s by %s' % \
+        (bi['name'], bi['datetime'], bi['humantime'], bi['email'])
     if options.use_jira:
         ticket_summary = get_jira_info(bi['name'])
         if ticket_summary:
@@ -115,33 +160,84 @@ def get_jira_info(b):
             status_resolution = ticket['fields']['status']['name']
             if status_resolution in ('Closed','Resolved'):
                 status_resolution += '/' + ticket['fields']['resolution']['name']
-            comment = "#%s %s %s: %s" % (issue, status_resolution.upper(), assignee, summary)
+            comment = "# %s %s %s: %s" % (issue, status_resolution.upper(), assignee, summary)
 
     return comment
 
+
+def get_tagname(branch_name):
+    """Returns a tag name, to be used to "archive" the branch; normally, this
+       will be 'archive/<branch_name>', but if that tag already exists in the
+       git repository, then it will try 'archive/<branch_name>-2', then
+       'archive/<branch_name>-3', and so on.
+    """
+    max_num_tags_per_branch = 10
+    init_tagname = 'archive/' + branch_name
+    for i in xrange(1, max_num_tags_per_branch+1):
+        tagname = init_tagname + ("-"+str(i) if (i > 1) else '' )
+        found_tagname = subprocess.check_output(['git', 'tag', '-l', tagname])
+        if found_tagname:
+            message  = '\n' if (i <= 1) else ''
+            message += '# WARNING: Tagname already exists: ' + tagname + '\n'
+            message += '#                        will try: ' + init_tagname+"-"+str(i+1) \
+                        if (i < max_num_tags_per_branch) else ''
+            print message
+        else:
+            return tagname
+
+    raise RuntimeError("Unable to create tags 'archive/%s-X': maximum of %d such tags already exist!"
+                       % (branch_name, max_num_tags_per_branch) )
+
+
 def make_archive_branches_script(branch_infos, olderthan, max_num_branches=10,
-                                 dry_run=False):
+                                 skip_branch_names=[], dry_run=False):
+    """Prints a script that can be used to "archive" (or tag, technically) and
+       delete unmerged branches that are older than the specified number of days,
+       up to a specified maximum number of branches, and skipping those whose
+       names contain any of several substrings.
+    """
     other_args = ''
     if dry_run:
         other_args = ' --dry-run'
+
     num_branches=0
+    num_skipped_branches=0
+    num_tagname_exceptions=0
     for bi in branch_infos:
         num_branches+=1
         if num_branches > max_num_branches:
-            print '\n#\n# Stopping, reached maximum number of (unmerged) branches', \
-                  'to list (& "archive"): %d, out of %d older than %d days.\n#' % \
-                  (max_num_branches, len(branch_infos), olderthan)
+            print get_final_comment(max_num_branches, len(branch_infos)-num_skipped_branches,
+                                    olderthan, num_skipped_branches, merged=False)
             return
+        b = bi['name']
+        sbn = [bn for bn in skip_branch_names if bn in b]
+        found_tagname_exception = False
+        if not sbn:
+            try:
+                tagname = get_tagname(b)
+            except:
+                found_tagname_exception = True
+                num_tagname_exceptions+=1
+                message  = "\n# Skipping branch '%s', because of the following " \
+                            % b + "exception while getting a tagname:\n#   "
+                message += "\n#   ".join( traceback.format_exc().split('\n') )
+        if sbn or found_tagname_exception:
+            num_branches-=1
+            num_skipped_branches+=1
+            if not found_tagname_exception:
+                message = "\n# Skipping branch '%s', because its name contains '%s'" \
+                            % (b, "', '".join(sbn))
+            print message
+            continue
         comment = make_comment(bi)
-        tagname = "archive/" + bi['name']
-        print
-        print comment
-        print 'git tag -m "archiving branch %s" %s origin/%s' % \
-            (bi['name'], tagname, bi['name'])
+        print '\n' + comment.encode('utf-8')
+        print 'git tag %s origin/%s -m "archiving branch %s"' % (tagname, b, b)
         print 'git push origin %s' % (tagname)
-        print 'git push origin --delete %s %s' % (other_args, bi['name'])
-    print '\n#\n# Completed list of %d (unmerged) branches older than %d days, to be archived.\n#' \
-          % (num_branches, olderthan)
+        print 'git push origin --delete %s %s' % (other_args, b)
+
+    print get_final_comment(num_branches, num_branches, olderthan, num_skipped_branches,
+                            merged=False, num_exceptions=num_tagname_exceptions)
+
 
 if __name__ == "__main__":
 
@@ -163,6 +259,11 @@ if __name__ == "__main__":
     parser.add_option('--max-num-branches', dest = 'max_num_branches', action = 'store',
                       help = "the maximum number of branches to list (and to remove, potentially)",
                       type="int", default = 100);
+    parser.add_option('--keep-branches', dest = 'keep_branches', action = 'store',
+                      help = "branch names (or substrings thereof) to be kept, i.e., "
+                      + "not to be removed or archived; aside from the standard branch "
+                      + "name substrings, which are always kept (keep, feature, integ)",
+                      default = '');
     parser.add_option('--release', dest = 'release', action = 'store',
                       help = "a release branch for checking merges, e.g. 'origin/release-8.4.x'");
 
@@ -173,6 +274,13 @@ if __name__ == "__main__":
     if options.use_jira:
         user = options.username
         password = options.password or getpass.getpass('Enter your Jira password: ')
+
+    # Initialize the list of branch names (or substrings) to be skipped, i.e.,
+    # branches whose names contain any of these strings will not be deleted
+    # (or listed for possible deletion)
+    skip_branch_names = ['keep', 'feature', 'integ']
+    if options.keep_branches:
+        skip_branch_names.extend(options.keep_branches.split(','))
 
     #Get the branch list
     branch_names = get_branch_list(options.merged, options.release)
@@ -206,8 +314,9 @@ if __name__ == "__main__":
 
     if options.merged:
         make_delete_branches_script(old_branch_infos, options.olderthan,
-                                    options.max_num_branches, dry_run=False)
+                                    options.max_num_branches, skip_branch_names,
+                                    dry_run=False)
     else:
         make_archive_branches_script(old_branch_infos, options.olderthan,
-                                     options.max_num_branches, dry_run=False)
-
+                                     options.max_num_branches, skip_branch_names,
+                                     dry_run=False)


### PR DESCRIPTION
Added a new '--keep-branches=' option to the
tools/git-remove-branches-script.py script, including: a new
skip_branch_names arg added to the make_delete_branches_script and
make_archive_branches_script functions (with related code, and standard
values 'keep', 'feature', and 'integ', which are always kept); also
added a new get_tagname function to pick an archive tag name, which for
branch FOO will normally return 'archive/FOO' as before, but if that
already exists will try 'archive/FOO-2', 'archive/FOO-3', etc., thus
making sure we don't delete a branch before archiving a *current*
version of it; and some miscellaneous improvements, including a new
get_final_comment function (which just refactors similar comments that
need to be printed in 4 different places) and other minor tweaks.