### PR TITLE
Changes on finalization behavior:

### DIFF
--- a/src/ee/storage/TableTupleAllocator.cpp
+++ b/src/ee/storage/TableTupleAllocator.cpp
@@ -589,16 +589,50 @@ inline void CompactingStorageTrait::thaw() {
             auto const& beginTxn = storage.beginTxn();
             bool const empty = beginTxn.empty();
             auto const stop = empty ? 0 : beginTxn.iterator()->id();
-            // NOTE: we **never** finalize a TXN chunk (that is
-            // only visible to snapshot), since they had been
-            // either:
-            // 1. removed without compaction at which time it is
-            // finalized; or
-            // 2. moved due to compaction, whence the move does
-            // *not* deep copy (see `remove_force()')
-            while (! m_storage.empty() && (empty || less_rolling(m_storage.front().id(), stop))) {
-                assert(storage.begin()->range_left() == storage.begin()->range_right());
-                storage.pop_front();
+            if (storage.finalizerAndCopier()) { // Finalize all TXN chunk (that is only visible to snapshot);
+                id_type id;
+                bool const hasFrozenBoundaries = static_cast<bool>(storage.frozenBoundaries());
+                auto const
+                    f_left = hasFrozenBoundaries ? storage.frozenBoundaries()->left() : position_type{},
+                           f_right = hasFrozenBoundaries ? storage.frozenBoundaries()->right() : position_type{};
+                while (! m_storage.empty() && (empty || less_rolling((id = m_storage.front().id()), stop))) {
+                    auto const& chunk =  m_storage.front();
+                    assert(chunk.range_left() == chunk.range_right());
+                    bool finalized = false;
+                    if (hasFrozenBoundaries) {
+                        if (id == f_left.id()) {                           // partial finalizable
+                            storage.pop_finalize(f_left.left(), f_left.right());
+                            finalized = true;
+                        } else if (id == f_right.id()) {
+                            storage.pop_finalize(f_right.left(), f_right.right());
+                            finalized = true;
+                        }
+                    }
+                    if (! finalized) {         // whole chunk finalizable
+                        storage.pop_finalize(chunk.range_begin(), chunk.range_end());
+                    }
+                }
+                if (! m_storage.empty()) {     // and also the last partially finalizable chunk that happens to be on
+                    id = m_storage.front().id();
+                    vassert(id == beginTxn.iterator()->id());
+                    char const
+                        *const stop = reinterpret_cast<char const*>(beginTxn.iterator()->range_left()),
+                        *cur = stop;
+                    if (id == f_left.id() || id == f_right.id()) {     // the boundary of frozen region;
+                        cur = reinterpret_cast<char const*>((id == f_left.id() ? f_left : f_right).left());
+                    } else if (less_rolling(id, f_right.id())) {       // or the boundary of TXN, short of frozen right boundary
+                        cur = reinterpret_cast<char const*>(beginTxn.iterator()->range_begin());
+                    }
+                    while (cur < stop) {
+                        storage.finalizerAndCopier().finalize(cur);
+                        cur += storage.tupleSize();
+                    }
+                }
+            } else {                       // No finalization needed
+                while (! m_storage.empty() && (empty || less_rolling(m_storage.front().id(), stop))) {
+                    assert(storage.begin()->range_left() == storage.begin()->range_right());
+                    storage.pop_front();
+                }
             }
         }
         m_frozen = false;
@@ -843,8 +877,7 @@ inline void CompactingChunks::clear(Remove_cb const& cb) {
         fold<IterableTableTupleChunks<CompactingChunks, truth>::const_iterator>(
                 static_cast<CompactingChunks const&>(*this),
                 [&cb] (void const* p) noexcept {cb(p);});
-        if (frozen()) {
-            assert(frozenBoundaries());
+        if (frozenBoundaries()) {
             if (m_finalizerAndCopier) {              // finalize the region between frozen right, and txn end
                 auto const& frozenRight = frozenBoundaries()->right();
                 if (less<position_type>()(frozenRight, *last())) {
@@ -2017,21 +2050,34 @@ TxnPreHook<Alloc, Trait, E>::TxnPreHook(size_t tupleSize, FinalizerAndCopier con
             }),
     m_changeStore(tupleSize), m_finalizerAndCopier(cb) {}
 
+/**
+ * Hook memory makes deep copy for original content of updated
+ * address.
+ */
 template<typename Alloc, typename Trait, typename E1>
 template<typename IteratorObserver, typename E2> inline void TxnPreHook<Alloc, Trait, E1>::addForUpdate(
         void const* dst, IteratorObserver& obs) {
     if (m_recording && ! obs(dst)) {
         auto const iter = m_changes.lower_bound(dst);
-        if (iter == m_changes.cend() || iter->first != dst) {   // create a fresh copy
-            void* fresh = m_changeStore.allocate();
-            m_changes.emplace_hint(iter, dst,
-                    m_finalizerAndCopier ?        // deep copy for updates only
-                    m_finalizerAndCopier.copy(fresh, dst) :            // deep copy, or
-                    memcpy(fresh, dst, m_changeStore.tupleSize()));    // shallow copy
+        if (iter == m_changes.cend() || iter->first != dst) {
+            void* fresh = m_changeStore.allocate();   // create a fresh copy
+            if (m_finalizerAndCopier) {
+                vassert(m_updates.find(dst) == m_updates.cend());
+                m_updates.emplace_hint(m_updates.cend(), dst);
+                m_changes.emplace_hint(iter, dst,
+                        m_finalizerAndCopier.copy(fresh, dst));
+            } else {
+                m_changes.emplace_hint(iter, dst,
+                        memcpy(fresh, dst, m_changeStore.tupleSize()));
+            }
         }
     }
 }
 
+/**
+ * Hook memory *never* deep copies the original content of
+ * deleted address.
+ */
 template<typename Alloc, typename Trait, typename E1>
 template<typename IteratorObserver, typename E2> inline void TxnPreHook<Alloc, Trait, E1>::addForDelete(
         void const* dst, IteratorObserver& obs) {
@@ -2055,11 +2101,18 @@ template<typename Alloc, typename Trait, typename E> inline void TxnPreHook<Allo
 
 template<typename Alloc, typename Trait, typename E> inline void TxnPreHook<Alloc, Trait, E>::thaw() {
     if (m_recording) {
+        vassert(m_finalizerAndCopier || m_updates.empty());
         if (m_finalizerAndCopier) {
-            for_each(m_changes.begin(), m_changes.end(),
-                    [this](typename map_type::value_type& p) { m_finalizerAndCopier.finalize(p.second); });
+            // Finalize on hook memory tracking updated addresses
+            for_each(m_updates.begin(), m_updates.end(),
+                    [this](void const* key) {                          // finalize on copied value (m_changes' value)
+                        auto const iter = m_changes.find(key);
+                        assert(iter != m_changes.cend());
+                        m_finalizerAndCopier.finalize(iter->second);
+                    });
         }
         m_changes.clear();
+        m_updates.clear();
         m_changeStore.clear();
         m_recording = false;
     } else {

--- a/src/ee/storage/TableTupleAllocator.hpp
+++ b/src/ee/storage/TableTupleAllocator.hpp
@@ -745,7 +745,7 @@ namespace voltdb {
              * State changes
              */
             void freeze();
-            void thaw();          // when to apply finalizer
+            void thaw();
             /**
              * Auxillary others
              */
@@ -795,9 +795,11 @@ namespace voltdb {
             typename = typename enable_if<is_chunks<Alloc>::value && is_base_of<BaseHistoryRetainTrait, Trait>::value>::type>
         class TxnPreHook : private Trait {
             using map_type = typename Collections<collections_type>::template map<void const*, void const*>;
+            using set_type = typename Collections<collections_type>::template set<void const*>;
             static FinalizerAndCopier const EMPTY_FINALIZER;
             bool m_recording = false;            // in snapshot process?
             map_type m_changes{};                // addr in persistent storage under change => addr storing before-change content
+            set_type m_updates{};                // a subset of keys of m_changes due to updates (whose values in m_changes need to be finalized)
             Alloc m_changeStore;
             FinalizerAndCopier const& m_finalizerAndCopier;
         public:


### PR DESCRIPTION
1. Compaction (i.e. tuple movement in deletion) now deep copies when
   copying src addr to dst addr.
2. Bug fix: since both deleted/updated contents are kept in hook memory,
   but only updated hook memory uses deep copier, the finalization at
   thaw time that release hook memory need to keep track of which is from
   updates, and only finalize the update changes.
3. Due to change #1, at thaw() time, the frozen region need to be finalized
   up to min(frozen right, txn begin).