### PR TITLE
ENG-17073: Backport: Only call AddConnection if TestConnection is a success

### DIFF
--- a/src/frontend/org/voltdb/dbmonitor/js/voltdb.core.js
+++ b/src/frontend/org/voltdb/dbmonitor/js/voltdb.core.js
@@ -450,10 +450,6 @@
                 callback(false, { "status": -100, "statusstring": "Server is not available." }, isLoginTest);
             }, callbackTimeout);
 
-            var unauthorizedTimeout = setTimeout(function () {
-                callback(false, { "status": -100, "statusstring": "Failed to authenticate to the server via Kerberos. Please check the configuration of your client/browser" }, isLoginTest);
-            }, callbackTimeout);
-
             conn.BeginExecute('@Statistics', ['TABLE', 0], function (response) {
                 try {
                     clearTimeout(timeout);
@@ -461,7 +457,6 @@
                         VoltDBCore.isLoginVerified = true;
                         callback(true, response, isLoginTest);
                     } else if(response.status == 401){
-                        clearTimeout(unauthorizedTimeout);
                         callback(true, response, isLoginTest);
                     }else{
                         callback(false, response, isLoginTest);

--- a/src/frontend/org/voltdb/dbmonitor/js/voltdb.service.js
+++ b/src/frontend/org/voltdb/dbmonitor/js/voltdb.service.js
@@ -453,10 +453,10 @@
                      VoltDBCore.TestConnection(server, port, isAdmin, user, password, isHashedPassword, processName, function (result) {
                          if (result == true) {
                              VoltDBCore.AddConnection(server, port, isAdmin, user, password, isHashedPassword, procedureNames, parameters, values, processName, function (connection, status) {
-                             if (adminReset) {
-                                 connection.admin = false; //Once necessary data has been fetched, set the admin privileges to false.
-                              }
-                              onConnectionAdded(connection, status);
+                                 if (adminReset) {
+                                     connection.admin = false; //Once necessary data has been fetched, set the admin privileges to false.
+                                 }
+                                 onConnectionAdded(connection, status);
                              });
                          }
                      });
@@ -502,10 +502,12 @@
              _connection = VoltDBCore.HasConnection(server, port, admin, user, processName);
              if (_connection == null) {
                  VoltDBCore.TestConnection(server, port, admin, user, password, isHashedPassword, processName, function (result) {
+                    if (result == true) {
                          VoltDBCore.AddConnection(server, port, admin, user, password, isHashedPassword, procedureNames, parameters, values, processName, function (connection, status) {
                              statusCallback(connection);
                          });
-                     });
+                     }
+                 });
              } else {
                  VoltDBCore.updateConnection(server, port, admin, user, password, isHashedPassword, procedureNames, parameters, values, processName, _connection, function (connection, status) {
                     statusCallback(connection);


### PR DESCRIPTION
[ backport cc48f70de237d1d82bcca15d100a716a4a52018d ]

If result of TestConnection is false do not call AddConnection in the
callback.

Also remove the unauthorizedTimeout from TestConnection. Since there is
already a timer for the response this second timer is not necessary.