### PR TITLE
More SSL choices for voltadmin etc.

### DIFF
--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -322,8 +322,10 @@ class FastSerializer:
             with open(os.path.expandvars(os.path.expanduser(self.ssl_config_file)), 'r') as f:
                 lines = f.readlines()
                 for line in lines:
-                    k, v = line.strip().split('=')
-                    jks_config[k.lower()] = v
+                    l = line.strip()
+                    if l:
+                        k, v = l.split('=')
+                        jks_config[k.lower()] = v
 
         def write_pem(der_bytes, type, f):
             f.write("-----BEGIN %s-----\n" % type)

--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -418,7 +418,7 @@ class FastSerializer:
                                ca_certs=self.ssl_config['ca_certs'])
 
     def __wrap_socket_none(self, ss):
-        print "SSL insecure mode specified: identity of remote server cannot be verified"
+        print "SSL insecure mode specified: identity of remote server will not be verified"
         return ssl.wrap_socket(ss, ssl_version=self.__best_tlsv())
 
     def __best_tlsv(self):


### PR DESCRIPTION
voltadmin, and anything else using the voltdb python client, required SSL config to be supplied in jks format. This in turn required the hard-to-set-up and probably-obsolete pyjks package.

It turns out that most of the pyjks gyrations were in order to get a pem format certificate for the ssl code.  It's a lot easier to just give  it a pem certificate; there are tools to generate them (I used the openssl command to post-process jks files made per voltdb documention).

So: the change: if the config file (--ssl=FILE on voltadmin command) has a .pem extenstion, it's a pem file (!).  We feed it to the ssl mode as the ca_certs argument. i.e., it's used to validate the cert we get from the server.  There is no mutual identification of us to the server.

Addiitonally, if the config file is the magic name "insecure" then we connect without cert verification.  This was in fact possible before by supplying an empty file, as long as you had the pyjks module imported so you could not use it. Making it explicit is cleaner and is useful in exactly those circumstances where you'd use '-k' on a curl command.

 I chose to overload the existing --ssl option rather than providing more confusingly-named --ssl-differently options. 
