### PR TITLE
report java user properties in host log

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1020,6 +1020,13 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 consoleLog.info(String.format("Licensed to: %s", licensee));
             }
         }
+
+        // Log some facts about the user account: account name,
+        // home dir, working dir where Java was started
+        hostLog.info(String.format("User properties: user.name '%s' user.home '%s' user.dir '%s'",
+                                   System.getProperty("user.name"),
+                                   System.getProperty("user.home"),
+                                   System.getProperty("user.dir")));
     }
 
     /**


### PR DESCRIPTION

Java provides system properties related to user identity.  We uses these properties in various places (to make filenames, etc).  I thought it would be handy to log them.  In particular, I discovered that if you don't have an account entry these strings may get set to '?'.

