### PR TITLE
add socket timeout to list of non-fatal errors

### DIFF
--- a/src/frontend/org/voltcore/messaging/SocketJoiner.java
+++ b/src/frontend/org/voltcore/messaging/SocketJoiner.java
@@ -792,10 +792,11 @@ public class SocketJoiner {
             return socket;
         }
         catch (java.net.ConnectException
-               | java.nio.channels.UnresolvedAddressException
-               | java.net.UnknownHostException
                | java.net.NoRouteToHostException
-               | java.net.PortUnreachableException ex) {
+               | java.net.PortUnreachableException
+               | java.net.SocketTimeoutException
+               | java.net.UnknownHostException
+               | java.nio.channels.UnresolvedAddressException ex) {
             safeClose(socket);
             throw new SocketRetryException(ex);
         }


### PR DESCRIPTION

SocketJoiner has a list of non-fatal errors.  Socket timeout isn't on that list; it should be.

Without this, we sometimes crash when we should not.
