### PR TITLE
ENG-19679: fix handling EE direct buffers (#7219)

### DIFF
--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -112,10 +112,31 @@ private:
     jmethodID m_storeLargeTempTableBlockMID;
     jmethodID m_loadLargeTempTableBlockMID;
     jmethodID m_releaseLargeTempTableBlockMID;
+    jmethodID m_NDBBWConstructorMID;
     jclass m_exportManagerClass;
     jclass m_partitionDRGatewayClass;
     jclass m_decompressionClass;
+    jclass m_NDBBWClass;
     jmethodID initJavaUserDefinedMethod(const char* name);
+
+    /**
+     * return a direct ByteBuffer wrapped into a NDBBWrapperContainer ensuring proper
+     * release of the EE memory.
+     */
+    jobject getDirectBufferContainer(char* data, int length) {
+        jobject buffer = m_jniEnv->NewDirectByteBuffer(data, length);
+        if (buffer == NULL) {
+            m_jniEnv->ExceptionDescribe();
+            throw std::exception();
+        }
+        jobject container = m_jniEnv->NewObject(m_NDBBWClass, m_NDBBWConstructorMID, buffer);
+        if (container == NULL) {
+            m_jniEnv->ExceptionDescribe();
+            throw std::exception();
+        }
+        m_jniEnv->DeleteLocalRef(buffer);
+        return container;
+    }
 };
 
 }

--- a/src/frontend/org/voltcore/utils/DBBPool.java.template
+++ b/src/frontend/org/voltcore/utils/DBBPool.java.template
@@ -243,12 +243,15 @@ public final class DBBPool {
     }
 
     /**
-     * Wrapper for native allocated direct memory
+     * Wrapper for native allocated direct memory, only instantiated
+     * in the native JNI topend. Ensures the native memory is properly
+     * discarded.
      *
      */
     public static final class NDBBWrapperContainer extends BBContainer {
         private NDBBWrapperContainer(ByteBuffer b) {
             super( b );
+            assert b.isDirect();
         }
 
         @Override
@@ -258,7 +261,7 @@ public final class DBBPool {
                return;
             }
             final DirectBuffer dbuf = (DirectBuffer) buf;
-            deleteCharArrayMemory(dbuf.address());
+            nativeDeleteCharArrayMemory(dbuf.address());
         }
     }
 
@@ -530,88 +533,27 @@ public final class DBBPool {
         }
     }
 
-    public static void registerUnsafeMemory(long pointer) {
-#ifdef MEMCHECK_FULL
-        m_allocatedStuff.put(pointer, new Throwable("Thread \"" + Thread.currentThread().getName() + "\" registered " + Long.toHexString(pointer) + " here at " + System.currentTimeMillis()));
-        m_deletedStuff.remove(pointer);
-#endif
-    }
-#ifdef MEMCHECK_FULL
-
-    private static NonBlockingHashMap<Long, Throwable> m_deletedStuff = new NonBlockingHashMap<Long, Throwable>();
-    private static NonBlockingHashMap<Long, Throwable> m_allocatedStuff = new NonBlockingHashMap<Long, Throwable>();
-#endif
-
-    /*
-     * Delete a char array that was allocated on the native heap
-     *
-     * If you want to debug issues with double free, uncomment m_deletedStuff
-     * and the code that populates it and comment out the call to nativeDeleteCharArrayMemory
-     * and it will validate that nothing is ever deleted twice at the cost of unbounded memory usage
-     */
-    private static void deleteCharArrayMemory(long pointer) {
-#ifdef MEMCHECK_FULL
-        if (!m_allocatedStuff.containsKey(pointer)) {
-            Long closest = Long.MAX_VALUE;
-            for (Long l : m_allocatedStuff.keySet()) {
-                long delta = pointer - l;
-                if (delta < 0) continue;
-                if (delta < pointer - closest) closest = l;
-            }
-            Throwable t = new Throwable("Thread \"" + Thread.currentThread().getName() + "\" deleted a pointer that was never allocated " + Long.toHexString(pointer) + " here at " + System.currentTimeMillis());
-            t.printStackTrace();
-            if (!closest.equals(Long.MAX_VALUE)) {
-                System.err.println("Closest known allocation is:");
-                m_allocatedStuff.get(closest).printStackTrace();
-            }
-            HOST.fatal("Deleted address that was never allocated", t);
-            if (!closest.equals(Long.MAX_VALUE)) HOST.fatal("Closest known allocation was:", m_allocatedStuff.get(closest));
-            System.exit(-1);
-        }
-        m_allocatedStuff.remove(pointer);
-        if (m_deletedStuff.putIfAbsent(pointer, new Throwable("Thread \"" + Thread.currentThread().getName() + "\" deleted " + Long.toHexString(pointer) + " here at " + System.currentTimeMillis())) != null) {
-            m_deletedStuff.get(pointer).printStackTrace();
-            Throwable t = new Throwable("Thread \"" + Thread.currentThread().getName() + "\" deleted " + Long.toHexString(pointer) + " twice at " + System.currentTimeMillis());
-            HOST.fatal("Original:", m_deletedStuff.get(pointer));
-            HOST.fatal("Second:", t);
-            System.exit(-1);
-        }
-#else
-        nativeDeleteCharArrayMemory(pointer);
-#endif
-    }
-
     private static native void nativeDeleteCharArrayMemory(long pointer);
-
-    public static BBContainer allocateUnsafeByteBuffer(long size) {
-        final BBContainer retcont = new NDBBWrapperContainer(nativeAllocateUnsafeByteBuffer(size));
-#ifdef MEMCHECK_FULL
-        final long pointer = retcont.address();
-        m_allocatedStuff.put(pointer, new Throwable("Thread \"" + Thread.currentThread().getName() + "\" allocated " + Long.toHexString(pointer) + " here at " + System.currentTimeMillis()));
-        m_deletedStuff.remove(pointer);
-#endif
-        return retcont;
-    }
 
     /*
      * Allocate a direct byte buffer that bypasses all GC and Java limits
      * and requires manual memory management. The memory will not be zeroed
-     * and will come from the new/delete in C++. The pointer can be freed
-     * using deleteCharArrayMemory.
+     * and will come from the new/delete in C++. The returned {@link BBContainer}
+     * ensures correct release using nativeDeleteCharArrayMemory.
      */
+    public static BBContainer allocateUnsafeByteBuffer(long size) {
+        return new NDBBWrapperContainer(nativeAllocateUnsafeByteBuffer(size));
+    }
+
     private static native ByteBuffer nativeAllocateUnsafeByteBuffer(long size);
 
     /*
-     * For managed buffers runs the cleaner, if there is no cleaner,
-     * called deleteCharArrayMemory on the address
+     * Run the cleaner on managed direct buffers
      */
     private static void cleanByteBuffer(ByteBuffer buf) {
         if (buf == null || !buf.isDirect()) {
             return;
         }
-        final DirectBuffer dbuf = (DirectBuffer) buf;
-        if (!VoltUnsafe.cleanDirectBuffer(buf)) {
-            deleteCharArrayMemory(dbuf.address());
-        }
+        VoltUnsafe.cleanDirectBuffer(buf);
     }
 }

--- a/src/frontend/org/voltcore/utils/DirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/DirectBufferCleaner.java
@@ -27,5 +27,5 @@ public interface DirectBufferCleaner {
      *
      * @param buf direct buffer.
      */
-    public boolean clean(ByteBuffer buf);
+    public void clean(ByteBuffer buf);
 }

--- a/src/frontend/org/voltcore/utils/ReflectiveDirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/ReflectiveDirectBufferCleaner.java
@@ -49,14 +49,11 @@ public class ReflectiveDirectBufferCleaner implements DirectBufferCleaner {
     }
 
     @Override
-    public boolean clean(ByteBuffer buf) {
+    public void clean(ByteBuffer buf) {
         try {
             Object cleaner = cleanerMtd.invoke(buf);
-            if (cleaner == null) {
-                return false;
-            }
+            assert cleaner != null;
             cleanMtd.invoke(cleaner);
-            return true;
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("Failed to invoke direct buffer cleaner", e);
         }

--- a/src/frontend/org/voltcore/utils/UnsafeDirectBufferCleaner.java
+++ b/src/frontend/org/voltcore/utils/UnsafeDirectBufferCleaner.java
@@ -16,10 +16,10 @@
  */
 
 package org.voltcore.utils;
-import sun.misc.Unsafe;
-
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+
+import sun.misc.Unsafe;
 
 /**
  * {@link DirectBufferCleaner} implementation based on {@code Unsafe.invokeCleaner} method.
@@ -40,8 +40,7 @@ public class UnsafeDirectBufferCleaner implements DirectBufferCleaner {
     }
 
     @Override
-    public boolean clean(ByteBuffer buf) {
+    public void clean(ByteBuffer buf) {
         VoltUnsafe.invoke(invokeCleanerMtd, buf);
-        return true;
     }
 }

--- a/src/frontend/org/voltcore/utils/VoltUnsafe.java
+++ b/src/frontend/org/voltcore/utils/VoltUnsafe.java
@@ -17,8 +17,6 @@
 
 package org.voltcore.utils;
 
-import sun.misc.Unsafe;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -26,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+
+import sun.misc.Unsafe;
 
 /*
  * <p>Wrapper for {@link sun.misc.Unsafe} class.</p>
@@ -62,10 +62,9 @@ public abstract class VoltUnsafe {
      *
      * @param buf Direct buffer.
      */
-    public static boolean cleanDirectBuffer(ByteBuffer buf) {
+    public static void cleanDirectBuffer(ByteBuffer buf) {
         assert buf.isDirect();
-
-        return DIRECT_BYTE_BUFFER_CLEANER.clean(buf);
+        DIRECT_BYTE_BUFFER_CLEANER.clean(buf);
     }
 
 

--- a/src/frontend/org/voltdb/PartitionDRGateway.java
+++ b/src/frontend/org/voltdb/PartitionDRGateway.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutionException;
 
-import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.iv2.SpScheduler.DurableUniqueIdListener;
 import org.voltdb.iv2.TransactionCommitInterest;
@@ -176,18 +175,14 @@ public class PartitionDRGateway implements DurableUniqueIdListener, TransactionC
     public void onSuccessfulProcedureCall(StoredProcedureInvocation spi) {}
     public void onSuccessfulMPCall(StoredProcedureInvocation spi) {}
     public long onBinaryDR(long lastCommittedSpHandle, int partitionId, long startSequenceNumber, long lastSequenceNumber,
-                           long lastSpUniqueId, long lastMpUniqueId, EventType eventType, ByteBuffer buf) {
-        final BBContainer cont = DBBPool.wrapBB(buf);
-        DBBPool.registerUnsafeMemory(cont.address());
+                           long lastSpUniqueId, long lastMpUniqueId, EventType eventType, BBContainer cont) {
         cont.discard();
         return -1;
     }
 
-    public void onPoisonPill(int partitionId, String reason, ByteBuffer failedBuf) {
+    public void onPoisonPill(int partitionId, String reason, BBContainer failedBufContainer) {
         m_debugDetectedPoisonPill = true;
-        final BBContainer cont = DBBPool.wrapBB(failedBuf);
-        DBBPool.registerUnsafeMemory(cont.address());
-        cont.discard();
+        failedBufContainer.discard();
     }
 
     @Override
@@ -201,21 +196,21 @@ public class PartitionDRGateway implements DurableUniqueIdListener, TransactionC
             long lastSpUniqueId,
             long lastMpUniqueId,
             int eventType,
-            ByteBuffer buf) {
+            BBContainer cont) {
         final PartitionDRGateway pdrg = m_partitionDRGateways.get(partitionId);
         if (pdrg == null) {
             return -1;
         }
         return pdrg.onBinaryDR(lastCommittedSpHandle, partitionId, startSequenceNumber, lastSequenceNumber,
-                lastSpUniqueId, lastMpUniqueId, EventType.values()[eventType], buf);
+                lastSpUniqueId, lastMpUniqueId, EventType.values()[eventType], cont);
     }
 
-    public static void pushPoisonPill(int partitionId, String reason, ByteBuffer failedBuf) {
+    public static void pushPoisonPill(int partitionId, String reason, BBContainer failedBufContainer) {
         final PartitionDRGateway pdrg = m_partitionDRGateways.get(partitionId);
         if (pdrg == null) {
             return;
         }
-        pdrg.onPoisonPill(partitionId, reason, failedBuf);
+        pdrg.onPoisonPill(partitionId, reason, failedBufContainer);
     }
 
     public void forceAllDRNodeBuffersToDisk(final boolean nofsync) {}

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -45,7 +45,6 @@ import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.BinaryPayloadMessage;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.utils.CoreUtils;
-import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.EstTime;
 import org.voltcore.utils.Pair;
@@ -729,18 +728,18 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             long committedSequenceNumber,
             int tupleCount,
             long uniqueId,
-            ByteBuffer buffer,
+            BBContainer cont,
             boolean poll) throws Exception {
         long lastSequenceNumber = calcEndSequenceNumber(startSequenceNumber, tupleCount);
         if (exportLog.isTraceEnabled()) {
             exportLog.trace("pushExportBufferImpl [" + startSequenceNumber + "," +
                     lastSequenceNumber + "], poll=" + poll);
         }
-        if (buffer != null) {
+        if (cont != null) {
+            ByteBuffer buffer = cont.b();
             // header space along is 8 bytes
             assert (buffer.capacity() > StreamBlock.HEADER_SIZE);
             buffer.order(ByteOrder.LITTLE_ENDIAN);
-            final BBContainer cont = DBBPool.wrapBB(buffer);
 
             // We should never try to push data on a source that is not in catalog
             if (!inCatalog()) {
@@ -827,7 +826,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
             final long committedSequenceNumber,
             final int tupleCount,
             final long uniqueId,
-            final ByteBuffer buffer) {
+            final BBContainer cont) {
         try {
             m_bufferPushPermits.acquire();
         } catch (InterruptedException e) {
@@ -846,7 +845,7 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                     try {
                         if (!m_closed) {
                             pushExportBufferImpl(startSequenceNumber, committedSequenceNumber,
-                                    tupleCount, uniqueId, buffer, m_readyForPolling);
+                                    tupleCount, uniqueId, cont, m_readyForPolling);
                         } else {
                             exportLogLimited.log("Closed: ignoring export buffer with " + tupleCount + " rows",
                                     EstTime.currentTimeMillis());

--- a/src/frontend/org/voltdb/export/ExportGeneration.java
+++ b/src/frontend/org/voltdb/export/ExportGeneration.java
@@ -47,7 +47,7 @@ import org.voltcore.messaging.HostMessenger;
 import org.voltcore.messaging.Mailbox;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
-import org.voltcore.utils.DBBPool;
+import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.EstTime;
 import org.voltcore.utils.Pair;
 import org.voltcore.utils.RateLimitedLogger;
@@ -814,7 +814,7 @@ public class ExportGeneration implements Generation {
     @Override
     public void pushExportBuffer(int partitionId, String tableName,
             long startSequenceNumber, long committedSequenceNumber,
-            int tupleCount, long uniqueId, ByteBuffer buffer) {
+            int tupleCount, long uniqueId, BBContainer container) {
 
         Map<String, ExportDataSource> sources = m_dataSourcesByPartition.get(partitionId);
 
@@ -824,8 +824,8 @@ public class ExportGeneration implements Generation {
                 exportLog.error("PUSH Could not find export data sources for partition "
                         + partitionId + ". The export data is being discarded.");
             }
-            if (buffer != null) {
-                DBBPool.wrapBB(buffer).discard();
+            if (container != null) {
+                container.discard();
             }
             return;
         }
@@ -841,14 +841,14 @@ public class ExportGeneration implements Generation {
                     + ") is being discarded.",
                     EstTime.currentTimeMillis());
 
-            if (buffer != null) {
-                DBBPool.wrapBB(buffer).discard();
+            if (container != null) {
+                container.discard();
             }
             return;
         }
 
         source.pushExportBuffer(startSequenceNumber, committedSequenceNumber,
-                tupleCount, uniqueId, buffer);
+                tupleCount, uniqueId, container);
     }
 
     private void cleanup() {

--- a/src/frontend/org/voltdb/export/ExportManagerInterface.java
+++ b/src/frontend/org/voltdb/export/ExportManagerInterface.java
@@ -18,12 +18,12 @@
 package org.voltdb.export;
 
 import java.lang.reflect.Constructor;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.voltcore.messaging.HostMessenger;
+import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltcore.zk.SynchronizedStatesManager;
 import org.voltdb.CatalogContext;
@@ -189,7 +189,7 @@ public interface ExportManagerInterface {
             long committedSequenceNumber,
             long tupleCount,
             long uniqueId,
-            ByteBuffer buffer);
+            BBContainer buffer);
 
     public void sync();
 

--- a/src/frontend/org/voltdb/export/Generation.java
+++ b/src/frontend/org/voltdb/export/Generation.java
@@ -16,10 +16,10 @@
  */
 package org.voltdb.export;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltdb.ExportStatsBase.ExportStatsRow;
 import org.voltdb.SnapshotCompletionMonitor.ExportSnapshotTuple;
 import org.voltdb.export.ExportDataSource.StreamStartAction;
@@ -37,7 +37,7 @@ public interface Generation {
     public void onSourceDrained(int partitionId, String tableName);
 
     public void pushExportBuffer(int partitionId, String signature, long seqNo, long committedSeqNo,
-            int tupleCount, long uniqueId, ByteBuffer buffer);
+            int tupleCount, long uniqueId, BBContainer container);
 
     public void updateInitialExportStateToSeqNo(int partitionId, String signature, StreamStartAction action,
             Map<Integer, ExportSnapshotTuple> sequenceNumberPerPartition);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.BackendTarget;
@@ -551,6 +552,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                     long tupleCount = getBytes(8).getLong();
                     long uniqueId = getBytes(8).getLong();
                     int length = getBytes(4).getInt();
+                    ByteBuffer buffer = length == 0 ? null : getBytes(length);
                     ExportManager.pushExportBuffer(
                             partitionId,
                             signature,
@@ -559,7 +561,7 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                             tupleCount,
                             uniqueId,
                             0,
-                            length == 0 ? null : getBytes(length));
+                            buffer == null ? null : DBBPool.wrapBB(buffer));
                 }
                 else if (status == kErrorCode_pushEndOfStream) {
                     ByteBuffer header = ByteBuffer.allocate(8);

--- a/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineJNI.java
@@ -135,7 +135,8 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     /*
      * For large result sets the EE will allocate new memory for the results
-     * and invoke a callback to set the allocated memory here.
+     * and invoke a callback to set the allocated memory here. This buffer will
+     * be deallocated by EE as well.
      */
     private ByteBuffer m_fallbackBuffer = null;
 
@@ -769,7 +770,7 @@ public class ExecutionEngineJNI extends ExecutionEngine {
 
     /*
      * Instead of using the reusable output buffer to get results for the next batch,
-     * use this buffer allocated by the EE. This is for one time use.
+     * use this buffer allocated by the EE. This is for one time use and is deallocated by EE.
      */
     public void fallbackToEEAllocatedBuffer(ByteBuffer buffer) {
         assert(buffer != null);

--- a/tests/frontend/org/voltdb/export/TestExportGeneration.java
+++ b/tests/frontend/org/voltdb/export/TestExportGeneration.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import org.voltcore.messaging.BinaryPayloadMessage;
 import org.voltcore.messaging.VoltMessage;
 import org.voltcore.utils.CoreUtils;
+import org.voltcore.utils.DBBPool;
 import org.voltcore.utils.Pair;
 import org.voltcore.zk.ZKUtil;
 import org.voltdb.MockVoltDB;
@@ -263,7 +264,7 @@ public class TestExportGeneration {
                     seqNo,
                     1,
                     0L,
-                    foo.duplicate()
+                    DBBPool.wrapBB(foo.duplicate())
                     );
             AckingContainer cont = (AckingContainer)m_expDs.poll().get();
             cont.updateStartTime(System.currentTimeMillis());
@@ -293,7 +294,7 @@ public class TestExportGeneration {
                 1L,
                 1,
                 0L,
-                foo.duplicate()
+                DBBPool.wrapBB(foo.duplicate())
                 );
 
         while( --retries >= 0 && size == m_expDs.sizeInBytes()) {
@@ -342,7 +343,7 @@ public class TestExportGeneration {
                 1L,
                 1,
                 0L,
-                foo.duplicate()
+                DBBPool.wrapBB(foo.duplicate())
                 );
 
         while( --retries >= 0 && size == m_expDs.sizeInBytes()) {


### PR DESCRIPTION
* Wrap EE's direct buffers into BBContainer in JNI topends
* Remove unneeded MEMCHECK_FULL code