### PR TITLE
Eng 19791 fix test mid rejoin death

### DIFF
--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotAckReceiver.java
@@ -83,14 +83,14 @@ public class StreamSnapshotAckReceiver implements Runnable {
         try {
             while (true) {
                 if (stopped) {
-                    rejoinLog.debug("Ack reciever thread stopped");
+                    rejoinLog.debug("Ack receiver thread stopped");
                     return;
                 }
 
                 rejoinLog.trace("Blocking on receiving mailbox");
                 VoltMessage msg = m_mb.recvBlocking(10 * 60 * 1000); // Wait for 10 minutes
                 if (stopped) {
-                    rejoinLog.debug("Ack reciever thread stopped");
+                    rejoinLog.debug("Ack receiver thread stopped");
                     return;
                 }
 
@@ -144,5 +144,9 @@ public class StreamSnapshotAckReceiver implements Runnable {
     private void handleException(String message, Exception exception) {
         rejoinLog.error(message, exception);
         m_callbacks.values().forEach(c -> c.receiveError(exception));
+    }
+
+    public boolean isStopped() {
+        return stopped;
     }
 }

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -733,7 +733,7 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
     private synchronized void waitForOutstandingWork()
     {
         boolean interrupted = false;
-        while (m_writeFailed.get() == null && (m_outstandingWorkCount.get() > 0)) {
+        while (m_writeFailed.get() == null && (m_outstandingWorkCount.get() > 0) && !m_ackReceiver.isStopped()) {
             try {
                 wait();
             } catch (InterruptedException e) {

--- a/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
+++ b/src/frontend/org/voltdb/rejoin/StreamSnapshotDataTarget.java
@@ -79,7 +79,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
 
     // schemas for all the tables on this partition
     private final Map<Integer, Pair<Boolean, byte[]>> m_schemas;
-    // HSId of the destination mailbox
+    // HSId of the source site mailbox
+    private final long m_srcHSId;
+    // HSId of the destination site mailbox
     private final long m_destHSId;
     private final Set<Long> m_otherDestHostHSIds;
     private final boolean m_replicatedTableTarget;
@@ -106,15 +108,15 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
 
     private final AtomicBoolean m_closed = new AtomicBoolean(false);
 
-    public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
+    public StreamSnapshotDataTarget(long srcHSId, long destHSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
             byte[] hashinatorConfig, List<SnapshotTableInfo> tables, SnapshotSender sender,
             StreamSnapshotAckReceiver ackReceiver)
     {
-        this(HSId, lowestDestSite, allDestHostHSIds, hashinatorConfig, tables, DEFAULT_WRITE_TIMEOUT_MS, sender,
+        this(srcHSId, destHSId, lowestDestSite, allDestHostHSIds, hashinatorConfig, tables, DEFAULT_WRITE_TIMEOUT_MS, sender,
                 ackReceiver);
     }
 
-    public StreamSnapshotDataTarget(long HSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
+    public StreamSnapshotDataTarget(long srcHSId, long destHSId, boolean lowestDestSite, Set<Long> allDestHostHSIds,
             byte[] hashinatorConfig, List<SnapshotTableInfo> tables, long writeTimeout, SnapshotSender sender,
             StreamSnapshotAckReceiver ackReceiver)
     {
@@ -124,7 +126,8 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         m_targetId = m_totalSnapshotTargetCount.getAndIncrement();
         m_schemas = tables.stream().collect(
                 Collectors.toMap(SnapshotTableInfo::getTableId, t -> Pair.of(t.isReplicated(), t.getSchema())));
-        m_destHSId = HSId;
+        m_srcHSId = srcHSId;
+        m_destHSId = destHSId;
         m_replicatedTableTarget = lowestDestSite;
         m_otherDestHostHSIds = new HashSet<>(allDestHostHSIds);
         m_otherDestHostHSIds.remove(m_destHSId);
@@ -134,8 +137,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         m_ackReceiver.setCallback(m_targetId, this, m_replicatedTableTarget ? allDestHostHSIds.size() : 1);
 
         rejoinLog.debug(String.format("Initializing snapshot stream processor " +
-                "for source site id: %s, and with processorid: %d%s" ,
-                CoreUtils.hsIdToString(HSId), m_targetId, (lowestDestSite?" [Lowest Site]":"")));
+                "for src site id : %s, dest site id: %s, and with processorid: %d%s" ,
+                CoreUtils.hsIdToString(m_srcHSId), CoreUtils.hsIdToString(m_destHSId),
+                m_targetId, (lowestDestSite?" [Lowest Site]":"")));
 
         // start a periodic task to look for timed out connections
         VoltDB.instance().scheduleWork(new Watchdog(0, writeTimeout, System.currentTimeMillis()), WATCHDOG_PERIOD_S, -1, TimeUnit.SECONDS);
@@ -278,9 +282,11 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                     m_ackCounter = new AtomicInteger(1);
                     sentBytes = send(mb, msgFactory, m_message);
                 }
-                rejoinLog.trace("Sent " + m_type.name() + " from " + m_targetId +
-                        " expected ackCounter " + m_ackCounter +
-                        " otherDestHSIds " + m_otherDestHSIds);
+                if (rejoinLog.isTraceEnabled()) {
+                    rejoinLog.trace("Sent " + m_type.name() + " from " + m_targetId +
+                            " expected ackCounter " + m_ackCounter +
+                            " otherDestHSIds " + m_otherDestHSIds);
+                }
                 return sentBytes;
             } finally {
                 // Buffers are only discarded after they are acked. Discarding them here would cause the sender to
@@ -339,8 +345,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                 final int destHostId = CoreUtils.getHostIdFromHSId(m_destHSId);
                 bytesWritten = m_sender.m_bytesSent.get(m_targetId).get();
                 bytesSentSinceLastCheck = bytesWritten - m_bytesWrittenSinceConstruction;
-                rejoinLog.info(String.format("While sending rejoin data to site %s, %d bytes have been sent in the past %s seconds.",
-                        CoreUtils.hsIdToString(m_destHSId), bytesSentSinceLastCheck, WATCHDOG_PERIOD_S));
+                rejoinLog.info(String.format("While sending rejoin data from site %s to site %s, %d bytes have been sent in the past %s seconds.",
+                        CoreUtils.hsIdToString(m_srcHSId), CoreUtils.hsIdToString(m_destHSId),
+                        bytesSentSinceLastCheck, WATCHDOG_PERIOD_S));
 
                 checkTimeout(m_writeTimeout);
                 if (m_writeFailed.get() != null) {
@@ -364,7 +371,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                     VoltDB.instance().scheduleWork(new Watchdog(bytesWritten, m_writeTimeout, bytesSentSinceLastCheck > 0 ? System.currentTimeMillis() : m_lastDataWrite),
                             WATCHDOG_PERIOD_S, -1, TimeUnit.SECONDS);
                 } else {
-                    rejoinLog.info(String.format("Stop watching stream snapshot to site %s", CoreUtils.hsIdToString(m_destHSId)));
+                    rejoinLog.info(String.format("Stop watching stream snapshot from site %s to site %s",
+                            CoreUtils.hsIdToString(m_srcHSId),
+                            CoreUtils.hsIdToString(m_destHSId)));
                 }
             }
         }
@@ -382,8 +391,9 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
             if ((now - work.m_ts) > timeoutMs) {
                 StreamSnapshotTimeoutException exception =
                         new StreamSnapshotTimeoutException(String.format(
-                                "A snapshot write task failed after a timeout (currently %d seconds outstanding). " +
+                                "A snapshot write task failed on site %s after a timeout (currently %d seconds outstanding). " +
                                         "Node rejoin may need to be retried",
+                                CoreUtils.hsIdToString(m_srcHSId),
                                 (now - work.m_ts) / 1000));
                 rejoinLog.error(exception.getMessage());
                 setWriteFailed(exception);
@@ -577,9 +587,10 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
                     // remove the schema once sent
                     byte[] schema = tableInfo.getSecond();
                     m_schemas.put(tableId, Pair.of(tableInfo.getFirst(), null));
-                    rejoinLog.debug("Sending schema for table " + tableId);
+                    if (rejoinLog.isDebugEnabled()) {
+                        rejoinLog.debug("Sending schema for table " + tableId);
+                    }
 
-                    rejoinLog.trace("Writing schema as part of this write");
                     send(StreamSnapshotMessageType.SCHEMA, tableId, schema, tableInfo.getFirst());
                 }
 
@@ -622,7 +633,8 @@ implements SnapshotDataTarget, StreamSnapshotAckReceiver.AckCallback {
         SettableFuture<Boolean> sendFuture = SettableFuture.create();
         if (rejoinLog.isTraceEnabled()) {
             rejoinLog.trace("Sending block " + blockIndex + " of type " + (replicatedTable?"REPLICATED ":"PARTITIONED ") + type.name() +
-                    " from targetId " + m_targetId + " to " + CoreUtils.hsIdToString(m_destHSId) +
+                    " from targetId " + m_targetId + " site " + CoreUtils.hsIdToString(m_srcHSId) +
+                    " to " + CoreUtils.hsIdToString(m_destHSId) +
                     (replicatedTable?", " + CoreUtils.hsIdCollectionToString(m_otherDestHostHSIds):""));
         }
         SendWork sendWork = new SendWork(type, m_targetId, m_destHSId,

--- a/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateSettings.java
@@ -25,7 +25,6 @@ import org.apache.zookeeper_voltpatches.ZooKeeper;
 import org.apache.zookeeper_voltpatches.data.Stat;
 import org.voltcore.logging.VoltLogger;
 import org.voltcore.messaging.HostMessenger;
-import org.voltcore.utils.CoreUtils;
 import org.voltdb.CatalogContext;
 import org.voltdb.DependencyPair;
 import org.voltdb.ParameterSet;
@@ -80,10 +79,6 @@ public class UpdateSettings extends VoltSystemProcedure {
         if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrier) {
             DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateSettingsBarrier,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
-            if (log.isInfoEnabled()) {
-                log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
-                        " reached settings update barrier.");
-            }
             return success;
 
         } else if (fragmentId == SysProcFragmentId.PF_updateSettingsBarrierAggregate) {

--- a/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
+++ b/src/frontend/org/voltdb/sysprocs/saverestore/StreamSnapshotWritePlan.java
@@ -203,7 +203,8 @@ public class StreamSnapshotWritePlan extends SnapshotWritePlan<StreamSnapshotReq
                             new DataTargetInfo(stream,
                                                srcHSId,
                                                destHSId,
-                                               new StreamSnapshotDataTarget(destHSId,
+                                               new StreamSnapshotDataTarget(srcHSId,
+                                                                            destHSId,
                                                                             (destHSId == stream.lowestSiteSinkHSId),
                                                                             destsByHostId.get(CoreUtils.getHostIdFromHSId(destHSId)),
                                             hashinatorConfig, tables, sender, ackReceiver));

--- a/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotDataTarget.java
+++ b/tests/frontend/org/voltdb/rejoin/TestStreamSnapshotDataTarget.java
@@ -92,7 +92,7 @@ public class TestStreamSnapshotDataTarget {
         VoltDB.instance().getHostMessenger().removeMailbox(100l);
     }
 
-    private StreamSnapshotDataTarget makeDataTarget(long destHSId, boolean sendHashinator, boolean lowestSite)
+    private StreamSnapshotDataTarget makeDataTarget(long srcHSId, long destHSId, boolean sendHashinator, boolean lowestSite)
     {
         byte[] hashinatorBytes = null;
         if (sendHashinator) {
@@ -102,7 +102,7 @@ public class TestStreamSnapshotDataTarget {
             hashinatorBytes = hashinator.array();
         }
 
-        return new StreamSnapshotDataTarget(destHSId, lowestSite, new HashSet<Long>(Arrays.asList(destHSId)),
+        return new StreamSnapshotDataTarget(srcHSId, destHSId, lowestSite, new HashSet<Long>(Arrays.asList(destHSId)),
                 hashinatorBytes, m_tables, m_sender, m_ack);
     }
 
@@ -206,8 +206,8 @@ public class TestStreamSnapshotDataTarget {
     @Test
     public void testStreamClose() throws IOException, InterruptedException, ExecutionException
     {
-        StreamSnapshotDataTarget dut1 = makeDataTarget(1000, false, true);
-        StreamSnapshotDataTarget dut2 = makeDataTarget(1001, false, false);
+        StreamSnapshotDataTarget dut1 = makeDataTarget(100, 1000, false, true);
+        StreamSnapshotDataTarget dut2 = makeDataTarget(101, 1001, false, false);
 
         closeStream(dut1);
         assertNotNull(VoltDB.instance().getHostMessenger().getMailbox(m_mb.getHSId()));
@@ -226,8 +226,8 @@ public class TestStreamSnapshotDataTarget {
     @Test
     public void testMultiplexing() throws IOException, InterruptedException, ExecutionException
     {
-        StreamSnapshotDataTarget dut1 = makeDataTarget(1000, false, true);
-        StreamSnapshotDataTarget dut2 = makeDataTarget(1001, false, false);
+        StreamSnapshotDataTarget dut1 = makeDataTarget(100, 1000, false, true);
+        StreamSnapshotDataTarget dut2 = makeDataTarget(101, 1001, false, false);
 
         writeAndVerify(/* dataTarget = */ dut1, /* tableId = */ 0, /* hasSchema = */ true);
         writeAndVerify(/* dataTarget = */ dut2, /* tableId = */ 1, /* hasSchema = */ true);
@@ -255,7 +255,7 @@ public class TestStreamSnapshotDataTarget {
     @Test
     public void testSendHashinatorConfig() throws IOException, ExecutionException, InterruptedException
     {
-        StreamSnapshotDataTarget dut = makeDataTarget(1000, true, true);
+        StreamSnapshotDataTarget dut = makeDataTarget(100, 1000, true, true);
 
         assertEquals(1, dut.m_outstandingWorkCount.get());
         while (m_mb.noSentMessages()) {


### PR DESCRIPTION
In close(), stream data target sends the last EOS and expects for an ACK. However,
when rejoin is timeout the AckReceiver is stopped, therefore no ACK would be received.
Add a liveness check on AckReceiver receiver inside close() to break the loop, let data target
to handle other resource release work.