### PR TITLE
ENG-17813: PersistentTable knows if it is replicated

### DIFF
--- a/src/ee/execution/VoltDBEngine.cpp
+++ b/src/ee/execution/VoltDBEngine.cpp
@@ -2986,7 +2986,7 @@ void VoltDBEngine::addToTuplesModified(int64_t amount) {
 
 void TempTableTupleDeleter::operator()(AbstractTempTable* tbl) const {
     if (tbl != NULL) {
-        tbl->deleteAllTempTuples();
+        tbl->deleteAllTuples();
     }
 }
 

--- a/src/ee/executors/abstractexecutor.h
+++ b/src/ee/executors/abstractexecutor.h
@@ -92,7 +92,7 @@ class AbstractExecutor {
     inline void cleanupTempOutputTable() {
         if (m_tmpOutputTable) {
             VOLT_TRACE("Clearing output table...");
-            m_tmpOutputTable->deleteAllTempTuples();
+            m_tmpOutputTable->deleteAllTuples();
         }
     }
 
@@ -184,7 +184,7 @@ inline bool AbstractExecutor::execute(const NValueArray& params) {
             // For simple no-op sequential scan nodes, sometimes the
             // input table and output table are the same table, hence
             // the check above.
-            table->deleteAllTempTuples();
+            table->deleteAllTuples();
         }
     }
 

--- a/src/ee/executors/commontableexecutor.cpp
+++ b/src/ee/executors/commontableexecutor.cpp
@@ -78,7 +78,7 @@ bool CommonTableExecutor::p_execute(const NValueArray& params) {
         }
 
         // Now prepare for the next iteration...
-        inputTable->deleteAllTempTuples();
+        inputTable->deleteAllTuples();
         inputTable->swapContents(recursiveOutputTable);
 
         // inputTable now has recursive output

--- a/src/ee/executors/deleteexecutor.cpp
+++ b/src/ee/executors/deleteexecutor.cpp
@@ -48,6 +48,7 @@
 #include "common/ExecuteWithMpMemory.h"
 
 #include "indexes/tableindex.h"
+#include "storage/persistenttable.h"
 #include "storage/tableutil.h"
 
 namespace voltdb {
@@ -108,7 +109,7 @@ bool DeleteExecutor::p_execute(const NValueArray &params) {
                            (int)targetTable->allocatedTupleCount());
 
                 // empty the table either by table swap or iteratively deleting tuple-by-tuple
-                targetTable->truncateTable(m_engine, m_replicatedTableOperation);
+                targetTable->truncateTable(m_engine);
             } else {
                 vassert(m_inputTable);
                 vassert(m_inputTuple.columnCount() == m_inputTable->columnCount());

--- a/src/ee/stats/StatsAgent.cpp
+++ b/src/ee/stats/StatsAgent.cpp
@@ -110,7 +110,7 @@ TempTable* StatsAgent::getStats(StatisticsSelectorType sst,
         m_statsTablesByStatsSelector[sst] = statsTable;
     }
 
-    statsTable->deleteAllTempTuples();
+    statsTable->deleteAllTuples();
 
     for (int ii = 0; ii < catalogIds.size(); ii++) {
         multimap<CatalogId, StatsSource*>::const_iterator iter;

--- a/src/ee/storage/AbstractTempTable.hpp
+++ b/src/ee/storage/AbstractTempTable.hpp
@@ -63,7 +63,7 @@ public:
 
     /** Delete all tuples in this table (done when fragment execution
         is complete) */
-    virtual void deleteAllTempTuples() = 0;
+    virtual void deleteAllTuples() = 0;
 
     /** The temp table limits object for this table */
     virtual const TempTableLimits* getTempTableLimits() const = 0;

--- a/src/ee/storage/BinaryLogSink.h
+++ b/src/ee/storage/BinaryLogSink.h
@@ -58,7 +58,7 @@ private:
      * Apply all records within a single transaction from the binary log.
      */
     int64_t applyTxn(BinaryLog *log, std::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool,
-            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId, bool replicatedTable);
+            VoltDBEngine *engine, int32_t remoteClusterId, int64_t localUniqueId);
 
     /**
      * Apply a single transaction to replicated tables
@@ -77,7 +77,7 @@ private:
      */
     int64_t applyRecord(BinaryLog *log, const DRRecordType type,
             std::unordered_map<int64_t, PersistentTable*> &tables, Pool *pool, VoltDBEngine *engine,
-            int32_t remoteClusterId, bool replicatedTable, bool skipRow);
+            int32_t remoteClusterId, bool skipRow);
 };
 
 

--- a/src/ee/storage/LargeTempTable.cpp
+++ b/src/ee/storage/LargeTempTable.cpp
@@ -106,7 +106,7 @@ TableIterator LargeTempTable::iteratorDeletingAsWeGo() {
 }
 
 
-void LargeTempTable::deleteAllTempTuples() {
+void LargeTempTable::deleteAllTuples() {
     finishInserts();
 
     LargeTempTableBlockCache& lttBlockCache = ExecutorContext::getExecutorContext()->lttBlockCache();
@@ -146,7 +146,7 @@ void LargeTempTable::swapContents(AbstractTempTable* otherTable) {
 }
 
 LargeTempTable::~LargeTempTable() {
-    deleteAllTempTuples();
+    deleteAllTuples();
 }
 
 void LargeTempTable::nextFreeTuple(TableTuple*) {
@@ -491,7 +491,7 @@ void LargeTempTable::sort(ProgressMonitorProxy* pmp,
     if (activeTupleCount() == 0) {
         return;
     } else if (limit == 0 || offset >= activeTupleCount()) {
-        deleteAllTempTuples();
+        deleteAllTuples();
         return;
     }
 

--- a/src/ee/storage/LargeTempTable.h
+++ b/src/ee/storage/LargeTempTable.h
@@ -68,12 +68,7 @@ public:
     TableIterator iteratorDeletingAsWeGo() override;
 
     /** Delete all the tuples in this table */
-    void deleteAllTuples(bool freeAllocatedStrings, bool fallible) override {
-        return deleteAllTempTuples();
-    }
-
-    /** Delete all the tuples in this table */
-    void deleteAllTempTuples() override;
+    void deleteAllTuples() override;
 
     /** insert a tuple into this table */
     bool insertTuple(TableTuple& tuple) override;

--- a/src/ee/storage/PersistentTableUndoTruncateTableAction.h
+++ b/src/ee/storage/PersistentTableUndoTruncateTableAction.h
@@ -26,12 +26,10 @@ class PersistentTableUndoTruncateTableAction: public UndoReleaseAction {
 public:
     PersistentTableUndoTruncateTableAction(TableCatalogDelegate * tcd,
             PersistentTable *originalTable,
-            PersistentTable *emptyTable,
-            bool replicatedTableAction)
+            PersistentTable *emptyTable)
         : m_tcd(tcd)
         , m_originalTable(originalTable)
         , m_emptyTable(emptyTable)
-        , m_replicatedTableAction(replicatedTableAction)
     {}
 
 private:
@@ -44,7 +42,7 @@ private:
      *
      */
     virtual void undo() {
-        m_emptyTable->truncateTableUndo(m_tcd, m_originalTable, m_replicatedTableAction);
+        m_emptyTable->truncateTableUndo(m_tcd, m_originalTable);
     }
 
     /*
@@ -67,7 +65,6 @@ private:
     TableCatalogDelegate* m_tcd;
     PersistentTable* m_originalTable;
     PersistentTable* m_emptyTable;
-    bool             m_replicatedTableAction;
 };
 
 }// namespace voltdb

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -267,7 +267,7 @@ public:
     // ------------------------------------------------------------------
     virtual void deleteAllTuples(bool, bool fallible = true);
 
-    void truncateTable(VoltDBEngine* engine, bool replicatedTable = true, bool fallible = true);
+    void truncateTable(VoltDBEngine* engine, bool fallible = true);
 
     void swapTable
            (PersistentTable* otherTable,
@@ -471,7 +471,7 @@ public:
 
     virtual int64_t validatePartitioning(TheHashinator* hashinator, int32_t partitionId);
 
-    void truncateTableUndo(TableCatalogDelegate* tcd, PersistentTable* originalTable, bool replicatedTableAction);
+    void truncateTableUndo(TableCatalogDelegate* tcd, PersistentTable* originalTable);
 
     void truncateTableRelease(PersistentTable* originalTable);
 

--- a/src/ee/storage/persistenttable.h
+++ b/src/ee/storage/persistenttable.h
@@ -265,9 +265,9 @@ public:
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool, bool fallible = true);
+    void deleteAllTuples();
 
-    void truncateTable(VoltDBEngine* engine, bool fallible = true);
+    void truncateTable(VoltDBEngine* engine);
 
     void swapTable
            (PersistentTable* otherTable,
@@ -657,7 +657,7 @@ private:
                                     std::vector<TableIndex*> const& indexesToUpdate);
 
     // Add truncate operation to dr log stream if dr is enabled and running
-    void drLogTruncate(const ExecutorContext* ec, bool fallible);
+    void drLogTruncate(const ExecutorContext* ec);
 
     void notifyBlockWasCompactedAway(TBPtr block);
 

--- a/src/ee/storage/streamedtable.cpp
+++ b/src/ee/storage/streamedtable.cpp
@@ -89,7 +89,7 @@ TableIterator StreamedTable::iteratorDeletingAsWeGo() {
     throw SerializableEEException("May not iterate a streamed table.");
 }
 
-void StreamedTable::deleteAllTuples(bool freeAllocatedStrings, bool fallible)
+void StreamedTable::deleteAllTuples()
 {
     throw SerializableEEException("May not delete all tuples of a streamed table.");
 }

--- a/src/ee/storage/streamedtable.h
+++ b/src/ee/storage/streamedtable.h
@@ -80,7 +80,7 @@ public:
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings, bool=true);
+    virtual void deleteAllTuples();
     void streamTuple(TableTuple &source, ExportTupleStream::STREAM_ROW_TYPE type, AbstractDRTupleStream *drStream = NULL);
     virtual bool insertTuple(TableTuple &tuple);
 

--- a/src/ee/storage/table.h
+++ b/src/ee/storage/table.h
@@ -117,7 +117,7 @@ class Table {
     // ------------------------------------------------------------------
     // OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings, bool fallible=true) = 0;
+    virtual void deleteAllTuples() = 0;
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     // -- Most callers should be using TempTable::insertTempTuple, anyway.
     virtual bool insertTuple(TableTuple& tuple) = 0;

--- a/src/ee/storage/temptable.cpp
+++ b/src/ee/storage/temptable.cpp
@@ -62,10 +62,6 @@ TempTable::~TempTable() {}
 // ------------------------------------------------------------------
 // OPERATIONS
 // ------------------------------------------------------------------
-void TempTable::deleteAllTuples(bool, bool) {
-    deleteAllTempTuples();
-}
-
 void TempTable::deleteAllTempTupleDeepCopies() {
     if (m_tupleCount == 0) {
         return;
@@ -77,7 +73,7 @@ void TempTable::deleteAllTempTupleDeepCopies() {
             target.freeObjectColumns();
         }
     }
-    deleteAllTempTuples();
+    deleteAllTuples();
 }
 
 bool TempTable::insertTuple(TableTuple &source) {

--- a/src/ee/storage/temptable.h
+++ b/src/ee/storage/temptable.h
@@ -91,14 +91,13 @@ class TempTable : public AbstractTempTable {
     // ------------------------------------------------------------------
     // GENERIC TABLE OPERATIONS
     // ------------------------------------------------------------------
-    virtual void deleteAllTuples(bool freeAllocatedStrings, bool = true);
     // TODO: change meaningless bool return type to void (starting in class Table) and migrate callers.
     // -- Most callers should be using TempTable::insertTempTuple, anyway.
     virtual bool insertTuple(TableTuple &tuple);
 
     void deleteAllTempTupleDeepCopies();
 
-    virtual void deleteAllTempTuples();
+    virtual void deleteAllTuples();
 
     /**
      * Uses the pool to do a deep copy of the tuple including allocations
@@ -212,7 +211,7 @@ inline void TempTable::insertTempTuple(TableTuple &source) {
     target.setNonInlinedDataIsVolatileFalse();
 }
 
-inline void TempTable::deleteAllTempTuples() {
+inline void TempTable::deleteAllTuples() {
     if (m_tupleCount == 0) {
         return;
     }

--- a/tests/ee/executors/MergeReceiveExecutorTest.cpp
+++ b/tests/ee/executors/MergeReceiveExecutorTest.cpp
@@ -105,7 +105,7 @@ public:
             ASSERT_TRUE(srcTuples[offset + i++].getNValue(0).op_equals(tuple.getNValue(0)).isTrue());
         }
         // Clean-up
-        m_tempDstTable->deleteAllTempTuples();
+        m_tempDstTable->deleteAllTuples();
     }
 
     char* addPartitionData(std::vector<int>& partitionValues,

--- a/tests/ee/storage/CopyOnWriteTest.cpp
+++ b/tests/ee/storage/CopyOnWriteTest.cpp
@@ -1773,7 +1773,7 @@ public:
     void initialize() {
         m_test.initTable(m_npartitions, static_cast<int>(m_test.m_tupleWidth * (m_tuplesPerBlock + sizeof(int32_t))));
 
-        m_test.m_table->deleteAllTuples(true);
+        m_test.m_table->deleteAllTuples();
         m_test.addRandomUniqueTuples(m_test.m_table, m_numInitial, &m_test.m_initial);
     }
 

--- a/tests/ee/storage/LargeTempTableTest.cpp
+++ b/tests/ee/storage/LargeTempTableTest.cpp
@@ -155,7 +155,7 @@ TEST_F(LargeTempTableTest, Basic) {
         ASSERT_EQ(pkVals.size(), i);
     }
 
-    ltt->deleteAllTempTuples();
+    ltt->deleteAllTuples();
 
     ASSERT_EQ(0, lttBlockCache.totalBlockCount());
     ASSERT_EQ(0, lttBlockCache.allocatedMemory());
@@ -298,7 +298,7 @@ TEST_F(LargeTempTableTest, MultiBlock) {
         ASSERT_EQ(500, i);
     }
 
-    ltt->deleteAllTempTuples();
+    ltt->deleteAllTuples();
 
     ASSERT_EQ(0, lttBlockCache.totalBlockCount());
     ASSERT_EQ(0, lttBlockCache.allocatedMemory());
@@ -411,7 +411,7 @@ TEST_F(LargeTempTableTest, OverflowCache) {
         ASSERT_EQ(NUM_TUPLES, i);
     }
 
-    ltt->deleteAllTempTuples();
+    ltt->deleteAllTuples();
 
     ASSERT_EQ(0, lttBlockCache.totalBlockCount());
     ASSERT_EQ(0, lttBlockCache.allocatedMemory());

--- a/tests/ee/storage/persistent_table_log_test.cpp
+++ b/tests/ee/storage/persistent_table_log_test.cpp
@@ -219,7 +219,7 @@ TEST_F(PersistentTableLogTest, LoadTableThenUndoTest) {
     // de-duplicated with executorcontext data
     m_engine->updateExecutorContextUndoQuantumForTest();
 
-    m_table->deleteAllTuples(true);
+    m_table->deleteAllTuples();
     m_engine->releaseUndoToken(INT64_MIN + 2, false);
 
     delete m_table;
@@ -264,7 +264,7 @@ TEST_F(PersistentTableLogTest, LoadTableThenReleaseTest) {
     // de-duplicated with executorcontext data
     m_engine->updateExecutorContextUndoQuantumForTest();
 
-    m_table->deleteAllTuples(true);
+    m_table->deleteAllTuples();
     m_engine->releaseUndoToken(INT64_MIN + 2, false);
 
     delete m_table;

--- a/tests/ee/storage/persistenttable_test.cpp
+++ b/tests/ee/storage/persistenttable_test.cpp
@@ -379,7 +379,7 @@ TEST_F(PersistentTableTest, TruncateTableTest) {
     beginWork();
     added = tableutil::addRandomTuples(table, tuplesToInsert);
     ASSERT_TRUE(added);
-    table->truncateTable(engine, false);
+    table->truncateTable(engine);
     commit();
 
     // refresh table pointer by fetching the table from catalog as in truncate old table
@@ -624,7 +624,7 @@ TEST_F(PersistentTableTest, SwapTablesTest) {
     validateCounts(1, table, dupTable, tuplesToInsert, tuplesToInsert*3);
 
     // X is not a partitioned table.
-    dupTable->truncateTable(engine, false);
+    dupTable->truncateTable(engine);
     dupTable = engine->getTableDelegate("X")->getPersistentTable();
 
     ASSERT_NE(NULL, dupTable);
@@ -665,7 +665,7 @@ TEST_F(PersistentTableTest, SwapTablesTest) {
 
     validateCounts(1, table, dupTable, 0, tuplesToInsert);
 
-    dupTable->truncateTable(engine, false);
+    dupTable->truncateTable(engine);
     dupTable = engine->getTableDelegate("X")->getPersistentTable();
     ASSERT_NE(NULL, dupTable);
 

--- a/tests/ee/storage/table_test.cpp
+++ b/tests/ee/storage/table_test.cpp
@@ -212,7 +212,7 @@ TEST_F(TableTest, TupleInsert) {
     //
     TableTuple &temp_tuple = m_table->tempTuple();
     tableutil::setRandomTupleValues(m_table, &temp_tuple);
-    m_table->deleteAllTuples(true);
+    m_table->deleteAllTuples();
     ASSERT_EQ(0, m_table->activeTupleCount());
     ASSERT_TRUE(m_table->insertTuple(temp_tuple));
     ASSERT_EQ(1, m_table->activeTupleCount());


### PR DESCRIPTION
VoltDBEngine::initMaterializedViewsAndLimitDeletePlans calls
disableReplicatedFlag() on all purge executors. The delete executor uses
the m_replicatedTableOperation for both synchronizing and passing into
PersistentTable::truncateTable. Because m_replicatedTableOperation was
always false forge purge truncates VoltDBEngine::rebuildTableCollections
was never rebuilding anything for replicated tables which resulted in
freed stats sources in the stats agent.

PersistentTable already knows if it is a replicated table or not so the
replicatedTable argument was unnecessary. By removing the argument the
executor cannot pass an incorrect value into the table.