### PR TITLE
ENG-19728 missed replica update

### DIFF
--- a/src/frontend/org/voltdb/iv2/SpTerm.java
+++ b/src/frontend/org/voltdb/iv2/SpTerm.java
@@ -83,6 +83,9 @@ public class SpTerm implements Term
             // (see explanation at SpInitiator, m_leadersChangeHandler handler),
             // ask non-leader (from scheduler perspective) to ignore replica list change.
             if (!m_promoting && !m_mailbox.m_scheduler.isLeader()) {
+                if (replicas.size() != m_replicas.size()) {
+                   m_mailbox.updateReplicas(replicas, null);
+                }
                 m_replicas = ImmutableList.copyOf(replicas);
                 return;
             }


### PR DESCRIPTION
The following events could cause a missed replica update and block transactions:  a partition leader is migrated away,  a node fails, rejoin and fails again. 