### PR TITLE
ENG-19758 reset PreparedStatement upon schema changes

### DIFF
--- a/src/frontend/org/voltdb/exportclient/JDBCExportClient.java
+++ b/src/frontend/org/voltdb/exportclient/JDBCExportClient.java
@@ -609,9 +609,7 @@ public class JDBCExportClient extends ExportClientBase {
                     throw new RestartBlockException(true);
                 }
             }
-            if (!ignoreGenerations) {
-                checkSchemas();
-            }
+            checkSchemas();
         }
 
         @Override
@@ -826,6 +824,9 @@ public class JDBCExportClient extends ExportClientBase {
 
         @Override
         public void sourceNoLongerAdvertised(AdvertisedDataSource source) {
+            if (m_es == null) {
+                return;
+            }
             m_es.shutdown();
             try {
                 if (!m_es.awaitTermination(SHUTDOWN_TIMEOUT_S, TimeUnit.SECONDS)) {


### PR DESCRIPTION
If property  ignoregenerations,  one of the export JDBC client configurations, is true, the client's PreparedStatement won't be updated upon schema changes.  Property  ignoregenerations can be confusing since it is overridden by property createtable. ignoregenerations will be set to true if createtable is set to false. Here proposed to ignore property ignoreGenerations  for schema change validation, update the PreparedStatement if schema has been updated.  

