### PR TITLE
Add REMOTECREATIONTIMESTAMP to DRProducer stats, add REMOTE_CREATION_…

### DIFF
--- a/src/frontend/org/voltdb/DRConsumerStatsBase.java
+++ b/src/frontend/org/voltdb/DRConsumerStatsBase.java
@@ -42,6 +42,8 @@ public class DRConsumerStatsBase {
         public static final String LAST_RECEIVED_TIMESTAMP = "LAST_RECEIVED_TIMESTAMP";
         public static final String LAST_APPLIED_TIMESTAMP = "LAST_APPLIED_TIMESTAMP";
         public static final String IS_PAUSED = "IS_PAUSED";
+        public static final String REMOTE_CREATION_TIMESTMAP = "REMOTE_CREATION_TIMESTMAP";
+        public static final String LAST_FAILURE = "LAST_FAILURE";
     }
 
     public static class DRConsumerNodeStatsBase extends StatsSource {
@@ -57,6 +59,8 @@ public class DRConsumerStatsBase {
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
             columns.add(new ColumnInfo(Columns.REPLICATION_RATE_1M, VoltType.BIGINT));
             columns.add(new ColumnInfo(Columns.REPLICATION_RATE_5M, VoltType.BIGINT));
+            columns.add(new ColumnInfo(Columns.REMOTE_CREATION_TIMESTMAP, VoltType.TIMESTAMP));
+            columns.add(new ColumnInfo(Columns.LAST_FAILURE, VoltType.INTEGER));
         }
 
         @Override

--- a/src/frontend/org/voltdb/DRProducerNodeStats.java
+++ b/src/frontend/org/voltdb/DRProducerNodeStats.java
@@ -20,7 +20,7 @@ package org.voltdb;
 public class DRProducerNodeStats {
     public static final DRProducerNodeStats DISABLED_NODE_STATS =
         new DRProducerNodeStats((byte) -1, (byte) -1, DRRoleStats.State.DISABLED, "NONE",
-                                -1, -1, 0);
+                                -1, -1, 0, 0);
 
     public final short clusterId;
     public final short consumerClusterId;
@@ -29,6 +29,7 @@ public class DRProducerNodeStats {
     public final long rowsInSyncSnapshot;
     public final long rowsAckedForSyncSnapshot;
     public final long queueDepth;
+    public final long remoteCreationTs;
 
     public DRProducerNodeStats(short clusterId,
                                short consumerClusterId,
@@ -36,7 +37,8 @@ public class DRProducerNodeStats {
                                String syncSnapshotState,
                                long rowsInSyncSnapshot,
                                long rowsAckedForSyncSnapshot,
-                               long queueDepth) {
+                               long queueDepth,
+                               long remoteCreationTs) {
         this.clusterId = clusterId;
         this.consumerClusterId = consumerClusterId;
         this.state = state;
@@ -44,5 +46,6 @@ public class DRProducerNodeStats {
         this.rowsInSyncSnapshot = rowsInSyncSnapshot;
         this.rowsAckedForSyncSnapshot = rowsAckedForSyncSnapshot;
         this.queueDepth = queueDepth;
+        this.remoteCreationTs = remoteCreationTs;
     }
 }

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -37,6 +37,7 @@ public class DRProducerStatsBase {
         public static final String ROWS_IN_SYNC_SNAPSHOT = "ROWSINSYNCSNAPSHOT";
         public static final String ROWS_ACKED_FOR_SYNC_SNAPSHOT = "ROWSACKEDFORSYNCSNAPSHOT";
         public static final String QUEUE_DEPTH = "QUEUEDEPTH";
+        public static final String REMOTE_CREATION_TIMESTAMP = "REMOTECREATIONTIMESTAMP";
 
         // columns for partition-level table
         public static final String STREAM_TYPE = "STREAMTYPE";
@@ -69,6 +70,7 @@ public class DRProducerStatsBase {
             columns.add(new ColumnInfo(Columns.ROWS_IN_SYNC_SNAPSHOT, VoltType.BIGINT));
             columns.add(new ColumnInfo(Columns.ROWS_ACKED_FOR_SYNC_SNAPSHOT, VoltType.BIGINT));
             columns.add(new ColumnInfo(Columns.QUEUE_DEPTH, VoltType.BIGINT));
+            columns.add(new ColumnInfo(Columns.REMOTE_CREATION_TIMESTAMP, VoltType.TIMESTAMP));
         }
 
         @Override


### PR DESCRIPTION
…TIMESTMAP and LAST_FAILURE to DRConsumer stats.

Change-Id: I45ba5f69a9b42f74b6aacf15c9b55bd9a7af5d64


Work is based on branch KO-386-EncodedDRErrorIds. 