### PR TITLE
Allow use of PEM-format CA certificate

### DIFF
--- a/lib/python/voltdbclient.py
+++ b/lib/python/voltdbclient.py
@@ -357,8 +357,6 @@ class FastSerializer:
             self.ssl_config['ca_certs'] = parsed_config['cacerts']
             self.ssl_config['cert_reqs'] = ssl.CERT_REQUIRED
 
-        self.__create('test.tmp').close()
-
         #if 'ssl_version' in parsed_config and parsed_config['ssl_version']:
         #   self.ssl_config['ca_certs'] = parsed_config['ssl_version']
 


### PR DESCRIPTION

Allow use of PEM-format CA certificate [chain] without
requiring pyjks module which we do not need anyway.

Prior to this change, voltdbclient had provision for
the following:

keystore - for *client* identification in jks format
truststore - for *server* identification in jks format
cacerts - for *server* identification in pem format

(Of the two server id formats, only one was used)

The trouble was that even if you only wanted the pem
format cacerts, you had to load the pyjks parsing
module, which would then not be used.

This rearranges the code flow slightly so that we
only check for pyjks if we're about to use it.

The jks file parsing is now in a separate method
for clarity.

Also, the ssl_version field was mishandled by
being treated as a certificate path!  I conclude
no-one ever attempted to supply it. I'll think
about version security in a later PR.

This replaces my attempt at this yesterday, it's
much less like an ugly bag on the side of the code.