### PR TITLE
ENG-19821 Do not delete staged catalog upon exception. 

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -446,14 +446,7 @@ public class UpdateCore extends VoltSystemProcedure {
         }
         catch (VoltAbortException vae) {
             log.info("Catalog verification failed: " + vae.getMessage());
-            // Do not remove staged catalog for transaction restart
-            if (vae instanceof TransactionRestartException) {
-                TransactionRestartException tre = (TransactionRestartException)vae;
-                // The exception should not be from re-routing/leader migration.
-                assert(!tre.isMisrouted());
-            } else {
-                ZKUtil.deleteRecursively(zk, ZKUtil.joinZKPath(VoltZK.catalogbytes, String.valueOf(nextCatalogVersion)));
-            }
+            // Do not delete staged catalog upon exception. Other hosts may fall behind in transaction and need the catalog.
             throw vae;
         }
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -45,7 +45,6 @@ import org.voltdb.catalog.CatalogMap;
 import org.voltdb.catalog.Table;
 import org.voltdb.client.ClientResponse;
 import org.voltdb.exceptions.SpecifiedException;
-import org.voltdb.exceptions.TransactionRestartException;
 import org.voltdb.export.ExportManagerInterface;
 import org.voltdb.plannerv2.VoltSchemaPlus;
 import org.voltdb.utils.CatalogUtil;
@@ -232,14 +231,19 @@ public class UpdateCore extends VoltSystemProcedure {
         if (fragmentId == SysProcFragmentId.PF_updateCatalogPrecheckAndSync) {
             String[] tablesThatMustBeEmpty = (String[]) params.getParam(0);
             String[] reasonsForEmptyTables = (String[]) params.getParam(1);
-
+            int nextCatalogVersion = (int) params.getParam(2);
+            ColumnInfo[] column = new ColumnInfo[2];
+            column[0] = new ColumnInfo("NEXT_VERSION", VoltType.INTEGER);
+            column[1] = new ColumnInfo("MESSAGE", VoltType.STRING);
+            VoltTable result = new VoltTable(column);
             try {
                 checkForNonEmptyTables(tablesThatMustBeEmpty, reasonsForEmptyTables, context);
             } catch (Exception ex) {
                 log.info("checking non-empty tables failed: " + ex.getMessage() +
                          ", cleaning up temp catalog jar file");
                 VoltDB.instance().cleanUpTempCatalogJar();
-                throw ex;
+                result.addRow(nextCatalogVersion, ex.getMessage());
+                return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSync, result);
             }
 
             // Note: this call can block up to a fixed timeout waiting for data source
@@ -250,21 +254,30 @@ public class UpdateCore extends VoltSystemProcedure {
             // all the cluster sites on the start of catalog update, we'll do
             // the actual work on the second round-trip below
 
-            // Don't actually care about the returned table, just need to send something back to the MPI
-            DependencyPair success = new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
-                    new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
-
             if (log.isDebugEnabled()) {
                 log.debug("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
                         " completed data precheck.");
             }
-            return success;
+            return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSync, result);
         }
         else if (fragmentId == SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate) {
-            // Don't actually care about the returned table, just need to send something
-            // back to the MPI scoreboard
             log.info("Site " + CoreUtils.hsIdToString(m_site.getCorrespondingSiteId()) +
                     " acknowledged data and catalog prechecks.");
+            List<VoltTable> tables = dependencies.get(SysProcFragmentId.PF_updateCatalogPrecheckAndSync);
+            for (VoltTable t : tables) {
+                if (t.advanceRow()) {
+                    // Update failed. Remove the staged catalog after all the sites get chance to work on it (ENG-19821)
+                    ZooKeeper zk = VoltDB.instance().getHostMessenger().getZK();
+                    final int nextVersion = (int) t.getLong("NEXT_VERSION");
+                    try {
+                        ZKUtil.deleteRecursively(zk, ZKUtil.joinZKPath(VoltZK.catalogbytes, Integer.toString(nextVersion)));
+                    } catch (Exception e) {
+                        log.error("error deleting staged catalog.", e);
+                    }
+                    log.info("@UpdateCore aborted for catalog version " + nextVersion);
+                    throw new SpecifiedException(ClientResponse.UNEXPECTED_FAILURE, t.getString("MESSAGE"));
+                }
+            }
             return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate,
                     new VoltTable(new ColumnInfo[] { new ColumnInfo("UNUSED", VoltType.BIGINT) } ));
         }
@@ -347,14 +360,15 @@ public class UpdateCore extends VoltSystemProcedure {
 
     private final void performCatalogVerifyWork(
             String[] tablesThatMustBeEmpty,
-            String[] reasonsForEmptyTables)
+            String[] reasonsForEmptyTables,
+            int nextCatalogVersion)
     {
         // Do a null round of work to sync up all the sites.  Avoids the possibility that
         // skew between nodes and/or partitions could result in cases where a catalog update
         // affects global state before transactions expecting the old catalog run
         createAndExecuteSysProcPlan(SysProcFragmentId.PF_updateCatalogPrecheckAndSync,
                 SysProcFragmentId.PF_updateCatalogPrecheckAndSyncAggregate, tablesThatMustBeEmpty,
-                reasonsForEmptyTables);
+                reasonsForEmptyTables, nextCatalogVersion);
     }
 
     private final VoltTable[] performCatalogUpdateWork(
@@ -442,11 +456,11 @@ public class UpdateCore extends VoltSystemProcedure {
         try {
             performCatalogVerifyWork(
                     tablesThatMustBeEmpty,
-                    reasonsForEmptyTables);
+                    reasonsForEmptyTables,
+                    nextCatalogVersion);
         }
         catch (VoltAbortException vae) {
             log.info("Catalog verification failed: " + vae.getMessage());
-            // Do not delete staged catalog upon exception. Other hosts may fall behind in transaction and need the catalog.
             throw vae;
         }
 


### PR DESCRIPTION
@UpdateCore may be far ahead in the transaction processing on some sites. If the transaction fails on these sites and the stage catalog is deleted, other sites which fall behind in transaction may not be able to get the catalog when needed.

[back port from master](https://github.com/VoltDB/voltdb/pull/7315)