### PR TITLE
KO-329, aggregate DR-related stats to determine XDCR readiness.

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -184,6 +184,7 @@ import org.voltdb.operator.PauseActivityStats;
 import org.voltdb.operator.ShutdownActivityStats;
 import org.voltdb.operator.StatusListener;
 import org.voltdb.operator.StopActivityStats;
+import org.voltdb.operator.XDCRReadinessStats;
 import org.voltdb.planner.ActivePlanRepository;
 import org.voltdb.probe.MeshProber;
 import org.voltdb.processtools.ShellTools;
@@ -1614,6 +1615,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
             sa.registerStatsSource(StatsSelector.SHUTDOWN_CHECK, 0, new ShutdownActivityStats());
             sa.registerStatsSource(StatsSelector.STOP_CHECK, 0, new StopActivityStats());
             sa.registerStatsSource(StatsSelector.PAUSE_CHECK, 0, new PauseActivityStats());
+            sa.registerStatsSource(StatsSelector.XDCR_READINESS, 0, new XDCRReadinessStats());
 
             /*
              * Initialize the command log on rejoin and join before configuring the IV2

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -78,7 +78,8 @@ public enum StatsSelector {
     // Activity summary for use by 'operator' functions
     SHUTDOWN_CHECK,
     STOP_CHECK,
-    PAUSE_CHECK;
+    PAUSE_CHECK,
+    XDCR_READINESS;
 
     /** Whether or not this stat supports interval collection */
     private final boolean m_supportsInterval;

--- a/src/frontend/org/voltdb/operator/ActivityHelper.java
+++ b/src/frontend/org/voltdb/operator/ActivityHelper.java
@@ -284,7 +284,7 @@ class ActivityHelper {
             }
         }
         catch (Exception ex) {
-            warn("checkDrProducerActivity", ex);
+            warn("checkDrProducer", ex);
         }
         drprodBytesPend = bytesPend;
         drprodRowsPend = rowsPend;
@@ -313,7 +313,7 @@ class ActivityHelper {
             }
         }
         catch (Exception ex) {
-            warn("checkDrConsumerActivity", ex);
+            warn("checkDrConsumer", ex);
         }
         drconsPend = pend;
         return isActive("DR consumer: %d partitions with pending data", pend);

--- a/src/frontend/org/voltdb/operator/ActivityHelper.java
+++ b/src/frontend/org/voltdb/operator/ActivityHelper.java
@@ -21,19 +21,20 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.voltcore.logging.VoltLogger;
+import org.voltcore.utils.Pair;
 import org.voltdb.ClientInterface;
 import org.voltdb.CommandLog;
 import org.voltdb.DRConsumerStatsBase;
 import org.voltdb.DRProducerStatsBase;
+import org.voltdb.DRRoleStats;
 import org.voltdb.StatsAgent;
 import org.voltdb.StatsSelector;
 import org.voltdb.StatsSource;
 import org.voltdb.VoltDB;
+import org.voltdb.export.ExportManagerInterface;
 import org.voltdb.importer.ImportManager;
 import org.voltdb.iv2.Cartographer;
-import org.voltdb.export.ExportManagerInterface;
-import org.voltcore.logging.VoltLogger;
-import org.voltcore.utils.Pair;
 
 /**
  * Activity stats helper class. This holds methods that collect
@@ -63,8 +64,11 @@ class ActivityHelper {
         IMPORT,
         EXPORT,
         EXMAST,
-        DRCONS,
-        DRPROD,
+        DRCONS_ACT, // check activity columns
+        DRCONS_RDY, // check readiness columns
+        DRPROD_ACT, // check activity columns
+        DRPROD_RDY, // check readiness columns
+        DRROLE,
     }
 
     /*
@@ -81,6 +85,15 @@ class ActivityHelper {
     long exportMasters;
     long drconsPend;
     long drprodBytesPend, drprodRowsPend;
+
+    // Readiness check
+    String drroleState;
+    String drprodState;
+    boolean drprodIsSynced = true;
+    String drprodCStatus = "UP";
+    String drconsState;
+    boolean drconsIsCovered = true;
+    boolean drconsIsPaused = false;
 
     /*
      * Main stats collection method. Stats values
@@ -111,11 +124,20 @@ class ActivityHelper {
             case EXMAST:
                 active |= checkExportMastership();
                 break;
-            case DRCONS:
-                active |= checkDrConsumer();
+            case DRCONS_ACT:
+                active |= checkDrConsumerActivity();
                 break;
-            case DRPROD:
-                active |= checkDrProducer();
+            case DRCONS_RDY:
+                active |= checkDrConsumerReadiness();
+                break;
+            case DRPROD_ACT:
+                active |= checkDrProducerActivity();
+                break;
+            case DRPROD_RDY:
+                active |= checkDrProducerReadiness();
+                break;
+            case DRROLE:
+                active |= checkDrRole();
                 break;
             }
         }
@@ -264,7 +286,7 @@ class ActivityHelper {
      * Counts outstanding data, expressed in bytes and table rows,
      * summed across all partitions.
      */
-    private boolean checkDrProducer() {
+    private boolean checkDrProducerActivity() {
         long bytesPend = 0, rowsPend = 0;
         try {
             StatsSource ss = getStatsSource(StatsSelector.DRPRODUCERPARTITION);
@@ -284,7 +306,7 @@ class ActivityHelper {
             }
         }
         catch (Exception ex) {
-            warn("checkDrProducer", ex);
+            warn("checkDrProducerActivity", ex);
         }
         drprodBytesPend = bytesPend;
         drprodRowsPend = rowsPend;
@@ -296,7 +318,7 @@ class ActivityHelper {
      * Counts partitions for which there is data not yet
      * successfully applied.
      */
-    private boolean checkDrConsumer() {
+    private boolean checkDrConsumerActivity() {
         long pend = 0;
         try {
             StatsSource ss = getStatsSource(StatsSelector.DRCONSUMERPARTITION);
@@ -313,10 +335,91 @@ class ActivityHelper {
             }
         }
         catch (Exception ex) {
-            warn("checkDrConsumer", ex);
+            warn("checkDrConsumerActivity", ex);
         }
         drconsPend = pend;
         return isActive("DR consumer: %d partitions with pending data", pend);
+    }
+
+    /*
+     * XDCR drconsumer readiness check
+     */
+    private boolean checkDrConsumerReadiness() {
+        try {
+            StatsSource ss = getStatsSource(StatsSelector.DRCONSUMERNODE);
+            if (ss != null) {
+                int idxState = getIndex(ss, DRConsumerStatsBase.Columns.STATE);
+                for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) { // only one row
+                    drconsState = String.valueOf(row[idxState]);
+                }
+            }
+            ss = getStatsSource(StatsSelector.DRCONSUMERPARTITION);
+            if (ss != null) {
+                int idxIsCovered = getIndex(ss, DRConsumerStatsBase.Columns.IS_COVERED);
+                int idxIsPaused = getIndex(ss, DRConsumerStatsBase.Columns.IS_PAUSED);
+                for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) {
+                    boolean isCovered = asBoolean(row[idxIsCovered]);
+                    boolean isPaused = asBoolean(row[idxIsPaused]);
+                    if (!isCovered) { drconsIsCovered = false; } // if any partition isn't covered.
+                    if (isPaused) { drconsIsPaused = true; } // if any partition is paused
+                }
+            }
+        }
+        catch (Exception ex) {
+            warn("checkDrConsumerReadiness", ex);
+        }
+        // Ready - in "RECEIVE" state, every partition is covered and no one is paused.
+        return (drconsState != null && !drconsState.equalsIgnoreCase("RECEIVE")) ||
+                !drconsIsCovered || drconsIsPaused;
+    }
+
+    /*
+     * XDCR drproducer readiness check
+     */
+    private boolean checkDrProducerReadiness() {
+        try {
+            StatsSource ss = getStatsSource(StatsSelector.DRPRODUCERNODE);
+            if (ss != null) {
+                int idxState = getIndex(ss, DRProducerStatsBase.Columns.STATE);
+                for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) { // only one row
+                    drprodState = String.valueOf(row[idxState]);
+                }
+            }
+            ss = getStatsSource(StatsSelector.DRPRODUCERPARTITION);
+            if (ss != null) {
+                int idxIsSynced = getIndex(ss, DRProducerStatsBase.Columns.IS_SYNCED);
+                int idxCStatus = getIndex(ss, DRProducerStatsBase.Columns.CONNECTION_STATUS);
+                for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) {
+                    boolean isSynced = asBoolean(row[idxIsSynced]);
+                    String conStatus = String.valueOf(row[idxCStatus]);
+                    if (!isSynced) { drprodIsSynced = false; } // if any partition isn't sync'ed.
+                    if (conStatus.equalsIgnoreCase("DOWN")) { drprodCStatus = "DOWN"; } // if any connection is down
+                }
+            }
+        }
+        catch (Exception ex) {
+            warn("checkDrProducerReadiness", ex);
+        }
+        // Ready - in "ACTIVE" state, every partition is sync'ed and every connection is up.
+        return (drprodState != null && !drprodState.equalsIgnoreCase("ACTIVE")) ||
+                !drprodIsSynced || (drprodCStatus != null && !drprodCStatus.equalsIgnoreCase("UP"));
+    }
+
+    private boolean checkDrRole() {
+        try {
+            StatsSource ss = getStatsSource(StatsSelector.DRROLE);
+            if (ss != null) {
+                int idxState = getIndex(ss, DRRoleStats.CN_STATE);
+                for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) { // only one row
+                    drroleState = String.valueOf(row[idxState]);
+                }
+            }
+        }
+        catch (Exception ex) {
+            warn("checkDrRole", ex);
+        }
+        // Ready - in "ACTIVE" state.
+        return drroleState != null && !drroleState.equalsIgnoreCase("ACTIVE");
     }
 
     /*
@@ -324,6 +427,13 @@ class ActivityHelper {
      */
     private static long asLong(Object obj) {
         return ((Long)obj).longValue();
+    }
+
+    /*
+     * Convert object in stats row to boolean.
+     */
+    private static boolean asBoolean(Object obj) {
+        return String.valueOf(obj).equalsIgnoreCase("true") ? true : false;
     }
 
     /*

--- a/src/frontend/org/voltdb/operator/PauseActivityStats.java
+++ b/src/frontend/org/voltdb/operator/PauseActivityStats.java
@@ -19,13 +19,11 @@ package org.voltdb.operator;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Set;
 
-import org.voltdb.StatsSelector;
+import org.voltcore.logging.VoltLogger;
 import org.voltdb.StatsSource;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltcore.logging.VoltLogger;
 
 /**
  * The PauseActivityStats statistics provide a summary of current
@@ -78,7 +76,7 @@ public class PauseActivityStats extends StatsSource {
      * used by 'voltadmin pause --wait'.
      */
     private static final ActivityHelper.Type[] statsList = {
-        ActivityHelper.Type.EXPORT, ActivityHelper.Type.DRPROD_ACT,
+        ActivityHelper.Type.EXPORT, ActivityHelper.Type.DRPROD,
     };
 
     @Override

--- a/src/frontend/org/voltdb/operator/PauseActivityStats.java
+++ b/src/frontend/org/voltdb/operator/PauseActivityStats.java
@@ -78,7 +78,7 @@ public class PauseActivityStats extends StatsSource {
      * used by 'voltadmin pause --wait'.
      */
     private static final ActivityHelper.Type[] statsList = {
-        ActivityHelper.Type.EXPORT, ActivityHelper.Type.DRPROD,
+        ActivityHelper.Type.EXPORT, ActivityHelper.Type.DRPROD_ACT,
     };
 
     @Override

--- a/src/frontend/org/voltdb/operator/ShutdownActivityStats.java
+++ b/src/frontend/org/voltdb/operator/ShutdownActivityStats.java
@@ -19,15 +19,13 @@ package org.voltdb.operator;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Set;
 
+import org.voltcore.logging.VoltLogger;
 import org.voltdb.CommandLog;
-import org.voltdb.StatsSelector;
 import org.voltdb.StatsSource;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.VoltType;
-import org.voltcore.logging.VoltLogger;
 
 /**
  * The ShutdownActivityStats statistics provide a summary of
@@ -105,8 +103,8 @@ public class ShutdownActivityStats extends StatsSource {
 
     private static final ActivityHelper.Type[] statsWithoutCmdLog = {
         ActivityHelper.Type.CLIENT, ActivityHelper.Type.IMPORT,
-        ActivityHelper.Type.DRCONS_ACT, ActivityHelper.Type.EXPORT,
-        ActivityHelper.Type.DRPROD_ACT,
+        ActivityHelper.Type.DRCONS, ActivityHelper.Type.EXPORT,
+        ActivityHelper.Type.DRPROD,
     };
 
     @Override

--- a/src/frontend/org/voltdb/operator/ShutdownActivityStats.java
+++ b/src/frontend/org/voltdb/operator/ShutdownActivityStats.java
@@ -105,8 +105,8 @@ public class ShutdownActivityStats extends StatsSource {
 
     private static final ActivityHelper.Type[] statsWithoutCmdLog = {
         ActivityHelper.Type.CLIENT, ActivityHelper.Type.IMPORT,
-        ActivityHelper.Type.DRCONS, ActivityHelper.Type.EXPORT,
-        ActivityHelper.Type.DRPROD,
+        ActivityHelper.Type.DRCONS_ACT, ActivityHelper.Type.EXPORT,
+        ActivityHelper.Type.DRPROD_ACT,
     };
 
     @Override

--- a/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
+++ b/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
@@ -1,0 +1,116 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb.operator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import org.voltcore.logging.VoltLogger;
+import org.voltdb.StatsSource;
+import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.VoltType;
+
+/**
+ * The XDCRReadinessStats statistics provide a summary of DRRole,
+ * DRConsumer and DRProducer that can be used to determine the cluster
+ * XDCR readiness.
+ *
+ * The result of the statistics request is a table with one
+ * row per host, and a summary of readiness in various categories.
+ * Readiness is summarized in the 'READY' column; if desired,
+ * then other columns can be used to determine the status of each category.
+ */
+public class XDCRReadinessStats extends StatsSource {
+    private static final VoltLogger logger = new VoltLogger("HOST");
+
+    private enum ColumnName {
+        READY, // 0 if all other gauges are in desired state, which happen to be the lowest display priority. Otherwise 1.
+        DRROLE_STATE,    // display priority (same as below): "DISABLED" > "PENDING" > "STOPPED" > "ACTIVE"
+        DRPROD_STATE,    // aggregated for all hosts, "OFF" > "PENDING" > "ACTIVE"
+        DRPROD_ISSYNCED, // aggregated for all partitions, "false" > "true"
+        DRPROD_CSTATUS,  // connection status, aggregated for all connections, "DOWN" > "UP"
+        DRCONS_STATE,    // aggregated for all hosts, "UNINITIALIZED" > "INITIALIZE" > "DISABLE" > "SYNC" > "RECEIVE"
+        DRCONS_ISCOVERED, // aggregated for all partitions, "false" > "true"
+        DRCONS_ISPAUSED,  // aggregated for all partitions, "true" > "false"
+    };
+
+    public XDCRReadinessStats() {
+        super(false);
+    }
+
+    /*
+     * Constructs a description of the columns we'll return
+     * in our stats table.
+     */
+    @Override
+    protected void populateColumnSchema(ArrayList<ColumnInfo> columns) {
+        super.populateColumnSchema(columns);
+        for (ColumnName col : ColumnName.values()) {
+            VoltType type = (col == ColumnName.READY ? VoltType.TINYINT : VoltType.STRING);
+            columns.add(new ColumnInfo(col.name(), type));
+        }
+    }
+
+    /*
+     * Iterator through the single row of stats we make available.
+     */
+    @Override
+    protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
+        return new ActivityHelper.OneShotIterator();
+    }
+
+    /*
+     * Main stats collection. We return a single row, and
+     * the key is irrelevant.
+     */
+    private static final ActivityHelper.Type[] statsList = {
+        ActivityHelper.Type.DRROLE, ActivityHelper.Type.DRPROD_RDY, ActivityHelper.Type.DRCONS_RDY
+    };
+
+    @Override
+    protected void updateStatsRow(Object key, Object[] row) {
+        boolean notReady = false;
+        try {
+            ActivityHelper helper = new ActivityHelper();
+            notReady = helper.collect(statsList);
+            setValue(row, ColumnName.DRROLE_STATE, helper.drroleState);
+            setValue(row, ColumnName.DRPROD_STATE, helper.drprodState);
+            setValue(row, ColumnName.DRPROD_ISSYNCED, helper.drprodIsSynced ? "true" : "false"); // unfortunately volt table doesn't support boolean column
+            setValue(row, ColumnName.DRPROD_CSTATUS, helper.drprodCStatus);
+            setValue(row, ColumnName.DRCONS_STATE, helper.drconsState);
+            setValue(row, ColumnName.DRCONS_ISCOVERED, helper.drconsIsCovered ? "true" : "false");
+            setValue(row, ColumnName.DRCONS_ISPAUSED, helper.drconsIsPaused ? "true" : "false");
+        }
+        catch (Exception ex) {
+            logger.error("Unhandled exception in XDCRReadinessStats: " + ex);
+        }
+        setValue(row, ColumnName.READY, notReady);
+        super.updateStatsRow(key, row);
+    }
+
+    /*
+     * Utilities to set a value in a row.
+     */
+    private void setValue(Object[] row, ColumnName col, String val) {
+        row[columnNameToIndex.get(col.name())] = val;
+    }
+
+    private void setValue(Object[] row, ColumnName col, boolean val) {
+        row[columnNameToIndex.get(col.name())] = (val ? 1 : 0);  // Align with other activity checks, ready - 0
+    }
+}

--- a/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
+++ b/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
@@ -73,7 +73,7 @@ public class XDCRReadinessStats extends StatsSource {
         String drroleState;
         String drprodState;
         String drprodIsSynced;
-        String drprodIsCxnUp;
+        String drprodIsCnxUp;
         String drconsState;
         String drconsIsCovered;
         String drconsIsPaused;
@@ -125,7 +125,7 @@ public class XDCRReadinessStats extends StatsSource {
                 logger.warn("Unexpected exception in checking DRConsumer Statistics", ex);
             }
             // Ready - in "RECEIVE" state, every partition is covered and no one is paused.
-            return drconsState != null && drconsState.equalsIgnoreCase("RECEIVE") &&
+            return "RECEIVE".equalsIgnoreCase(drconsState) &&
                     drconsIsCovered != null && drconsIsCovered.equalsIgnoreCase("true") &&
                     drconsIsPaused != null && drconsIsPaused.equalsIgnoreCase("false");
         }
@@ -155,7 +155,7 @@ public class XDCRReadinessStats extends StatsSource {
                     }
                     if (rows.length != 0) {
                         drprodIsSynced = String.valueOf(isSynced);
-                        drprodIsCxnUp = isUp ? "UP" : "DOWN";
+                        drprodIsCnxUp = isUp ? "UP" : "DOWN";
                     }
                 }
             }
@@ -165,7 +165,7 @@ public class XDCRReadinessStats extends StatsSource {
             // Ready - in "ACTIVE" state, every partition is sync'ed and every connection is up.
             return drprodState != null && drprodState.equalsIgnoreCase("ACTIVE") &&
                     drprodIsSynced != null && drprodIsSynced.equalsIgnoreCase("true") &&
-                    drprodIsCxnUp != null && drprodIsCxnUp.equalsIgnoreCase("UP");
+                    drprodIsCnxUp != null && drprodIsCnxUp.equalsIgnoreCase("UP");
         }
 
         private boolean checkDrRole() {
@@ -231,7 +231,7 @@ public class XDCRReadinessStats extends StatsSource {
             setValue(row, ColumnName.DRROLE_STATE, helper.drroleState);
             setValue(row, ColumnName.DRPROD_STATE, helper.drprodState);
             setValue(row, ColumnName.DRPROD_ISSYNCED, helper.drprodIsSynced); // unfortunately volt table doesn't support boolean column
-            setValue(row, ColumnName.DRPROD_CNXSTS, helper.drprodIsCxnUp);
+            setValue(row, ColumnName.DRPROD_CNXSTS, helper.drprodIsCnxUp);
             setValue(row, ColumnName.DRCONS_STATE, helper.drconsState);
             setValue(row, ColumnName.DRCONS_ISCOVERED, helper.drconsIsCovered);
             setValue(row, ColumnName.DRCONS_ISPAUSED, helper.drconsIsPaused);

--- a/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
+++ b/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
@@ -72,11 +72,11 @@ public class XDCRReadinessStats extends StatsSource {
         String ready;
         String drroleState;
         String drprodState;
-        boolean drprodIsSynced;
-        boolean drprodIsCxnUp;
+        String drprodIsSynced;
+        String drprodIsCxnUp;
         String drconsState;
-        boolean drconsIsCovered;
-        boolean drconsIsPaused;
+        String drconsIsCovered;
+        String drconsIsPaused;
         /*
          * Main stats collection method. Stats values
          * are saved as member variables.
@@ -110,19 +110,24 @@ public class XDCRReadinessStats extends StatsSource {
                     int idxIsPaused = getIndex(ss, DRConsumerStatsBase.Columns.IS_PAUSED);
                     boolean isCovered = true;
                     boolean isPaused = false;
-                    for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) {
+                    Object[][] rows = ss.getStatsRows(false, System.currentTimeMillis());
+                    for (Object[] row : rows) {
                         isCovered &= asBoolean(row[idxIsCovered]); // false if any partition isn't covered.
                         isPaused |= asBoolean(row[idxIsPaused]);   // true if any partition is paused
                     }
-                    drconsIsCovered = isCovered;
-                    drconsIsPaused = isPaused;
+                    if (rows.length != 0) {
+                        drconsIsCovered = String.valueOf(isCovered);
+                        drconsIsPaused = String.valueOf(isPaused);
+                    }
                 }
             }
             catch (Exception ex) {
                 logger.warn("Unexpected exception in checking DRConsumer Statistics", ex);
             }
             // Ready - in "RECEIVE" state, every partition is covered and no one is paused.
-            return drconsState != null && drconsState.equalsIgnoreCase("RECEIVE") && drconsIsCovered && !drconsIsPaused;
+            return drconsState != null && drconsState.equalsIgnoreCase("RECEIVE") &&
+                    drconsIsCovered != null && drconsIsCovered.equalsIgnoreCase("true") &&
+                    drconsIsPaused != null && drconsIsPaused.equalsIgnoreCase("false");
         }
 
         /*
@@ -143,12 +148,15 @@ public class XDCRReadinessStats extends StatsSource {
                     int idxCStatus = getIndex(ss, DRProducerStatsBase.Columns.CONNECTION_STATUS);
                     boolean isSynced = true;
                     boolean isUp = true;
-                    for (Object[] row : ss.getStatsRows(false, System.currentTimeMillis())) {
+                    Object[][] rows = ss.getStatsRows(false, System.currentTimeMillis());
+                    for (Object[] row : rows) {
                         isSynced &= asBoolean(row[idxIsSynced]); // false if any partition isn't sync'ed.
                         isUp &= String.valueOf(row[idxCStatus]).equalsIgnoreCase("UP"); // false if any connection is down
                     }
-                    drprodIsSynced = isSynced;
-                    drprodIsCxnUp = isUp;
+                    if (rows.length != 0) {
+                        drprodIsSynced = String.valueOf(isSynced);
+                        drprodIsCxnUp = isUp ? "UP" : "DOWN";
+                    }
                 }
             }
             catch (Exception ex) {
@@ -156,7 +164,8 @@ public class XDCRReadinessStats extends StatsSource {
             }
             // Ready - in "ACTIVE" state, every partition is sync'ed and every connection is up.
             return drprodState != null && drprodState.equalsIgnoreCase("ACTIVE") &&
-                    drprodIsSynced && drprodIsCxnUp;
+                    drprodIsSynced != null && drprodIsSynced.equalsIgnoreCase("true") &&
+                    drprodIsCxnUp != null && drprodIsCxnUp.equalsIgnoreCase("UP");
         }
 
         private boolean checkDrRole() {
@@ -221,11 +230,11 @@ public class XDCRReadinessStats extends StatsSource {
             setValue(row, ColumnName.IS_READY, helper.ready);
             setValue(row, ColumnName.DRROLE_STATE, helper.drroleState);
             setValue(row, ColumnName.DRPROD_STATE, helper.drprodState);
-            setValue(row, ColumnName.DRPROD_ISSYNCED, helper.drprodIsSynced ? "true" : "false"); // unfortunately volt table doesn't support boolean column
-            setValue(row, ColumnName.DRPROD_CNXSTS, helper.drprodIsCxnUp ? "UP" : "DOWN");
+            setValue(row, ColumnName.DRPROD_ISSYNCED, helper.drprodIsSynced); // unfortunately volt table doesn't support boolean column
+            setValue(row, ColumnName.DRPROD_CNXSTS, helper.drprodIsCxnUp);
             setValue(row, ColumnName.DRCONS_STATE, helper.drconsState);
-            setValue(row, ColumnName.DRCONS_ISCOVERED, helper.drconsIsCovered ? "true" : "false");
-            setValue(row, ColumnName.DRCONS_ISPAUSED, helper.drconsIsPaused ? "true" : "false");
+            setValue(row, ColumnName.DRCONS_ISCOVERED, helper.drconsIsCovered);
+            setValue(row, ColumnName.DRCONS_ISPAUSED, helper.drconsIsPaused);
         }
         catch (Exception ex) {
             logger.error("Unexpected exception in XDCR_READINESS Stats: " + ex);

--- a/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
+++ b/src/frontend/org/voltdb/operator/XDCRReadinessStats.java
@@ -125,7 +125,7 @@ public class XDCRReadinessStats extends StatsSource {
                 logger.warn("Unexpected exception in checking DRConsumer Statistics", ex);
             }
             // Ready - in "RECEIVE" state, every partition is covered and no one is paused.
-            return "RECEIVE".equalsIgnoreCase(drconsState) &&
+            return drconsState != null && drconsState.equalsIgnoreCase("RECEIVE") &&
                     drconsIsCovered != null && drconsIsCovered.equalsIgnoreCase("true") &&
                     drconsIsPaused != null && drconsIsPaused.equalsIgnoreCase("false");
         }


### PR DESCRIPTION
XDCR readiness criteria:
1) DRRole.State in "ACTIVE" state,
2) DRProducer.State in "ACTIVE" state,
3) DRProducer.Is_synced is true,
4) DRProducer.Connection_status is "UP",
5) DRConsumer.State in "RECEIVE" state,
6) DRConsumer.Is_covered is true,
7) DRConsumer.Is_paused is false.

XCDR must meet all the criteria to be "ready".
