### PR TITLE
ENG-19814: Add force response node

### DIFF
--- a/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
+++ b/src/frontend/org/voltcore/zk/SynchronizedStatesManager.java
@@ -1344,12 +1344,7 @@ public class SynchronizedStatesManager {
                         m_log.debug(m_stateMachineId + ": Initialized (existing) with State " +
                                 stateToString(m_synchronizedState.asReadOnlyBuffer()));
                     }
-                    ByteBuffer staleTask;
-                    if (existingAndProposedStates.m_requestType != REQUEST_TYPE.INITIALIZING) {
-                        staleTask = existingAndProposedStates.m_proposal.asReadOnlyBuffer();
-                    } else {
-                        staleTask = null;
-                    }
+
                     m_initializationCompleted = true;
                     cancelDistributedLock();
                     // Add an acceptable result so the next initializing member recognizes an immediate quorum.
@@ -1366,17 +1361,6 @@ public class SynchronizedStatesManager {
                                 }
                                 m_initializationCompleted = false;
                                 submitCallable(new CallbackExceptionHandler(StateMachineInstance.this));
-                            }
-                            if (staleTask != null) {
-                                try {
-                                    staleTaskRequestNotification(staleTask);
-                                } catch (Exception e) {
-                                    if (m_log.isDebugEnabled()) {
-                                        m_log.debug("Error in StateMachineInstance callbacks.", e);
-                                    }
-                                    m_initializationCompleted = false;
-                                    submitCallable(new CallbackExceptionHandler(StateMachineInstance.this));
-                                }
                             }
                         }
                     };
@@ -1912,12 +1896,6 @@ public class SynchronizedStatesManager {
          * warning: The ByteBuffer is not guaranteed to start at position 0 (avoid rewind, flip, ...)
          */
         protected void taskRequested(ByteBuffer proposedTask) {}
-
-        /*
-         * Notification of a task request for newly joined members.
-         * warning: The ByteBuffer is not guaranteed to start at position 0 (avoid rewind, flip, ...)
-         */
-        protected void staleTaskRequestNotification(ByteBuffer proposedTask) {}
 
         /*
          * Called to accept or reject a new proposed state change by another member.


### PR DESCRIPTION
Add version specific responses so that responses to two different proposals use different nodes and do not collide

Add a new node which is used by an initializing node when it is unable to determine the current state of the system because not all hosts have posted results. When the force result node is created all hosts create a result for the requested proposal version and the initializing host can then determine the next initialization step.