### PR TITLE
Eng 19697 close snapshot targets before report serialization error.

### DIFF
--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -581,7 +581,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public IOException getLastWriteException() {
+    public Exception getLastWriteException() {
         return m_writeException;
     }
 
@@ -591,7 +591,7 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public IOException getSerializationException() {
+    public Exception getSerializationException() {
         return m_reportedSerializationFailure;
     }
 

--- a/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DefaultSnapshotDataTarget.java
@@ -590,6 +590,11 @@ public class DefaultSnapshotDataTarget implements SnapshotDataTarget {
         return SnapshotFormat.NATIVE;
     }
 
+    @Override
+    public IOException getSerializationException() {
+        return m_reportedSerializationFailure;
+    }
+
     /**
      * Get the row count if any, of the content wrapped in the given {@link BBContainer}
      * @param tupleData

--- a/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
@@ -258,6 +258,11 @@ public class DeprecatedDefaultSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
+    public Throwable getSerializationException() {
+        return m_reportedSerializationFailure;
+    }
+
+    @Override
     public boolean needsFinalClose()
     {
         return m_needsFinalClose;

--- a/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/DeprecatedDefaultSnapshotDataTarget.java
@@ -258,7 +258,7 @@ public class DeprecatedDefaultSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public Throwable getSerializationException() {
+    public Exception getSerializationException() {
         return m_reportedSerializationFailure;
     }
 
@@ -390,7 +390,7 @@ public class DeprecatedDefaultSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public IOException getLastWriteException() {
+    public Exception getLastWriteException() {
         return m_writeException;
     }
 

--- a/src/frontend/org/voltdb/DevNullSnapshotTarget.java
+++ b/src/frontend/org/voltdb/DevNullSnapshotTarget.java
@@ -63,7 +63,7 @@ public class DevNullSnapshotTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public Throwable getSerializationException() {
+    public Exception getSerializationException() {
         return m_reportedSerializationFailure;
     }
 
@@ -96,7 +96,7 @@ public class DevNullSnapshotTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public Throwable getLastWriteException() {
+    public Exception getLastWriteException() {
         return m_lastWriteException;
     }
 

--- a/src/frontend/org/voltdb/DevNullSnapshotTarget.java
+++ b/src/frontend/org/voltdb/DevNullSnapshotTarget.java
@@ -63,6 +63,11 @@ public class DevNullSnapshotTarget implements SnapshotDataTarget {
     }
 
     @Override
+    public Throwable getSerializationException() {
+        return m_reportedSerializationFailure;
+    }
+
+    @Override
     public boolean needsFinalClose()
     {
         return true;

--- a/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
@@ -22,6 +22,7 @@ import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,7 +32,6 @@ import org.voltcore.utils.Bits;
 import org.voltcore.utils.CoreUtils;
 import org.voltcore.utils.DBBPool.BBContainer;
 
-import com.google_voltpatches.common.base.Throwables;
 import com.google_voltpatches.common.util.concurrent.ListenableFuture;
 import com.google_voltpatches.common.util.concurrent.ListeningExecutorService;
 
@@ -73,7 +73,7 @@ public class SimpleFileSnapshotDataTarget implements SnapshotDataTarget {
      * extra serialization work.
      */
     private volatile boolean m_writeFailed = false;
-    private volatile Throwable m_writeException = null;
+    private volatile Exception m_writeException = null;
     private volatile IOException m_reportedSerializationFailure = null;
 
     public SimpleFileSnapshotDataTarget(
@@ -156,10 +156,10 @@ public class SimpleFileSnapshotDataTarget implements SnapshotDataTarget {
                     } finally {
                         data.discard();
                     }
-                } catch (Throwable t) {
-                    m_writeException = t;
+                } catch (InterruptedException | ExecutionException | IOException e) {
+                    m_writeException = e;
                     m_writeFailed = true;
-                    throw Throwables.propagate(t);
+                    throw e;
                 }
                 return null;
             }
@@ -172,7 +172,7 @@ public class SimpleFileSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public Throwable getSerializationException() {
+    public Exception getSerializationException() {
         return m_reportedSerializationFailure;
     }
 
@@ -211,7 +211,7 @@ public class SimpleFileSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
-    public Throwable getLastWriteException() {
+    public Exception getLastWriteException() {
         return m_writeException;
     }
 

--- a/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SimpleFileSnapshotDataTarget.java
@@ -172,6 +172,11 @@ public class SimpleFileSnapshotDataTarget implements SnapshotDataTarget {
     }
 
     @Override
+    public Throwable getSerializationException() {
+        return m_reportedSerializationFailure;
+    }
+
+    @Override
     public boolean needsFinalClose()
     {
         return m_needsFinalClose;

--- a/src/frontend/org/voltdb/SnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SnapshotDataTarget.java
@@ -48,6 +48,11 @@ public interface SnapshotDataTarget {
     public void reportSerializationFailure(IOException ex);
 
     /**
+     * Get the first exception that occurred during serialization
+     */
+    public Throwable getSerializationException();
+
+    /**
      * Does this target need to be closed by the last site to finish snapshotting?
      */
     public boolean needsFinalClose();

--- a/src/frontend/org/voltdb/SnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/SnapshotDataTarget.java
@@ -50,7 +50,7 @@ public interface SnapshotDataTarget {
     /**
      * Get the first exception that occurred during serialization
      */
-    public Throwable getSerializationException();
+    public Exception getSerializationException();
 
     /**
      * Does this target need to be closed by the last site to finish snapshotting?
@@ -72,7 +72,7 @@ public interface SnapshotDataTarget {
     /**
      * Get last cached exception that occurred during writes
      */
-    public Throwable getLastWriteException();
+    public Exception getLastWriteException();
 
     /**
      * Get the snapshot format this target uses

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -183,7 +183,7 @@ public class SnapshotSiteProcessor {
     private final int m_snapshotPriority;
 
     private boolean m_isTruncation;
-    private boolean m_perSiteLastSnapshotSucceded = true;
+    private boolean m_perSiteLastSnapshotSucceeded = true;
 
     /**
      * List of threads to join to block on snapshot completion
@@ -420,7 +420,7 @@ public class SnapshotSiteProcessor {
         ExecutionSitesCurrentlySnapshotting.add(this);
         final long now = System.currentTimeMillis();
         m_quietUntil = now + 200;
-        m_perSiteLastSnapshotSucceded = true;
+        m_perSiteLastSnapshotSucceeded = true;
         m_lastSnapshotTxnId = txnId;
         m_isTruncation = isTruncation;
         m_snapshotTableTasks = MiscUtils.sortedArrayListMultimap();
@@ -568,7 +568,7 @@ public class SnapshotSiteProcessor {
                             try {
                                 tableTask.m_target.close();
                             } catch (IOException | InterruptedException e) {
-                                m_perSiteLastSnapshotSucceded = false;
+                                m_perSiteLastSnapshotSucceeded = false;
                                 throw new RuntimeException(e);
                             }
 
@@ -636,7 +636,7 @@ public class SnapshotSiteProcessor {
                         try {
                             writeFutures.get();
                         } catch (Throwable t) {
-                            if (m_perSiteLastSnapshotSucceded) {
+                            if (m_perSiteLastSnapshotSucceeded) {
                                 if (t instanceof StreamSnapshotTimeoutException ||
                                         t.getCause() instanceof StreamSnapshotTimeoutException) {
                                     //This error is already logged by the watchdog when it generates the exception
@@ -647,7 +647,7 @@ public class SnapshotSiteProcessor {
                                     }
                                     SNAP_LOG.error("Error while attempting to write snapshot data", t);
                                 }
-                                m_perSiteLastSnapshotSucceded = false;
+                                m_perSiteLastSnapshotSucceeded = false;
                             }
                         }
                     }

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -742,7 +742,6 @@ public class SnapshotSiteProcessor {
                                         exp = e;
                                     }
                                     continue;
-//                                    throw new RuntimeException(e);
                                 }
                             }
                             if (!snapshotSucceeded) {

--- a/src/frontend/org/voltdb/SnapshotSiteProcessor.java
+++ b/src/frontend/org/voltdb/SnapshotSiteProcessor.java
@@ -567,10 +567,7 @@ public class SnapshotSiteProcessor {
                         public void run() {
                             try {
                                 tableTask.m_target.close();
-                            } catch (IOException e) {
-                                m_perSiteLastSnapshotSucceded = false;
-                                throw new RuntimeException(e);
-                            } catch (InterruptedException e) {
+                            } catch (IOException | InterruptedException e) {
                                 m_perSiteLastSnapshotSucceded = false;
                                 throw new RuntimeException(e);
                             }
@@ -735,13 +732,21 @@ public class SnapshotSiteProcessor {
                                     return;
                                 }
                             }
+                            Exception exp = null;
                             for (final SnapshotDataTarget t : snapshotTargets) {
                                 try {
                                     t.close();
                                 } catch (IOException | InterruptedException e) {
                                     snapshotSucceeded = false;
-                                    throw new RuntimeException(e);
+                                    if (exp == null) {
+                                        exp = e;
+                                    }
+                                    continue;
+//                                    throw new RuntimeException(e);
                                 }
+                            }
+                            if (!snapshotSucceeded) {
+                                throw new RuntimeException(exp);
                             }
 
                             Runnable r = null;

--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -162,11 +162,14 @@ public class SnapshotStatus extends StatsSource {
         rowValues[columnNameToIndex.get("DURATION")] = duration;
         rowValues[columnNameToIndex.get("THROUGHPUT")] = throughput;
         String result;
-        if (t.error == null && t.size == 0) {
-            // still in progress
-            result = SnapshotResult.IN_PROGRESS.toString();
+        if (t.writeExp == null && t.serializationExp == null) {
+            if (t.size == 0) {
+                result = SnapshotResult.IN_PROGRESS.toString();
+            } else {
+                result = SnapshotResult.SUCCESS.toString();
+            }
         } else {
-            result = t.error == null ? SnapshotResult.SUCCESS.toString() : SnapshotResult.FAILURE.toString();
+            result = SnapshotResult.FAILURE.toString();
         }
         rowValues[columnNameToIndex.get("RESULT")] = result;
         rowValues[columnNameToIndex.get("TYPE")] = m_typeChecker.getSnapshotType(s.path, s.nonce).name();

--- a/src/frontend/org/voltdb/SnapshotStatus.java
+++ b/src/frontend/org/voltdb/SnapshotStatus.java
@@ -163,10 +163,10 @@ public class SnapshotStatus extends StatsSource {
         rowValues[columnNameToIndex.get("THROUGHPUT")] = throughput;
         String result;
         if (t.writeExp == null && t.serializationExp == null) {
-            if (t.size == 0) {
-                result = SnapshotResult.IN_PROGRESS.toString();
-            } else {
+            if (s.result == SnapshotResult.SUCCESS) {
                 result = SnapshotResult.SUCCESS.toString();
+            } else {
+                result = SnapshotResult.IN_PROGRESS.toString();
             }
         } else {
             result = SnapshotResult.FAILURE.toString();

--- a/src/frontend/org/voltdb/SnapshotSummary.java
+++ b/src/frontend/org/voltdb/SnapshotSummary.java
@@ -35,7 +35,7 @@ import org.voltdb.sysprocs.SnapshotRegistry.Snapshot.SnapshotScanner;
 
 public class SnapshotSummary extends StatsSource {
 
-    public enum ColumnName {
+    private enum ColumnName {
         NONCE,
         TXNID,
         START_TIME,

--- a/src/frontend/org/voltdb/SnapshotSummary.java
+++ b/src/frontend/org/voltdb/SnapshotSummary.java
@@ -35,7 +35,7 @@ import org.voltdb.sysprocs.SnapshotRegistry.Snapshot.SnapshotScanner;
 
 public class SnapshotSummary extends StatsSource {
 
-    private enum ColumnName {
+    public enum ColumnName {
         NONCE,
         TXNID,
         START_TIME,

--- a/src/frontend/org/voltdb/SnapshotSummary.java
+++ b/src/frontend/org/voltdb/SnapshotSummary.java
@@ -162,11 +162,13 @@ public class SnapshotSummary extends StatsSource {
                 new SnapshotScanner<SnapshotResult>() {
                     public List<SnapshotResult> flatten(Snapshot s) {
                         // Ignore join and index snapshot
+                        List<SnapshotResult> result  = new ArrayList<>();
                         SnapshotType type = m_typeChecker.getSnapshotType(s.path, s.nonce);
                         if (type == SnapshotType.ELASTIC) {
-                            return new ArrayList<>();
+                            return result;
                         }
-                        return s.iterateTableErrors();
+                        result.add(s.result);
+                        return result;
                     }
                 });
     }

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -634,7 +634,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     }
 
     @Override
-    public Throwable getSerializationException() {
+    public Exception getSerializationException() {
         return m_reportedSerializationFailure;
     }
 
@@ -747,7 +747,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     }
 
     @Override
-    public synchronized Throwable getLastWriteException() {
+    public synchronized Exception getLastWriteException() {
         Exception exception = m_sender.m_lastException;
         if (exception != null) {
             return exception;

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -634,6 +634,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     }
 
     @Override
+    public Throwable getSerializationException() {
+        return m_reportedSerializationFailure;
+    }
+
+    @Override
     public boolean needsFinalClose()
     {
         // Streamed snapshot targets always need to be closed by the last site

--- a/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/SnapshotWritePlan.java
@@ -36,6 +36,7 @@ import org.voltdb.ExtensibleSnapshotDigestData;
 import org.voltdb.PostSnapshotTask;
 import org.voltdb.SnapshotDataTarget;
 import org.voltdb.SnapshotSiteProcessor;
+import org.voltdb.SnapshotStatus.SnapshotResult;
 import org.voltdb.SnapshotTableTask;
 import org.voltdb.SystemProcedureExecutionContext;
 import org.voltdb.VoltTable;
@@ -106,19 +107,25 @@ public abstract class SnapshotWritePlan<C extends SnapshotRequestConfig>
                             return m_snapshotRecord.new Table(
                                 registryTable,
                                 m_sdt.getBytesWritten(), /* Bytes written is shared between multiple stream snapshot tables */
-                                m_sdt.getLastWriteException());
+                                m_sdt.getLastWriteException(),
+                                m_sdt.getSerializationException());
                             }
                     });
                 int tablesLeft = m_numTables.decrementAndGet();
                 if (tablesLeft == 0) {
                     final SnapshotRegistry.Snapshot completed =
                         SnapshotRegistry.finishSnapshot(m_snapshotRecord);
-                    final double duration =
-                        (completed.timeFinished - completed.timeStarted) / 1000.0;
-                    SNAP_LOG.info(
-                            "Snapshot " + m_snapshotRecord.nonce + " finished at " +
-                            completed.timeFinished + " and took " + duration
-                            + " seconds ");
+                    if (completed.result == SnapshotResult.SUCCESS) {
+                        final double duration =
+                            (completed.timeFinished - completed.timeStarted) / 1000.0;
+                        SNAP_LOG.info(
+                                "Snapshot " + m_snapshotRecord.nonce + " finished at " +
+                                completed.timeFinished + " and took " + duration
+                                + " seconds ");
+                    } else {
+                        SNAP_LOG.info(
+                                "Failed to take snapshot " + m_snapshotRecord.nonce);
+                    }
                 }
             }
         }

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
@@ -58,7 +58,6 @@ import org.voltdb.client.ProcCallException;
 import org.voltdb.client.SyncCallback;
 import org.voltdb.jni.ExecutionEngine;
 import org.voltdb.sysprocs.saverestore.SnapshotUtil;
-import org.voltdb.sysprocs.saverestore.SystemTable;
 import org.voltdb.types.GeographyPointValue;
 import org.voltdb.types.GeographyValue;
 import org.voltdb.utils.SnapshotVerifier;
@@ -67,8 +66,6 @@ import org.voltdb.utils.SnapshotVerifier;
  * Test the SnapshotSave and SnapshotRestore system procedures
  */
 public class TestSaveRestoreSerializationFailures extends SaveRestoreBase {
-    private final static int SITE_COUNT = 2;
-    private final static int TABLE_COUNT = 11 + SystemTable.values().length; // Must match schema used.
 
     public TestSaveRestoreSerializationFailures(String name) {
         super(name);
@@ -429,7 +426,7 @@ public class TestSaveRestoreSerializationFailures extends SaveRestoreBase {
 
         try
         {
-            checkSnapshotStatus(client, TMPDIR, "first", null, "SUCCESS", TABLE_COUNT);
+            checkSnapshotStatus(client, TMPDIR, "first", null, "FAILURE", 1 /*first*/);
         }
         catch (Exception ex)
         {

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSerializationFailures.java
@@ -47,7 +47,6 @@ import org.voltcore.utils.DBBPool.BBContainer;
 import org.voltcore.utils.Pair;
 import org.voltdb.BackendTarget;
 import org.voltdb.RealVoltDB;
-import org.voltdb.SnapshotSummary;
 import org.voltdb.TableStreamType;
 import org.voltdb.VoltDB;
 import org.voltdb.VoltTable;
@@ -574,7 +573,6 @@ public class TestSaveRestoreSerializationFailures extends SaveRestoreBase {
         VoltTable statusResults[] = client.callProcedure("@Statistics", "SnapshotSummary", 0).getResults();
         assertNotNull(statusResults);
         assertEquals( 1, statusResults.length);
-        assertEquals( SnapshotSummary.ColumnName.values().length, statusResults[0].getColumnCount());
 
         // Validate row count if requested.
         Integer resultRowCount = statusResults[0].getRowCount();

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -3806,6 +3806,9 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
                 client.close();
             }
 
+            // Give voltdb 1s to get @SnapshotSave done.
+            Thread.sleep(2000);
+
             // Connect to each host and check @SnapshotStatus.
             // Only one host should say it saved the replicated table we're watching.
             Set<Long> hostIds = new HashSet<>();

--- a/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
+++ b/tests/frontend/org/voltdb/regressionsuites/TestSaveRestoreSysprocSuite.java
@@ -3806,9 +3806,6 @@ public class TestSaveRestoreSysprocSuite extends SaveRestoreBase {
                 client.close();
             }
 
-            // Give voltdb 1s to get @SnapshotSave done.
-            Thread.sleep(2000);
-
             // Connect to each host and check @SnapshotStatus.
             // Only one host should say it saved the replicated table we're watching.
             Set<Long> hostIds = new HashSet<>();


### PR DESCRIPTION
Snapshot serialization exception can happen in streamMore(), defer the reporting of error will give every data target a chance to close itself and maintain the record in snapshot registry, so that the result of snapshot (success or failure) can be determined at finish time.