### PR TITLE
ENG-19802.  Default to no trial license in enterprise kit

### DIFF
--- a/tools/kit_tools/build_kits.py
+++ b/tools/kit_tools/build_kits.py
@@ -268,6 +268,7 @@ if __name__ == "__main__":
     parser.add_argument('-g','--gitloc', default="git@github.com:VoltDB", help="Repository location. For example: /home/github-mirror")
     parser.add_argument('--nomac', action='store_true', help="Don't build Mac OSX")
     parser.add_argument('--nocommunity', action='store_true', help="Don't build community")
+    parser.add_argument('-l','--includelicense', action='store_true', help="Include a trial license in the Enterprise kit")
     args = parser.parse_args()
 
 
@@ -288,10 +289,15 @@ if __name__ == "__main__":
 
     rmNativeLibs()
 
+    #Set a bunch of build_args
+    build_args=""
     try:
         build_args = os.environ['VOLTDB_BUILD_ARGS']
     except:
-        build_args=""
+        pass
+
+    if not args.includelicense:
+        build_args += " -Dtriallicense=false"
 
     print "Building with pro: %s and voltdb: %s" % (proTreeish, voltdbTreeish)
 


### PR DESCRIPTION
Can use -l or --includelicense to make the kit with a trial license.