### PR TITLE
KO-434, report last failure in Statistics.DRPRODUCER.cluster (the 3rd table)

### DIFF
--- a/src/frontend/org/voltdb/DRProducerClusterStats.java
+++ b/src/frontend/org/voltdb/DRProducerClusterStats.java
@@ -1,0 +1,37 @@
+/* This file is part of VoltDB.
+ * Copyright (C) 2020 VoltDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.voltdb;
+
+import org.voltdb.dr2.DRCtrlRespFailure;
+
+public class DRProducerClusterStats {
+    public final short clusterId;
+    public final short consumerClusterId;
+    public final DRRoleStats.State state;
+    public final DRCtrlRespFailure lastFailure;
+
+    public DRProducerClusterStats(short clusterId,
+                               short consumerClusterId,
+                               DRRoleStats.State state,
+                               DRCtrlRespFailure lastFailure) {
+        this.clusterId = clusterId;
+        this.consumerClusterId = consumerClusterId;
+        this.state = state;
+        this.lastFailure = lastFailure;
+    }
+}

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -31,8 +31,13 @@ public class DRProducerStatsBase {
         public static final String CLUSTER_ID = "CLUSTER_ID";
         public static final String REMOTE_CLUSTER_ID = "REMOTE_CLUSTER_ID";
 
-        // columns for the node-level table
+        // column for both cluster-level and node-level tables
         public static final String STATE = "STATE";
+
+        // columns for cluster-level table
+        public static final String LAST_FAILURE = "LASTFAILURE";
+
+        // columns for the node-level table
         public static final String SYNC_SNAPSHOT_STATE = "SYNCSNAPSHOTSTATE";
         public static final String ROWS_IN_SYNC_SNAPSHOT = "ROWSINSYNCSNAPSHOT";
         public static final String ROWS_ACKED_FOR_SYNC_SNAPSHOT = "ROWSACKEDFORSYNCSNAPSHOT";
@@ -52,6 +57,27 @@ public class DRProducerStatsBase {
         public static final String IS_SYNCED = "ISSYNCED";
         public static final String MODE = "MODE";
         public static final String CONNECTION_STATUS = "CONNECTION_STATUS";
+    }
+
+    public static class DRProducerClusterStatsBase extends StatsSource {
+
+        public DRProducerClusterStatsBase() {
+            super(false);
+        }
+
+        @Override
+        protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
+            super.populateColumnSchema(columns);
+            columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.SMALLINT));
+            columns.add(new ColumnInfo(Columns.REMOTE_CLUSTER_ID, VoltType.SMALLINT));
+            columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));
+            columns.add(new ColumnInfo(Columns.LAST_FAILURE, VoltType.SMALLINT));
+        }
+
+        @Override
+        protected Iterator<Object> getStatsRowKeyIterator(boolean interval) {
+            return ImmutableSet.of().iterator();
+        }
     }
 
     public static class DRProducerNodeStatsBase extends StatsSource {

--- a/src/frontend/org/voltdb/DRProducerStatsBase.java
+++ b/src/frontend/org/voltdb/DRProducerStatsBase.java
@@ -67,7 +67,6 @@ public class DRProducerStatsBase {
 
         @Override
         protected void populateColumnSchema(ArrayList<VoltTable.ColumnInfo> columns) {
-            super.populateColumnSchema(columns);
             columns.add(new ColumnInfo(Columns.CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.REMOTE_CLUSTER_ID, VoltType.SMALLINT));
             columns.add(new ColumnInfo(Columns.STATE, VoltType.STRING));

--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -1707,6 +1707,8 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                         new DRProducerStatsBase.DRProducerNodeStatsBase());
                 getStatsAgent().registerStatsSource(StatsSelector.DRPRODUCERPARTITION, 0,
                         new DRProducerStatsBase.DRProducerPartitionStatsBase());
+                getStatsAgent().registerStatsSource(StatsSelector.DRPRODUCERCLUSTER, 0,
+                        new DRProducerStatsBase.DRProducerClusterStatsBase());
             }
             m_drRoleStats = new DRRoleStats(this);
             getStatsAgent().registerStatsSource(StatsSelector.DRROLE, 0, m_drRoleStats);

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -89,6 +89,10 @@ public class StatsAgent extends OpsAgent
             break;
         case SNAPSHOTSUMMARY:
             request.aggregateTables = SnapshotSummary.summarize(request.aggregateTables[0]);
+            break;
+        case DRPRODUCER:
+            request.aggregateTables = aggregateDRProducerClusterStats(request.aggregateTables);
+            break;
         default:
         }
     }
@@ -461,6 +465,11 @@ public class StatsAgent extends OpsAgent
 
     private VoltTable[] aggregateDRRoleStats(VoltTable[] stats) {
         return new VoltTable[] { DRRoleStats.aggregateStats(stats[0]) };
+    }
+
+    private VoltTable[] aggregateDRProducerClusterStats(VoltTable[] stats) {
+        VoltTable clusterStats = DRProducerClusterStats.aggregateStats(stats[2]);
+        return new VoltTable[] { stats[0], stats[1], clusterStats };
     }
 
     public void registerStatsSource(StatsSelector selector, long siteId, StatsSource source) {

--- a/src/frontend/org/voltdb/StatsAgent.java
+++ b/src/frontend/org/voltdb/StatsAgent.java
@@ -28,6 +28,7 @@ import org.voltdb.TheHashinator.HashinatorConfig;
 import org.voltdb.VoltTable.ColumnInfo;
 import org.voltdb.catalog.Procedure;
 import org.voltdb.client.ClientResponse;
+import org.voltdb.dr2.DRProducerClusterStats;
 import org.voltdb.task.TaskStatsSource;
 
 import com.google_voltpatches.common.base.Supplier;

--- a/src/frontend/org/voltdb/StatsSelector.java
+++ b/src/frontend/org/voltdb/StatsSelector.java
@@ -45,12 +45,13 @@ public enum StatsSelector {
     PROCEDUREDETAIL(PROCEDURE),  // provides more granular statistics for procedure calls at a per-statement level.
 
     /*
-     * DRPRODUCERPARTITION and DRPRODUCERNODE are internal names
+     * DRPRODUCERPARTITION, DRPRODUCERNODE and DRPRODUCERCLUSTER are internal names
      * Externally the selector is "DRPRODUCER", or just "DR"
      */
     DRPRODUCERPARTITION(false),
     DRPRODUCERNODE(false),
-    DR(DRPRODUCERPARTITION, DRPRODUCERNODE),
+    DRPRODUCERCLUSTER(false),
+    DR(DRPRODUCERPARTITION, DRPRODUCERNODE, DRPRODUCERCLUSTER),
     DRPRODUCER(DR.subSelectors()),
 
     DRCONSUMERNODE(false),

--- a/src/frontend/org/voltdb/dr2/DRProducerClusterStats.java
+++ b/src/frontend/org/voltdb/dr2/DRProducerClusterStats.java
@@ -31,6 +31,8 @@ public class DRProducerClusterStats {
     public final DRRoleStats.State state;
     public final byte lastErrorCode;
 
+    private final static byte NO_FAILURE = 0;
+
     public DRProducerClusterStats(short clusterId,
                                short consumerClusterId,
                                DRRoleStats.State state,
@@ -71,8 +73,7 @@ public class DRProducerClusterStats {
             Byte failure = failureMap.get(key);
             if (failure == null) {
                 failureMap.put(key, lastFailure);
-            } else if (failure == DRCtrlRespFailure.NONE.errorCode() &&
-                    lastFailure != DRCtrlRespFailure.NONE.errorCode()){
+            } else if (failure == NO_FAILURE && lastFailure != NO_FAILURE){
                 failureMap.put(key, lastFailure);
             }
 

--- a/src/frontend/org/voltdb/dr2/DRProducerClusterStats.java
+++ b/src/frontend/org/voltdb/dr2/DRProducerClusterStats.java
@@ -15,28 +15,30 @@
  * along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.voltdb;
+package org.voltdb.dr2;
 
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.voltcore.utils.Pair;
-import org.voltdb.dr2.DRCtrlRespFailure;
+import org.voltdb.DRProducerStatsBase;
+import org.voltdb.DRRoleStats;
+import org.voltdb.VoltTable;
 
 public class DRProducerClusterStats {
     public final short clusterId;
     public final short consumerClusterId;
     public final DRRoleStats.State state;
-    public final DRCtrlRespFailure lastFailure;
+    public final byte lastErrorCode;
 
     public DRProducerClusterStats(short clusterId,
                                short consumerClusterId,
                                DRRoleStats.State state,
-                               DRCtrlRespFailure lastFailure) {
+                               byte lastFailure) {
         this.clusterId = clusterId;
         this.consumerClusterId = consumerClusterId;
         this.state = state;
-        this.lastFailure = lastFailure;
+        this.lastErrorCode = lastFailure;
     }
 
     /**

--- a/tests/frontend/org/voltdb/TestStatsAgent.java
+++ b/tests/frontend/org/voltdb/TestStatsAgent.java
@@ -22,23 +22,26 @@
  */
 package org.voltdb;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.voltcore.network.*;
+import org.voltcore.network.Connection;
+import org.voltcore.network.MockConnection;
+import org.voltcore.network.MockWriteStream;
+import org.voltcore.network.WriteStream;
 import org.voltdb.client.ClientResponse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class TestStatsAgent {
 
@@ -104,6 +107,8 @@ public class TestStatsAgent {
         });
         m_mvoltdb.getStatsAgent().registerStatsSource(StatsSelector.DRPRODUCERNODE, 0, nodeSource);
 
+        m_mvoltdb.getStatsAgent().registerStatsSource(StatsSelector.DRPRODUCERCLUSTER, 0, nodeSource);
+
         List<VoltTable.ColumnInfo> snapshotStatusColumns = Arrays.asList(new VoltTable.ColumnInfo[] {
             new VoltTable.ColumnInfo("c1", VoltType.STRING),
             new VoltTable.ColumnInfo("c2", VoltType.STRING)
@@ -146,7 +151,7 @@ public class TestStatsAgent {
         VoltTable results[] = response.getResults();
         System.out.println(results[0]);
         System.out.println(results[1]);
-        verifyResults(response);
+        verifyResults(response, 3);
     }
 
     @Test
@@ -236,12 +241,12 @@ public class TestStatsAgent {
          */
         m_mvoltdb.getStatsAgent().performOpsAction(m_mockConnection, 32, OpsSelector.STATISTICS, subselect("DR", 0));
         ClientResponseImpl response = responses.take();
-        verifyResults(response);
+        verifyResults(response, 3);
     }
 
-    private void verifyResults(ClientResponseImpl response) {
+    private void verifyResults(ClientResponseImpl response, int expectedTables) {
         VoltTable results[] = response.getResults();
-        assertEquals(2, results.length);
+        assertEquals(expectedTables, results.length);
 
         Set<Integer> pValues = new HashSet<Integer>();
         pValues.add(45);

--- a/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
+++ b/tests/frontend/org/voltdb/regressionsuites/statistics/TestStatisticsSuiteDRStats.java
@@ -49,10 +49,18 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
 
     private static int REPLICATION_PORT = 11000;
 
+    private static final ColumnInfo[] expectedDRClusterStatsSchema;
     private static final ColumnInfo[] expectedDRNodeStatsSchema;
     private static final ColumnInfo[] expectedDRPartitionStatsSchema;
 
     static {
+        expectedDRClusterStatsSchema = new ColumnInfo[] {
+                new ColumnInfo("CLUSTER_ID", VoltType.SMALLINT),
+                new ColumnInfo("REMOTE_CLUSTER_ID", VoltType.SMALLINT),
+                new ColumnInfo("STATE", VoltType.STRING),
+                new ColumnInfo("LASTFAILURE", VoltType.SMALLINT)
+        };
+
         expectedDRNodeStatsSchema = new ColumnInfo[] {
             new ColumnInfo("TIMESTAMP", VoltType.BIGINT),
             new ColumnInfo("HOST_ID", VoltType.INTEGER),
@@ -63,7 +71,8 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
             new ColumnInfo("SYNCSNAPSHOTSTATE", VoltType.STRING),
             new ColumnInfo("ROWSINSYNCSNAPSHOT", VoltType.BIGINT),
             new ColumnInfo("ROWSACKEDFORSYNCSNAPSHOT", VoltType.BIGINT),
-            new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT)
+            new ColumnInfo("QUEUEDEPTH", VoltType.BIGINT),
+            new ColumnInfo("REMOTECREATIONTIMESTAMP", VoltType.TIMESTAMP)
         };
 
         expectedDRPartitionStatsSchema = new ColumnInfo[] {
@@ -229,17 +238,19 @@ public class TestStatisticsSuiteDRStats extends StatisticsTestSuiteBase {
 
         VoltTable expectedTable1 = new VoltTable(expectedDRPartitionStatsSchema);
         VoltTable expectedTable2 = new VoltTable(expectedDRNodeStatsSchema);
-
+        VoltTable expectedTable3 = new VoltTable(expectedDRClusterStatsSchema);
         //
         // DR
         //
         VoltTable[] results = client.callProcedure("@Statistics", "DR", 0).getResults();
         // two aggregate tables returned
-        assertEquals(2, results.length);
+        assertEquals(3, results.length);
         System.out.println("Test DR table: " + results[0].toString());
         System.out.println("Test DR table: " + results[1].toString());
+        System.out.println("Test DR table: " + results[2].toString());
         validateSchema(results[0], expectedTable1);
         validateSchema(results[1], expectedTable2);
+        validateSchema(results[2], expectedTable3);
 
         // One row per host for DRNODE stats
         results[1].advanceRow();


### PR DESCRIPTION
Failures are encoded byte defined in https://github.com/VoltDB/pro/blob/KO-integration/src/frontend/org/voltdb/dr2/DRCtrlRespFailure.java.

The main purpose is to expose programmatically information for XDCR cluster to decide when to do _dr reset_.  