### PR TITLE
True deterministic row order

### DIFF
--- a/src/ee/storage/TableCatalogDelegate.cpp
+++ b/src/ee/storage/TableCatalogDelegate.cpp
@@ -570,9 +570,6 @@ static void migrateChangedTuples(catalog::Table const& catalogTable,
         existingTable->allocator().remove(PersistentTable::remove_direction::from_head, scannedTuple.address());
         ++tuplesMigrated;
     });
-    if (tuplesMigrated) {                          // mark completion of removing from head
-        existingTable->allocator().remove(PersistentTable::remove_direction::from_head, nullptr);
-    }
 
     // release any memory held by the default values --
     // normally you'd want this in a finally block, but since this code failing

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -222,7 +222,6 @@ namespace voltdb {
             ChunkHolder(ChunkHolder const&) = delete;  // non-copyable, non-assignable, non-moveable
             ChunkHolder& operator=(ChunkHolder const&) = delete;
             ChunkHolder(ChunkHolder&&) = delete;
-            bool valid(bool compact) const noexcept;
         public:
             constexpr static allocator_enum_type const enum_type = T;
             ChunkHolder(id_type id, size_t tupleSize, size_t chunkSize);
@@ -237,8 +236,7 @@ namespace voltdb {
             void*const range_right() const noexcept;
             size_t tupleSize() const noexcept;
             id_type id() const noexcept;
-            allocator_type<T>& get_allocator() noexcept;               // TODO: needed?
-            allocator_type<T> const& get_allocator() const noexcept;
+            bool valid(bool compact) const noexcept;
         };
 
         /**
@@ -518,7 +516,7 @@ namespace voltdb {
          * A state abstraction of a ChunkHolder.
          */
         class CompactingChunks;
-        class position_type {                          // TODO: more book keepings needed?
+        class position_type {
             id_type const m_chunkId = 0;               // default constructible due to FrozenTxnBoundaries ctor needing to pre-validate
             void const* m_beg = nullptr;
             void const* m_end = nullptr;

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -217,7 +217,7 @@ namespace voltdb {
             size_t const m_tupleSize;                  // size of a table tuple per allocation
             void*const m_end;                          // indication of chunk capacity
         protected:
-            void* m_next;                              // tail of allocation
+            void *m_left, *right;                      // left/right boundaries
             ChunkHolder(ChunkHolder const&) = delete;  // non-copyable, non-assignable, non-moveable
             ChunkHolder& operator=(ChunkHolder const&) = delete;
             ChunkHolder(ChunkHolder&&) = delete;
@@ -232,7 +232,8 @@ namespace voltdb {
             bool empty() const noexcept;
             void*const range_begin() const noexcept;
             void*const range_end() const noexcept;
-            void*const range_next() const noexcept;
+            void*const range_left() const noexcept;
+            void*const range_right() const noexcept;
             size_t tupleSize() const noexcept;
             id_type id() const noexcept;
             allocator_type<T>& get_allocator() noexcept;
@@ -514,26 +515,21 @@ namespace voltdb {
          */
         class CompactingChunks;
         class position_type {
-            id_type const m_chunkId = 0;
-            void const* m_addr = nullptr;
+            id_type const m_chunkId;
+            void const* m_left;
+            void const* m_right;
         public:
-            struct less_address {                      // special comparator on m_addr only
-                bool operator()(position_type const& lhs, position_type const& rhs) const noexcept {
-                    return lhs.address() < rhs.address();
-                }
-            };
-            position_type() noexcept = default;
             position_type(CompactingChunks const&, void const*);
-            position_type(void const*);                // NOTE: only uses this when you know what you are doing
             // NOTE: iterator arg is dereferenced, therefore it
             // *can not* be end().
-            template<typename iterator> position_type(void const*, iterator const&);
+            template<typename iterator> position_type(iterator const&);
             position_type(ChunkHolder<> const&) noexcept;
             position_type(position_type const&) noexcept = default;
             position_type(position_type&&) noexcept = default;
             position_type& operator=(position_type const&) noexcept;
-            id_type chunkId() const noexcept;
-            void const* address() const noexcept;
+            id_type id() const noexcept;
+            void const* left() const noexcept;
+            void const* right() const noexcept;
             bool operator==(position_type const&) const noexcept;
         };
 
@@ -601,22 +597,24 @@ namespace voltdb {
         class CompactingChunks : private ChunkList<CompactingChunk, true_type>, private CompactingStorageTrait {
         public:
             using Compact = true_type;
-            class TxnLeftBoundary final {
+            class BegTxnBoundary final {
                 ChunkList<CompactingChunk, Compact> const& m_chunks;
                 typename ChunkList<CompactingChunk, Compact>::iterator m_iter;
-                void const* m_next;
+                void const* m_left = nullptr;
+                void const* m_right = nullptr;
             public:
-                TxnLeftBoundary(ChunkList<CompactingChunk, Compact>&) noexcept;
+                BegTxnBoundary(ChunkList<CompactingChunk, Compact>&) noexcept;
                 typename ChunkList<CompactingChunk, Compact>::iterator const& iterator() const noexcept;
                 typename ChunkList<CompactingChunk, Compact>::iterator& iterator() noexcept;
                 typename ChunkList<CompactingChunk, Compact>::iterator const&
                     iterator(ChunkList<CompactingChunk, Compact>::iterator const&) noexcept;
-                void const*& range_next() noexcept;
+                void const*& left() noexcept;
+                void const*& right() noexcept;
                 bool empty() const noexcept;
             };
             class FrozenTxnBoundaries final {
-                position_type const m_left{};          // NOTE: need to be empty-constructed, since we need to
-                position_type const m_right{};         // validate ChunkList state before assignment.
+                position_type const m_left;
+                position_type const m_right;
             public:
                 FrozenTxnBoundaries(ChunkList<CompactingChunk, Compact> const&) noexcept;
                 FrozenTxnBoundaries& operator=(FrozenTxnBoundaries const&) noexcept;
@@ -631,7 +629,7 @@ namespace voltdb {
             // equivalent to "table id", to ensure injection relation to rw iterator
             id_type const m_id = ChunksIdValidator::instance().id();
             char const* m_lastFreeFromHead = nullptr;  // arg of previous call to free(from_head, ?)
-            TxnLeftBoundary m_txnFirstChunk;           // (moving) left boundary for txn
+            BegTxnBoundary m_txnFirstChunk;           // (moving) left boundary for txn
             boost::optional<FrozenTxnBoundaries> m_frozenTxnBoundaries{};  // frozen boundaries for txn
             // action before deallocating a tuple from txn (or hook) memory.
             FinalizerAndCopier const m_finalizerAndCopier;
@@ -643,7 +641,7 @@ namespace voltdb {
             typename list_type::iterator releasable();
             void pop_front();
             void pop_back();
-            void pop_finalize(const void*);
+            void pop_finalize(const void*, const void*);
         protected:
             class DelayedRemover {
                 CompactingChunks& m_chunks;
@@ -687,7 +685,6 @@ namespace voltdb {
             } m_batched;
             size_t m_allocs = 0;
             using list_type::last;
-            void pop_frozen();
             template<typename Remove_cb> void clear(Remove_cb const&);
             pair<bool, list_type::iterator> find(void const*, bool) noexcept; // search in txn invisible range, too
             pair<bool, list_type::iterator> find(id_type, bool) noexcept; // search in txn invisible range, too
@@ -712,8 +709,8 @@ namespace voltdb {
             // search in txn memory region (i.e. excludes snapshot-related, front portion of list)
             pair<bool, list_type::iterator> find(void const*) noexcept;
             pair<bool, list_type::iterator> find(id_type) noexcept;
-            TxnLeftBoundary const& beginTxn() const noexcept;   // (moving) txn left boundary
-            TxnLeftBoundary& beginTxn() noexcept;               // NOTE: this should really be private. Use it with care!!!
+            BegTxnBoundary const& beginTxn() const noexcept;   // (moving) txn left boundary
+            BegTxnBoundary& beginTxn() noexcept;               // NOTE: this should really be private. Use it with care!!!
             boost::optional<FrozenTxnBoundaries> const& frozenBoundaries() const noexcept;  // txn boundaries when freezing
             /**
              * Memory operations

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -222,7 +222,7 @@ namespace voltdb {
             ChunkHolder(ChunkHolder const&) = delete;  // non-copyable, non-assignable, non-moveable
             ChunkHolder& operator=(ChunkHolder const&) = delete;
             ChunkHolder(ChunkHolder&&) = delete;
-            bool validate(bool compact) const noexcept;
+            bool valid(bool compact) const noexcept;
         public:
             constexpr static allocator_enum_type const enum_type = T;
             ChunkHolder(id_type id, size_t tupleSize, size_t chunkSize);
@@ -519,7 +519,7 @@ namespace voltdb {
          */
         class CompactingChunks;
         class position_type {                          // TODO: more book keepings needed?
-            id_type const m_chunkId = 0;               // default constructible due to FrozenTxnBoundary ctor needing to pre-validate
+            id_type const m_chunkId = 0;               // default constructible due to FrozenTxnBoundaries ctor needing to pre-validate
             void const* m_beg = nullptr;
             void const* m_end = nullptr;
             void const* m_left = nullptr;

--- a/tests/ee/storage/TableTupleAllocatorTest.cpp
+++ b/tests/ee/storage/TableTupleAllocatorTest.cpp
@@ -928,7 +928,7 @@ void testHookedCompactingChunksBatchRemove_multi3() {
     for(i = 0; i < AllocsPerChunk / 2; ++i) {
         memcpy(const_cast<void*>(addresses[i] = alloc.allocate()), gen.get(), TupleSize);
     }
-    auto const& iter = alloc.template freeze<truth>();
+    alloc.template freeze<truth>();
     remove_multiple(alloc, addresses.cbegin(), next(addresses.cbegin(), AllocsPerChunk / 2));
     assert(alloc.empty());
     for (; i < AllocsPerChunk * 3; ++i) {


### PR DESCRIPTION
Changed compaction order detail of the bottom of the design, so that compaction is truly/always rolling right-ward, rather than compacting from tail of head chunk. 

The finalization behavior is left unchanged. There are a few lingering **TODO**s related to finalization behavior and more thorough test; but they are left here since we do not know for sure if current handling works.

To get most understanding out of the changes, it's advisable to review all the source code (not just changes), and EE test code.

Pending CI tests status check, before any system tests can be run.

NOTE: `CopyOnWriteTest` is currently failing.