### PR TITLE
ENG-19743: Backport: Unregister dr consumer from global service leader

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -4476,6 +4476,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 hostLog.warn("Interrupted shutting down dr replication", e);
             }
             finally {
+                m_globalServiceElector.unregisterService(m_consumerDRGateway);
                 m_consumerDRGateway = null;
             }
         }

--- a/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
+++ b/tests/frontend/org/voltdb/regressionsuites/LocalCluster.java
@@ -2366,7 +2366,7 @@ public class LocalCluster extends VoltServerConfig {
     }
 
     // verify the presence of messages in the log from specified host
-    private boolean logMessageContains(int hostId, List<String> patterns) {
+    public boolean logMessageContains(int hostId, List<String> patterns) {
         return patterns.stream().allMatch(s -> verifyLogMessage(hostId, s));
     }
 


### PR DESCRIPTION
[ backport 79475e81fb52bb207d0d43bf1ac1e969dc5650ab ]

When a cluster is promoted the ConsumerDRGateway is shutdown and set to
null in RealVoltDB, however an instace of the gateway is still
registered with the GlobalServiceElector. When the gateway is shutdown
deregister it from the GlobalServiceElector.