### PR TITLE
Change the max column name width of VoltTable to 90.

### DIFF
--- a/src/frontend/org/voltdb/VoltTable.java
+++ b/src/frontend/org/voltdb/VoltTable.java
@@ -1585,7 +1585,7 @@ public final class VoltTable extends VoltTableRow implements JSONString {
      */
     public String toFormattedString(boolean includeColumnNames) {
 
-        final int MAX_PRINTABLE_CHARS = 30;
+        final int MAX_PRINTABLE_CHARS = 90;
         // chose print width for geography column such that it can print polygon in
         // aligned manner with geography column for a polygon up to:
         // a polygon composed of 4 vertices + 1 repeat vertex,


### PR DESCRIPTION
Many stats tables look ugly under the 30 max column width, because of the lengthy names or long paths.
```
exec @Statistics SNAPSHOTSummary 0;
NONCE                           TXNID             TYPE        START_TIME     END_TIME       DURATION  PROGRESS_PCT  RESULT
------------------------------- ----------------- ----------- -------------- -------------- --------- ------------- --------
1592486383194                    3619631923232767 COMMANDLOG   1592486383259  1592486383530         0         100.0 SUCCESS
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  3619631923314687 MANUAL       1592486393488  1592486393734         0         100.0 SUCCESS
```
It looks better with this patch, doesn't it?
```
exec @Statistics SNAPSHOTSummary 0;
NONCE                               TXNID             TYPE        START_TIME     END_TIME       DURATION  PROGRESS_PCT  RESULT
----------------------------------- ----------------- ----------- -------------- -------------- --------- ------------- --------
1592485578825                        3619631923232767 COMMANDLOG   1592485578888  1592485579144         0         100.0 SUCCESS
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa   3619631923331071 MANUAL       1592486038058  1592486038308         0         100.0 SUCCESS
```

This setting doesn't affect the printable width of value.


```
1> create table bar(a varchar(256));
Command succeeded.
2> insert into bar values ('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
(Returned 1 rows in 0.06s)
3> select * from bar;
A
-------------------------------------------------------------------------------------------
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

(Returned 1 rows in 0.02s)
``` 

```
4> create table foobar(a varchar(256));
Command succeeded.
5> insert into foobar values ('aaa');
(Returned 1 rows in 0.01s)
6> select * from foobar;
A
----
aaa

(Returned 1 rows in 0.00s)
```