### PR TITLE
1. log contradictory ssl args, 2. fix restore NPE

### DIFF
--- a/src/frontend/org/voltdb/RealVoltDB.java
+++ b/src/frontend/org/voltdb/RealVoltDB.java
@@ -3394,7 +3394,7 @@ public class RealVoltDB implements VoltDBInterface, RestoreAgent.Callback, HostM
                 result = value;
             }
             else if (value != null && !value.equals(result)) {
-                hostLog.info(String.format("System property '%s' overrides deployment-file value"));
+                hostLog.info(String.format("System property '%s' overrides deployment-file value", sysPropName));
             }
         }
 


### PR DESCRIPTION

SSL key/trust store info comes from the deployment file.  It seems however that Java system properties can override the deployment. This caught my attention while debugging some SSL work and concerned me enough that I wanted to log any conflict. Actual operation unchanged.

Fixes KO-501 NPE as well. Affects unit test only.
