### PR TITLE
ENG-19849 abort catalog update and snapshot if there are no active sites 

### DIFF
--- a/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
+++ b/src/frontend/org/voltdb/sysprocs/SnapshotSave.java
@@ -44,6 +44,8 @@ import org.voltdb.VoltDB;
 import org.voltdb.VoltSystemProcedure;
 import org.voltdb.VoltTable;
 import org.voltdb.VoltTable.ColumnInfo;
+import org.voltdb.client.ClientResponse;
+import org.voltdb.exceptions.SpecifiedException;
 import org.voltdb.VoltType;
 import org.voltdb.VoltZK;
 import org.voltdb.iv2.MpInitiator;
@@ -79,6 +81,11 @@ public class SnapshotSave extends VoltSystemProcedure
         String hostname = CoreUtils.getHostnameOrAddress();
         if (fragmentId == SysProcFragmentId.PF_createSnapshotTargets)
         {
+            final int numLocalSites = context.getLocalActiveSitesCount();
+            if (numLocalSites == 0) {
+                throw new SpecifiedException(ClientResponse.GRACEFUL_FAILURE,
+                        String.format("All sites on host %d have been de-commissioned.", context.getHostId()));
+            }
             // Those plan fragments are created in performSnapshotCreationWork()
             VoltTable result = SnapshotUtil.constructNodeResultsTable();
 

--- a/src/frontend/org/voltdb/sysprocs/UpdateCore.java
+++ b/src/frontend/org/voltdb/sysprocs/UpdateCore.java
@@ -235,6 +235,12 @@ public class UpdateCore extends VoltSystemProcedure {
             column[0] = new ColumnInfo("NEXT_VERSION", VoltType.INTEGER);
             column[1] = new ColumnInfo("MESSAGE", VoltType.STRING);
             VoltTable result = new VoltTable(column);
+            final int numLocalSites = context.getLocalActiveSitesCount();
+            if (numLocalSites == 0) {
+                result.addRow(nextCatalogVersion, String.format("All sites on host %d have been de-commissioned.", context.getHostId()));
+                return new DependencyPair.TableDependencyPair(SysProcFragmentId.PF_updateCatalogPrecheckAndSync, result);
+            }
+
             try {
                 checkForNonEmptyTables(tablesThatMustBeEmpty, reasonsForEmptyTables, context);
             } catch (Exception ex) {


### PR DESCRIPTION
A host may not have any partition leaders, such as a newly rejoined host.  When hash mismatch occurs, a host without partition leader will be shutdown.  Under certain race conditions, the host may still receive transaction processing requests before it is shutdown.  Procedures, such as catalog update or snapshot save, which require synchronization among all sites, may be broken since the host does not have any active sites.  