### PR TITLE
ENG-19677: Use TxnId for replicated tables

### DIFF
--- a/src/ee/common/Topend.cpp
+++ b/src/ee/common/Topend.cpp
@@ -78,12 +78,6 @@ namespace voltdb {
         receivedExportBuffer = true;
     }
 
-    void DummyTopend::pushEndOfStream(int32_t partitionId, std::string signature) {
-        partitionIds.push(partitionId);
-        signatures.push(signature);
-        receivedExportBuffer = true;
-    }
-
     // only used for EE Test, ignore the committedSpHandle for now
     int64_t DummyTopend::pushDRBuffer(int32_t partitionId, DrStreamBlock *block) {
         receivedDRBuffer = true;

--- a/src/ee/common/Topend.h
+++ b/src/ee/common/Topend.h
@@ -68,11 +68,6 @@ class Topend {
             int32_t partitionId,
             std::string tableName,
             ExportStreamBlock *block) = 0;
-    // Not used right now and will be removed or altered after a decision has been made on how Schema changes
-    // are managed (they really don't belong in row buffers).
-    virtual void pushEndOfStream(
-            int32_t partitionId,
-            std::string tableName) = 0;
 
     virtual int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block) = 0;
 
@@ -141,7 +136,6 @@ public:
 
     int64_t getFlushedExportBytes(int32_t partitionId);
     virtual void pushExportBuffer(int32_t partitionId, std::string signature, ExportStreamBlock *block);
-    virtual void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block);
 

--- a/src/ee/common/TxnEgo.h
+++ b/src/ee/common/TxnEgo.h
@@ -1,0 +1,80 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2008-2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include "common/ids.h"
+
+namespace voltdb {
+
+/**
+ * Class to interact with transaction IDs either TxnId or SpHandle. This mirrors the java class of the same name.
+ */
+class TxnEgo {
+public:
+    /**
+     * @return the ID of the partition which generated id
+     */
+    static inline int16_t getPartitionId(TransactionId id) {
+        return static_cast<int16_t>(id & PARTITIONID_MASK);
+    }
+
+    /**
+     * @return the sequence number portion of  id
+     */
+    static inline int64_t getSequenceNumber(TransactionId id) {
+        return id >> PARTITIONID_BITS;
+    }
+
+    TxnEgo(TransactionId id) : m_id(id) {}
+
+    inline TransactionId getId() const {
+        return m_id;
+    }
+
+    /**
+     * @return the ID of the partition which generated this transaction ID
+     */
+    inline int16_t getPartitionId() const {
+        return getPartitionId(m_id);
+    }
+
+    /**
+     * @return the sequence number portion of this ID
+     */
+    inline int64_t getSequenceNumber() const {
+        return getSequenceNumber(m_id);
+    }
+
+    bool operator==(const TxnEgo& other) const {
+        return m_id == other.m_id;
+    }
+
+    bool operator!=(const TxnEgo& other) const {
+        return m_id != other.m_id;
+    }
+
+protected:
+    const static int64_t PARTITIONID_BITS = 14;
+    const static int64_t PARTITIONID_MASK = (1 << PARTITIONID_BITS) - 1;
+
+private:
+    const TransactionId m_id;
+};
+
+}

--- a/src/ee/common/executorcontext.cpp
+++ b/src/ee/common/executorcontext.cpp
@@ -332,7 +332,7 @@ void ExecutorContext::setDrStream(AbstractDRTupleStream *drStream) {
     vassert(m_drStream != NULL);
     vassert(drStream != NULL);
     vassert(m_drStream->m_committedSequenceNumber >= drStream->m_committedSequenceNumber);
-    int64_t lastCommittedSpHandle = std::max(m_lastCommittedSpHandle, drStream->m_openSpHandle);
+    int64_t lastCommittedSpHandle = std::max(m_lastCommittedSpHandle, drStream->m_openTxnId);
     m_drStream->periodicFlush(-1L, lastCommittedSpHandle);
     int64_t oldSeqNum = m_drStream->m_committedSequenceNumber;
     m_drStream = drStream;
@@ -345,7 +345,7 @@ void ExecutorContext::setDrReplicatedStream(AbstractDRTupleStream *drReplicatedS
         return;
     }
     vassert(m_drReplicatedStream->m_committedSequenceNumber >= drReplicatedStream->m_committedSequenceNumber);
-    int64_t lastCommittedSpHandle = std::max(m_lastCommittedSpHandle, drReplicatedStream->m_openSpHandle);
+    int64_t lastCommittedSpHandle = std::max(m_lastCommittedSpHandle, drReplicatedStream->m_openTxnId);
     m_drReplicatedStream->periodicFlush(-1L, lastCommittedSpHandle);
     int64_t oldSeqNum = m_drReplicatedStream->m_committedSequenceNumber;
     m_drReplicatedStream = drReplicatedStream;

--- a/src/ee/execution/JNITopend.cpp
+++ b/src/ee/execution/JNITopend.cpp
@@ -176,15 +176,6 @@ JNITopend::JNITopend(JNIEnv *env, jobject caller) : m_jniEnv(env), m_javaExecuti
         vassert(m_pushExportBufferMID != NULL);
         throw std::exception();
     }
-    m_pushExportEOFMID = m_jniEnv->GetStaticMethodID(
-            m_exportManagerClass,
-            "pushEndOfStream",
-            "(ILjava/lang/String;)V");
-    if (m_pushExportEOFMID == NULL) {
-        m_jniEnv->ExceptionDescribe();
-        vassert(m_pushExportEOFMID != NULL);
-        throw std::exception();
-    }
 
     m_partitionDRGatewayClass = m_jniEnv->FindClass("org/voltdb/PartitionDRGateway");
     if (m_partitionDRGatewayClass == NULL) {
@@ -626,23 +617,6 @@ void JNITopend::pushExportBuffer(
                 NULL,
                 NULL);
     }
-    m_jniEnv->DeleteLocalRef(tableNameString);
-    if (m_jniEnv->ExceptionCheck()) {
-        m_jniEnv->ExceptionDescribe();
-        throw std::exception();
-    }
-}
-
-void JNITopend::pushEndOfStream(
-        int32_t partitionId,
-        string tableName) {
-    jstring tableNameString = m_jniEnv->NewStringUTF(tableName.c_str());
-    //std::cout << "Block is null" << std::endl;
-    m_jniEnv->CallStaticVoidMethod(
-                    m_exportManagerClass,
-                    m_pushExportEOFMID,
-                    partitionId,
-                    tableNameString);
     m_jniEnv->DeleteLocalRef(tableNameString);
     if (m_jniEnv->ExceptionCheck()) {
         m_jniEnv->ExceptionDescribe();

--- a/src/ee/execution/JNITopend.h
+++ b/src/ee/execution/JNITopend.h
@@ -49,9 +49,6 @@ public:
             int32_t partitionId,
             std::string signature,
             ExportStreamBlock *block);
-    void pushEndOfStream(
-            int32_t partitionId,
-            std::string signature);
 
     int64_t pushDRBuffer(int32_t partitionId, DrStreamBlock *block);
 
@@ -97,7 +94,6 @@ private:
     jmethodID m_planForFragmentIdMID;
     jmethodID m_crashVoltDBMID;
     jmethodID m_pushExportBufferMID;
-    jmethodID m_pushExportEOFMID;
     jmethodID m_pushDRBufferMID;
     jmethodID m_pushPoisonPillMID;
     jmethodID m_reportDRConflictMID;

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -61,7 +61,7 @@ public:
         // Set m_opened = false first otherwise checkOpenTransaction() may
         // consider the transaction being rolled back as open.
         if (mark == INVALID_DR_MARK) {
-            m_openSpHandle = m_committedSpHandle;
+            m_openTxnId = m_committedTxnId;
             m_openUniqueId = m_committedUniqueId;
             m_openSequenceNumber = m_committedSequenceNumber;
             m_opened = false;

--- a/src/ee/storage/AbstractDRTupleStream.h
+++ b/src/ee/storage/AbstractDRTupleStream.h
@@ -163,7 +163,7 @@ private:
 
 class DRTupleStreamDisableGuard {
 public:
-    DRTupleStreamDisableGuard(ExecutorContext *ec, bool ignore) :
+    DRTupleStreamDisableGuard(const ExecutorContext *ec, bool ignore) :
             m_drStream(ec->drStream()), m_drReplicatedStream(ec->drReplicatedStream()), m_drStreamOldValue(ec->drStream()->m_guarded),
             m_drReplicatedStreamOldValue(m_drReplicatedStream?m_drReplicatedStream->m_guarded:true)
     {
@@ -171,7 +171,7 @@ public:
             setGuard();
         }
     }
-    DRTupleStreamDisableGuard(ExecutorContext *ec) :
+    DRTupleStreamDisableGuard(const ExecutorContext *ec) :
             m_drStream(ec->drStream()), m_drReplicatedStream(ec->drReplicatedStream()), m_drStreamOldValue(ec->drStream()->m_guarded),
             m_drReplicatedStreamOldValue(m_drReplicatedStream?m_drReplicatedStream->m_guarded:true)
     {

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -65,7 +65,7 @@ void ExportTupleStream::setGenerationIdCreated(int64_t generation) {
  */
 size_t ExportTupleStream::appendTuple(
         VoltDBEngine* engine,
-        int64_t spHandle,
+        int64_t txnId,
         int64_t seqNo,
         int64_t uniqueId,
         const TableTuple &tuple,
@@ -77,14 +77,14 @@ size_t ExportTupleStream::appendTuple(
 
     // Transaction IDs for transactions applied to this tuple stream
     // should always be moving forward in time.
-    if (spHandle < m_openSpHandle)
+    if (txnId < m_openSpHandle)
     {
         throwFatalException(
                 "Active transactions moving backwards: openSpHandle is %jd, while the append spHandle is %jd",
-                (intmax_t)m_openSpHandle, (intmax_t)spHandle
+                (intmax_t)m_openSpHandle, (intmax_t)txnId
                 );
     }
-    m_openSpHandle = spHandle;
+    m_openSpHandle = txnId;
     m_openUniqueId = uniqueId;
 
     // Compute the upper bound on bytes required to serialize tuple.
@@ -116,7 +116,7 @@ size_t ExportTupleStream::appendTuple(
     ExportSerializeOutput io(m_currBlock->mutableDataPtr() + streamHeaderSz, m_currBlock->remaining() - streamHeaderSz);
 
     // write metadata columns - data we always write this.
-    io.writeLong(spHandle);
+    io.writeLong(txnId);
     io.writeLong(UniqueId::ts(uniqueId));
     io.writeLong(seqNo);
     io.writeLong(m_partitionId);
@@ -230,9 +230,9 @@ void ExportTupleStream::removeFromFlushList(VoltDBEngine* engine, bool moveToTai
 /*
  * Handoff fully committed blocks to the top end.
  */
-void ExportTupleStream::commit(VoltDBEngine* engine, int64_t currentSpHandle, int64_t uniqueId)
+void ExportTupleStream::commit(VoltDBEngine* engine, int64_t currentTxnId, int64_t uniqueId)
 {
-    vassert(currentSpHandle == m_openSpHandle && uniqueId == m_openUniqueId);
+    vassert(currentTxnId == m_openSpHandle && uniqueId == m_openUniqueId);
 
     if (m_uso != m_committedUso) {
         m_committedUso = m_uso;
@@ -296,7 +296,7 @@ void ExportTupleStream::pushEndOfStream() {
  * pending list for commit to operate against.
  */
 bool ExportTupleStream::periodicFlush(int64_t timeInMillis,
-                                      int64_t lastCommittedSpHandle)
+                                      int64_t lastCommittedTxnId)
 {
     // negative timeInMillis instructs a mandatory flush
     vassert(timeInMillis < 0 || (timeInMillis - m_lastFlush > s_exportFlushTimeout));

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -285,12 +285,6 @@ void ExportTupleStream::pushStreamBuffer(ExportStreamBlock *block) {
                     block);
 }
 
-void ExportTupleStream::pushEndOfStream() {
-    ExecutorContext::getPhysicalTopend()->pushEndOfStream(
-                    m_partitionId,
-                    m_tableName);
-}
-
 /*
  * Create a new buffer and flush all pending committed data.
  * Creating a new buffer will push all queued data into the

--- a/src/ee/storage/ExportTupleStream.cpp
+++ b/src/ee/storage/ExportTupleStream.cpp
@@ -18,6 +18,7 @@
 #include "storage/ExportTupleStream.h"
 #include "execution/VoltDBEngine.h"
 #include "common/TupleSchema.h"
+#include "common/TxnEgo.h"
 #include "common/UniqueId.hpp"
 
 #include <cstdio>
@@ -119,7 +120,8 @@ size_t ExportTupleStream::appendTuple(
     io.writeLong(txnId);
     io.writeLong(UniqueId::ts(uniqueId));
     io.writeLong(seqNo);
-    io.writeLong(m_partitionId);
+    // Report the TxnId partition ID
+    io.writeLong(TxnEgo::getPartitionId(txnId));
     io.writeLong(m_siteId);
     // use 1 for INSERT EXPORT op
     io.writeByte(static_cast<int8_t>(type));

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -91,7 +91,7 @@ public:
     /** write a tuple to the stream */
     virtual size_t appendTuple(
             VoltDBEngine* engine,
-            int64_t spHandle,
+            int64_t txnId,
             int64_t seqNo,
             int64_t uniqueId,
             const TableTuple &tuple,
@@ -99,7 +99,7 @@ public:
             ExportTupleStream::STREAM_ROW_TYPE type);
 
     /** Close Txn and send full buffers with committed data to the top end. */
-    void commit(VoltDBEngine* engine, int64_t spHandle, int64_t uniqueId);
+    void commit(VoltDBEngine* engine, int64_t txnId, int64_t uniqueId);
     inline void rollbackExportTo(size_t mark, int64_t seqNo) {
         // make the stream of tuples contiguous outside of actual system failures
         vassert(seqNo > m_committedSequenceNumber && m_nextSequenceNumber > m_committedSequenceNumber);
@@ -132,7 +132,7 @@ public:
         return (timeInMillis < 0 || (timeInMillis - m_lastFlush > s_exportFlushTimeout));
     }
     virtual bool periodicFlush(int64_t timeInMillis,
-                               int64_t lastComittedSpHandle);
+                               int64_t lastComittedTxnId);
     virtual void extendBufferChain(size_t minLength);
 
     virtual int partitionId() { return m_partitionId; }

--- a/src/ee/storage/ExportTupleStream.h
+++ b/src/ee/storage/ExportTupleStream.h
@@ -86,7 +86,6 @@ public:
     }
 
     void pushStreamBuffer(ExportStreamBlock *block);
-    void pushEndOfStream();
 
     /** write a tuple to the stream */
     virtual size_t appendTuple(

--- a/src/ee/storage/persistenttable.cpp
+++ b/src/ee/storage/persistenttable.cpp
@@ -287,7 +287,7 @@ void PersistentTable::nextFreeTuple(TableTuple* tuple) {
     }
 }
 
-void PersistentTable::drLogTruncate(ExecutorContext* ec, bool fallible) {
+void PersistentTable::drLogTruncate(const ExecutorContext* ec, bool fallible) {
     AbstractDRTupleStream* drStream = getDRTupleStream(ec);
     if (doDRActions(drStream)) {
         int64_t currentSpHandle = ec->currentSpHandle();
@@ -305,12 +305,11 @@ void PersistentTable::drLogTruncate(ExecutorContext* ec, bool fallible) {
 
 void PersistentTable::deleteAllTuples(bool, bool fallible) {
     // Instead of recording each tuple deletion, log it as a table truncation DR.
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
-    drLogTruncate(ec, fallible);
+    drLogTruncate(m_executorContext, fallible);
 
     // Temporarily disable DR binary logging so that it doesn't record the
     // individual deletions below.
-    DRTupleStreamDisableGuard drGuard(ec, false);
+    DRTupleStreamDisableGuard drGuard(m_executorContext, false);
 
     // nothing interesting
     TableIterator ti(this, m_data.begin());
@@ -407,7 +406,7 @@ template<class T> static inline PersistentTable* constructEmptyDestTable(
 void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, bool fallible) {
     if (isPersistentTableEmpty()) {
         // Always log the the truncate if dr is enabled, see ENG-14528.
-        drLogTruncate(ExecutorContext::getExecutorContext(), fallible);
+        drLogTruncate(m_executorContext, fallible);
         return;
     }
 
@@ -539,10 +538,9 @@ void PersistentTable::truncateTable(VoltDBEngine* engine, bool replicatedTable, 
 
     engine->rebuildTableCollections(replicatedTable, false);
 
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
-    drLogTruncate(ec, fallible);
+    drLogTruncate(m_executorContext, fallible);
 
-    UndoQuantum* uq = ec->getCurrentUndoQuantum();
+    UndoQuantum* uq = m_executorContext->getCurrentUndoQuantum();
     if (uq) {
         if (!fallible) {
             throwFatalException("Attempted to truncate table %s when there was an "
@@ -834,12 +832,10 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
         setDRTimestampForTuple(target, false);
     }
 
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
-    AbstractDRTupleStream* drStream = getDRTupleStream(ec);
+    AbstractDRTupleStream* drStream = getDRTupleStream(m_executorContext);
     if (doDRActions(drStream) && shouldDRStream) {
-        ExecutorContext* ec = ExecutorContext::getExecutorContext();
-        int64_t currentSpHandle = ec->currentSpHandle();
-        int64_t currentUniqueId = ec->currentUniqueId();
+        int64_t currentSpHandle = m_executorContext->currentSpHandle();
+        int64_t currentUniqueId = m_executorContext->currentUniqueId();
         size_t drMark = drStream->appendTuple(m_signature, m_partitionColumn, currentSpHandle,
                                               currentUniqueId, target, DR_RECORD_INSERT);
 
@@ -911,7 +907,7 @@ void PersistentTable::doInsertTupleCommon(TableTuple& source, TableTuple& target
                 vassert(m_shadowStream != nullptr);
 
                 // insert to partitioned table or partition id 0 for replicated
-                if (!isReplicatedTable() || ec->getPartitionId() == 0) {
+                if (!isReplicatedTable() || m_executorContext->getPartitionId() == 0) {
                      m_shadowStream->streamTuple(target, ExportTupleStream::STREAM_ROW_TYPE::INSERT);
                 }
             }
@@ -988,7 +984,6 @@ void PersistentTable::updateTupleWithSpecificIndexes(
     UndoQuantum* uq = NULL;
     char* oldTupleData = NULL;
     int tupleLength = targetTupleToUpdate.tupleLength();
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
 
     /**
      * Check for index constraint violations.
@@ -1015,7 +1010,7 @@ void PersistentTable::updateTupleWithSpecificIndexes(
              */
            oldTupleData = partialCopyToPool(uq->getPool(), targetTupleToUpdate.address(), targetTupleToUpdate.tupleLength());
            // We assume that only fallible and undoable UPDATEs should be propagated to the EXPORT Shadow Stream
-           if (!isReplicatedTable() || ec->getPartitionId() == 0) {
+           if (!isReplicatedTable() || m_executorContext->getPartitionId() == 0) {
                if (isTableWithExportUpdateOld(m_tableType)) {
                    m_shadowStream->streamTuple(targetTupleToUpdate, ExportTupleStream::STREAM_ROW_TYPE::UPDATE_OLD);
                }
@@ -1046,10 +1041,10 @@ void PersistentTable::updateTupleWithSpecificIndexes(
        }
     }
 
-    AbstractDRTupleStream* drStream = getDRTupleStream(ec);
+    AbstractDRTupleStream* drStream = getDRTupleStream(m_executorContext);
     if (!fromMigrate && doDRActions(drStream)) {
-        int64_t currentSpHandle = ec->currentSpHandle();
-        int64_t currentUniqueId = ec->currentUniqueId();
+        int64_t currentSpHandle = m_executorContext->currentSpHandle();
+        int64_t currentUniqueId = m_executorContext->currentUniqueId();
         size_t drMark = drStream->appendUpdateRecord(m_signature, m_partitionColumn, currentSpHandle,
                 currentUniqueId, targetTupleToUpdate, sourceTupleWithNewValues);
 
@@ -1140,7 +1135,7 @@ void PersistentTable::updateTupleWithSpecificIndexes(
         vassert(isTableWithMigrate(m_tableType) && m_shadowStream != nullptr);
         migratingAdd(getTableTxnId(), targetTupleToUpdate);
         // add to shadow stream if the table is partitioned or partition 0 for replicated table
-        if (!isReplicatedTable() || ec->getPartitionId() == 0) {
+        if (!isReplicatedTable() || m_executorContext->getPartitionId() == 0) {
             m_shadowStream->streamTuple(sourceTupleWithNewValues, ExportTupleStream::MIGRATE, doDRActions(drStream) ? drStream : NULL);
         }
     }
@@ -1278,11 +1273,10 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible, bool remove
 
     // Write to the DR stream before doing anything else to ensure nothing will
     // be left forgotten in case this throws.
-    ExecutorContext* ec = ExecutorContext::getExecutorContext();
-    AbstractDRTupleStream* drStream = getDRTupleStream(ec);
+    AbstractDRTupleStream* drStream = getDRTupleStream(m_executorContext);
     if (doDRActions(drStream)) {
-        int64_t currentSpHandle = ec->currentSpHandle();
-        int64_t currentUniqueId = ec->currentUniqueId();
+        int64_t currentSpHandle = m_executorContext->currentSpHandle();
+        int64_t currentUniqueId = m_executorContext->currentUniqueId();
         size_t drMark = drStream->appendTuple(m_signature, m_partitionColumn, currentSpHandle,
                                               currentUniqueId, target, DR_RECORD_DELETE);
 
@@ -1309,7 +1303,7 @@ void PersistentTable::deleteTuple(TableTuple& target, bool fallible, bool remove
         SynchronizedThreadLock::addUndoAction(isReplicatedTable(), uq, undoAction, this);
         if (isTableWithExportDeletes(m_tableType)) {
             vassert(m_shadowStream != nullptr);
-            if (!isReplicatedTable() || ec->getPartitionId() == 0) {
+            if (!isReplicatedTable() || m_executorContext->getPartitionId() == 0) {
                 m_shadowStream->streamTuple(target, ExportTupleStream::STREAM_ROW_TYPE::DELETE);
             }
         }
@@ -2205,7 +2199,7 @@ void PersistentTableSurgeon::activateSnapshot() {
 
 std::pair<TableIndex const*, uint32_t> PersistentTable::getUniqueIndexForDR() {
     // In active-active we always send full tuple instead of just index tuple.
-    bool isActiveActive = ExecutorContext::getExecutorContext()->getEngine()->getIsActiveActiveDREnabled();
+    bool isActiveActive = m_executorContext->getEngine()->getIsActiveActiveDREnabled();
     if (isActiveActive) {
         TableIndex* nullIndex = NULL;
         return std::make_pair(nullIndex, 0);

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -657,7 +657,7 @@ private:
                                     std::vector<TableIndex*> const& indexesToUpdate);
 
     // Add truncate operation to dr log stream if dr is enabled and running
-    void drLogTruncate(ExecutorContext* ec, bool fallible);
+    void drLogTruncate(const ExecutorContext* ec, bool fallible);
 
     void notifyBlockWasCompactedAway(TBPtr block);
 
@@ -717,7 +717,7 @@ private:
 
     TBPtr allocateNextBlock();
 
-    AbstractDRTupleStream* getDRTupleStream(ExecutorContext* ec) {
+    AbstractDRTupleStream* getDRTupleStream(const ExecutorContext* ec) {
         if (isReplicatedTable()) {
             return ec->drReplicatedStream();
         }

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -37,30 +37,26 @@
 
 using namespace voltdb;
 
-StreamedTable::StreamedTable(int partitionColumn)
-    : Table(1)
+StreamedTable::StreamedTable(int partitionColumn, bool isReplicated)
+    : ViewableAndReplicableTable(1, partitionColumn, isReplicated)
     , m_stats(this)
-    , m_executorContext(ExecutorContext::getExecutorContext())
     , m_wrapper(NULL)
     , m_sequenceNo(0)
-    , m_partitionColumn(partitionColumn)
 {
 }
 
-StreamedTable::StreamedTable(ExportTupleStream *wrapper, int partitionColumn)
-    : Table(1)
+StreamedTable::StreamedTable(ExportTupleStream *wrapper, int partitionColumn, bool isReplicated)
+    : ViewableAndReplicableTable(1, partitionColumn, isReplicated)
     , m_stats(this)
-    , m_executorContext(ExecutorContext::getExecutorContext())
     , m_wrapper(wrapper)
     , m_sequenceNo(0)
-    , m_partitionColumn(partitionColumn)
 {
 }
 
 StreamedTable *
 StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
     TupleSchema *schema, std::string tableName, std::vector<std::string> & columnNames) {
-    StreamedTable * st = new StreamedTable();
+    StreamedTable * st = new StreamedTable(-1, true);
     st->m_name = tableName;
     st->m_wrapper = new ExportTupleStream(ctx->m_partitionId, ctx->m_siteId, 0, st->m_name);
     st->initializeWithColumns(schema, columnNames, false, wrapperBufSize);
@@ -68,34 +64,7 @@ StreamedTable::createForTest(size_t wrapperBufSize, ExecutorContext *ctx,
     return st;
 }
 
-/*
- * claim ownership of a view. table is responsible for this view*
- */
-void StreamedTable::addMaterializedView(MaterializedViewTriggerForStreamInsert* view) {
-    m_views.push_back(view);
-}
-
-void StreamedTable::dropMaterializedView(MaterializedViewTriggerForStreamInsert* targetView) {
-    vassert( ! m_views.empty());
-    MaterializedViewTriggerForStreamInsert* lastView = m_views.back();
-    if (targetView != lastView) {
-        // iterator to vector element:
-        std::vector<MaterializedViewTriggerForStreamInsert*>::iterator toView = find(m_views.begin(), m_views.end(), targetView);
-        vassert(toView != m_views.end());
-        // Use the last view to patch the potential hole.
-        *toView = lastView;
-    }
-    // The last element is now excess.
-    m_views.pop_back();
-    delete targetView;
-}
-
 StreamedTable::~StreamedTable() {
-    // note this class has ownership of the views, even if they
-    // were allocated by VoltDBEngine
-    for (int i = 0; i < m_views.size(); i++) {
-        delete m_views[i];
-    }
     //When stream is dropped its wrapper is kept safe in pending list until tick or push pushes all buffers and deleted there after.
     if (m_wrapper) {
         delete m_wrapper;
@@ -108,8 +77,7 @@ void StreamedTable::notifyQuantumRelease() {
         if (m_migrateTxnSizeGuard.undoToken == getLastSeenUndoToken()) {
             m_migrateTxnSizeGuard.reset();
         }
-        m_wrapper->commit(m_executorContext->getContextEngine(),
-                m_executorContext->currentSpHandle(), m_executorContext->currentUniqueId());
+        m_wrapper->commit(m_executorContext->getContextEngine(), getTableTxnId(), m_executorContext->currentUniqueId());
     }
 }
 
@@ -139,7 +107,7 @@ void StreamedTable::streamTuple(TableTuple &source, ExportTupleStream::STREAM_RO
         int64_t currSequenceNo = ++m_sequenceNo;
         vassert(m_columnNames.size() == source.columnCount());
         size_t mark = m_wrapper->appendTuple(m_executorContext->getContextEngine(),
-                                      m_executorContext->currentSpHandle(),
+                                      getTableTxnId(),
                                       currSequenceNo,
                                       m_executorContext->currentUniqueId(),
                                       source,

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -21,8 +21,8 @@
 #include <vector>
 
 #include "common/ids.h"
-#include "table.h"
 
+#include "storage/viewableandreplicabletable.h"
 #include "storage/StreamedTableStats.h"
 #include "storage/TableStats.h"
 
@@ -56,14 +56,14 @@ public:
  * are passed through a ExportTupleStream to Export. The table exists
  * only to support Export.
  */
-class StreamedTable : public Table, public UndoQuantumReleaseInterest {
+class StreamedTable : public ViewableAndReplicableTable<MaterializedViewTriggerForStreamInsert>, public UndoQuantumReleaseInterest {
     friend class TableFactory;
     friend class StreamedTableStats;
 
 public:
-    StreamedTable(int partitionColumn = -1);
+    StreamedTable(int partitionColumn, bool isReplicated);
     //Used for test
-    StreamedTable(ExportTupleStream *wrapper, int partitionColumn = -1);
+    StreamedTable(ExportTupleStream *wrapper, int partitionColumn = -1, bool isReplicated = true);
     static StreamedTable* createForTest(size_t, ExecutorContext*, TupleSchema *schema,
             std::string tableName, std::vector<std::string> & columnNames);
 
@@ -94,12 +94,6 @@ public:
     // There's no reason to actually use MatViewType in the class definition.
     // That would just make the code a little harder to analyze.
     typedef MaterializedViewTriggerForStreamInsert MatViewType;
-
-    /** Add/drop/list materialized views to this table */
-    void addMaterializedView(MaterializedViewTriggerForStreamInsert* view);
-    void dropMaterializedView(MaterializedViewTriggerForStreamInsert* targetView);
-    std::vector<MaterializedViewTriggerForStreamInsert*>& views() { return m_views; }
-    bool hasViews() { return (m_views.size() > 0); }
 
     virtual std::string tableType() const { return "StreamedTable"; }
 
@@ -166,15 +160,8 @@ private:
     virtual void nextFreeTuple(TableTuple *tuple);
 
     voltdb::StreamedTableStats m_stats;
-    ExecutorContext *m_executorContext;
     ExportTupleStream *m_wrapper;
     int64_t m_sequenceNo;
-
-    // partition key
-    const int m_partitionColumn;
-
-    // list of materialized views that are sourced from this table
-    std::vector<MaterializedViewTriggerForStreamInsert*> m_views;
 
     // Used to prevent migrate transaction from generating >50MB DR binary log
     MigrateTxnSizeGuard m_migrateTxnSizeGuard;

--- a/src/ee/storage/tablefactory.cpp
+++ b/src/ee/storage/tablefactory.cpp
@@ -62,7 +62,7 @@ Table* TableFactory::getPersistentTable(
     PersistentTable *persistentTable = NULL;
 
     if (tableTypeIsStream(tableType)) {
-        table = streamedTable = new StreamedTable(partitionColumn);
+        table = streamedTable = new StreamedTable(partitionColumn, isReplicated);
     } else {
         table = persistentTable = new PersistentTable(
                 partitionColumn, signature, tableIsMaterialized, tableAllocationTargetSize,
@@ -91,7 +91,7 @@ Table* TableFactory::getPersistentTable(
 
     // If a regular table with export enabled, create a companion streamed table
     if (isTableWithStream(tableType)) {
-        streamedTable = new StreamedTable(partitionColumn);
+        streamedTable = new StreamedTable(partitionColumn, isReplicated);
         initCommon(databaseId, streamedTable, name, schema, columnNames,
                    false,  // companion streamed table will NOT take ownership of TupleSchema object
                    compactionThreshold);

--- a/src/ee/storage/viewableandreplicabletable.h
+++ b/src/ee/storage/viewableandreplicabletable.h
@@ -1,0 +1,101 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "storage/table.h"
+
+namespace voltdb {
+
+/**
+ * Base class for tables which can either be replicated or partitioned.
+ *
+ * All views which are added to this class are considered to be owned by this class and deleted
+ * when this classes destructor is called.
+ */
+template<class ViewType>
+class ViewableAndReplicableTable : public Table {
+public:
+    virtual ~ViewableAndReplicableTable() {
+        // note this class has ownership of the views, even if they were allocated by VoltDBEngine
+        for (auto view : m_views) {
+            delete view;
+        }
+    }
+
+    /**
+     * @return true if this table is a replicated table
+     */
+    inline bool isReplicatedTable() const {
+        return m_isReplicated;
+    }
+
+    /**
+     * @return the TxnId which is appropriate for this table type
+     */
+    TransactionId getTableTxnId() const {
+        return isReplicatedTable() ? m_executorContext->currentTxnId() : m_executorContext->currentSpHandle();
+    }
+
+    /*
+     * claim ownership of a view. table is responsible for this view*
+     */
+    void addMaterializedView(ViewType* view) {
+        m_views.push_back(view);
+    }
+
+    /*
+     * drop a view. the table is no longer feeding it.
+     * The destination table will go away when the view metadata is deleted (or later?) as its refcount goes to 0.
+     */
+    void dropMaterializedView(ViewType* targetView) {
+        vassert( ! m_views.empty());
+        ViewType* lastView = m_views.back();
+        if (targetView != lastView) {
+            // iterator to vector element:
+            auto toView = find(m_views.begin(), m_views.end(), targetView);
+            vassert(toView != m_views.end());
+            // Use the last view to patch the potential hole.
+            *toView = lastView;
+        }
+        // The last element is now excess.
+        m_views.pop_back();
+        delete targetView;
+    }
+
+    std::vector<ViewType*>& views() { return m_views; }
+
+    bool hasViews() { return (m_views.size() > 0); }
+
+protected:
+    ViewableAndReplicableTable(int tableAllocationTargetSize, int partitionColumn, bool isReplicated) :
+            Table(tableAllocationTargetSize),
+            m_partitionColumn(partitionColumn), m_isReplicated(isReplicated), m_views() {}
+
+    // If the table is partitioned which column it is partitioned on
+    const int m_partitionColumn;
+
+    // If true this table is replicated otherwise this table is partitioned
+    const bool m_isReplicated;
+
+    // Cached pointer to the executor context
+    const ExecutorContext* m_executorContext = ExecutorContext::getExecutorContext();
+
+    // list of materialized views that are sourced from this table
+    std::vector<ViewType*> m_views;
+};
+}

--- a/src/ee/voltdbipc.cpp
+++ b/src/ee/voltdbipc.cpp
@@ -79,7 +79,6 @@ public:
         kErrorCode_needPlan = 110,                     // fetch a plan from java for a fragment
         kErrorCode_progressUpdate = 111,               // Update Java on execution progress
         kErrorCode_decodeBase64AndDecompress = 112,    // Decode base64, compressed data
-        kErrorCode_pushEndOfStream = 113,              // Push EOF for dropped stream.
         kErrorCode_callJavaUserDefinedAggregateStart = 114,  // Notify the frontend to call a Java user-defined aggregate function start method.
         kErrorCode_callJavaUserDefinedAggregateAssemble = 115,  // Notify the frontend to call a Java user-defined aggregate function assemble method.
         kErrorCode_callJavaUserDefinedAggregateCombine = 116,  // Notify the frontend to call a Java user-defined aggregate function combine method.
@@ -151,7 +150,6 @@ public:
 
     int64_t getQueuedExportBytes(int32_t partitionId, std::string signature);
     void pushExportBuffer(int32_t partitionId, std::string signature, voltdb::ExportStreamBlock *block);
-    void pushEndOfStream(int32_t partitionId, std::string signature);
 
     int reportDRConflict(int32_t partitionId, int32_t remoteClusterId, int64_t remoteTimestamp, std::string tableName, voltdb::DRRecordType action,
             voltdb::DRConflictType deleteConflict, voltdb::Table *existingMetaTableForDelete, voltdb::Table *existingTupleTableForDelete,
@@ -1876,21 +1874,6 @@ void VoltDBIPC::pushExportBuffer(
         *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(0);
         writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, index + 4);
     }
-}
-
-void VoltDBIPC::pushEndOfStream(
-        int32_t partitionId,
-        std::string signature) {
-    int32_t index = 0;
-    m_reusedResultBuffer[index++] = kErrorCode_pushExportBuffer;
-    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(partitionId);
-    index += 4;
-    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(static_cast<int32_t>(signature.size()));
-    index += 4;
-    ::memcpy( &m_reusedResultBuffer[index], signature.c_str(), signature.size());
-    index += static_cast<int32_t>(signature.size());
-    *reinterpret_cast<int32_t*>(&m_reusedResultBuffer[index]) = htonl(0);
-    writeOrDie(m_fd, (unsigned char*)m_reusedResultBuffer, index + 4);
 }
 
 void VoltDBIPC::executeTask(struct ipc_command *cmd) {

--- a/src/frontend/org/voltdb/export/AckingContainer.java
+++ b/src/frontend/org/voltdb/export/AckingContainer.java
@@ -31,7 +31,7 @@ public class AckingContainer extends BBContainer {
     // Note: the schema doesn't need an explicit discard
     ExportRowSchema m_schema;
     long m_startTime = 0;
-    long m_commitSpHandle = 0;
+    long m_commitTxnId = 0;
     private static VoltLogger EXPORT_LOG = new VoltLogger("EXPORT");
 
     private AckingContainer(ExportDataSource source, BBContainer cont,
@@ -70,8 +70,8 @@ public class AckingContainer extends BBContainer {
         return m_commitSeqNo;
     }
 
-    public void setCommittedSpHandle(long spHandle) {
-        m_commitSpHandle = spHandle;
+    public void setCommittedTxnId(long txnId) {
+        m_commitTxnId = txnId;
     }
 
     long getStartSeqNo() {
@@ -105,7 +105,7 @@ public class AckingContainer extends BBContainer {
         checkDoubleFree();
         internalDiscard(false);
         try {
-            m_source.advance(m_lastSeqNo, m_commitSeqNo, m_commitSpHandle, m_startTime);
+            m_source.advance(m_lastSeqNo, m_commitSeqNo, m_commitTxnId, m_startTime);
         } catch (RejectedExecutionException rej) {
             //Don't expect this to happen outside of test, but in test it's harmless
             if (EXPORT_LOG.isDebugEnabled()) {

--- a/src/frontend/org/voltdb/export/ExportDataSource.java
+++ b/src/frontend/org/voltdb/export/ExportDataSource.java
@@ -1192,11 +1192,11 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
      *
      * @param lastSeqNo the export sequence number advances to
      * @param commitSeqNo the committed export sequence number
-     * @param commitSpHandle the committed SpHandle
+     * @param commitTxnId the committed TxnId
      * @param startTime the time of when the buffer is delivered to export client
      * @throws RejectedExecutionException - if the stream's task executor cannot accept the task
      */
-    public void advance(long lastSeqNo, long commitSeqNo, long commitSpHandle, long startTime) {
+    public void advance(long lastSeqNo, long commitSeqNo, long commitTxnId, long startTime) {
         m_es.execute(new Runnable() {
             @Override
             public void run() {
@@ -1215,8 +1215,8 @@ public class ExportDataSource implements Comparable<ExportDataSource> {
                 try {
                     localAck(commitSeqNo, lastSeqNo);
                     forwardAckToOtherReplicas();
-                    if (m_migrateRowsDeleter != null && commitSpHandle > 0 && m_coordinator.isMaster()) {
-                        m_migrateRowsDeleter.delete(commitSpHandle);
+                    if (m_migrateRowsDeleter != null && commitTxnId > 0 && m_coordinator.isMaster()) {
+                        m_migrateRowsDeleter.delete(commitTxnId);
                     }
                 } catch (Exception e) {
                     exportLog.error("Error acking export buffer", e);

--- a/src/frontend/org/voltdb/export/ExportManager.java
+++ b/src/frontend/org/voltdb/export/ExportManager.java
@@ -539,14 +539,6 @@ public class ExportManager implements ExportManagerInterface
     }
 
     /*
-     * End of stream indicates that no more data is coming from this source
-     * for this generation.
-     */
-    public static void pushEndOfStream(
-            int partitionId,
-            String tableName) {
-    }
-    /*
      * Push an export buffer
      */
     public static void pushExportBuffer(

--- a/src/frontend/org/voltdb/export/processors/GuestProcessor.java
+++ b/src/frontend/org/voltdb/export/processors/GuestProcessor.java
@@ -336,7 +336,7 @@ public class GuestProcessor implements ExportDataProcessor {
                         int backoffQuantity = 10 + (int)(10 * ThreadLocalRandom.current().nextDouble());
 
                         // Extract the sp handle of the last committed row in the block, if present
-                        long committedSpHandle = 0L;
+                        long committedTxnId = 0L;
 
                         /*
                          * If there is an error processing the block the decoder thinks is recoverable
@@ -385,8 +385,8 @@ public class GuestProcessor implements ExportDataProcessor {
                                         firstRowOfBlock = false;
                                     }
                                     edb.processRow(row);
-                                    if (committedSpHandle == 0) {
-                                        committedSpHandle = extractCommittedSpHandle(row, cont.getCommittedSeqNo());
+                                    if (committedTxnId == 0) {
+                                        committedTxnId = extractCommittedTxnId(row, cont.getCommittedSeqNo());
                                     }
                                 }
                                 if (row != null) {
@@ -407,10 +407,10 @@ public class GuestProcessor implements ExportDataProcessor {
                                 // that container isn't fully consumed. Discard the buffer prematurely
                                 // would cause missing rows in export stream.
                                 if (!m_shutdown && cont != null) {
-                                    if (committedSpHandle != 0) {
+                                    if (committedTxnId != 0) {
                                         // We came across the last committed row in the buffer,
                                         // record its sp handle
-                                        cont.setCommittedSpHandle(committedSpHandle);
+                                        cont.setCommittedTxnId(committedTxnId);
                                     }
                                     cont.discard();
                                     cont = null;
@@ -479,7 +479,7 @@ public class GuestProcessor implements ExportDataProcessor {
      * @param committedSeqNo the sequence number of the last committed row
      * @return
      */
-    private long extractCommittedSpHandle(ExportRow row, long committedSeqNo) {
+    private long extractCommittedTxnId(ExportRow row, long committedSeqNo) {
         long ret = 0;
         if (committedSeqNo == ExportDataSource.NULL_COMMITTED_SEQNO) {
             return ret;

--- a/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
+++ b/src/frontend/org/voltdb/jni/ExecutionEngineIPC.java
@@ -290,11 +290,6 @@ public class ExecutionEngineIPC extends ExecutionEngine {
         static final int kErrorCode_callJavaUserDefinedFunction = 107;
 
         /**
-         * An error code that can be sent at any time indicating that an export stream is dropped
-         */
-        static final int kErrorCode_pushEndOfStream = 113;
-
-        /**
          * Instruct the Java side to start a user-defined aggregate function.
          */
         static final int kErrorCode_callJavaUserDefinedAggregateStart = 114;
@@ -569,32 +564,6 @@ public class ExecutionEngineIPC extends ExecutionEngine {
                             uniqueId,
                             0,
                             buffer == null ? null : DBBPool.wrapBB(buffer));
-                }
-                else if (status == kErrorCode_pushEndOfStream) {
-                    ByteBuffer header = ByteBuffer.allocate(8);
-                    while (header.hasRemaining()) {
-                        final int read = m_socket.getChannel().read(header);
-                        if (read == -1) {
-                            throw new EOFException();
-                        }
-                    }
-                    header.flip();
-
-                    int partitionId = header.getInt();
-                    int signatureLength = header.getInt();
-                    ByteBuffer sigbuf = ByteBuffer.allocate(signatureLength);
-                    while (sigbuf.hasRemaining()) {
-                        final int read = m_socket.getChannel().read(sigbuf);
-                        if (read == -1) {
-                            throw new EOFException();
-                        }
-                    }
-                    sigbuf.flip();
-                    byte signatureBytes[] = new byte[signatureLength];
-                    sigbuf.get(signatureBytes);
-                    String signature = new String(signatureBytes, "UTF-8");
-
-                    ExportManager.pushEndOfStream(partitionId, signature);
                 }
                 else if (status == ExecutionEngine.ERRORCODE_DECODE_BASE64_AND_DECOMPRESS) {
                     int dataLength = m_connection.readInt();


### PR DESCRIPTION
In export and migration use the TxnId for replicated tables and the
SpHandle for partitioned tables. This allows the transaction ID column
of replication to always be in the same number space and increase in
value. This also keeps it so that the same transaction ID is used to
identify migrating rows in replicated tables.

Create a new abstract table class to hold some of the common methods and
functions between streamed and persistent tables. This includes the
method to determine which transaction ID to be used for the table.