### PR TITLE
Remove unnecessary regex during bulkloading

### DIFF
--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -140,7 +140,7 @@ public class ParameterConverter {
         // Remove commas.  Doing this seems kind of dubious since it lets strings like
         //    ,,,3.1,4,,e,+,,16
         // be parsed as a valid double value (for example).
-        String commaFreeValue = value.contains(",") ? value.replaceAll(",", "") : value;
+        String commaFreeValue = value.contains(",") ? value.replace(",", "") : value;
 
         try {
             // autoboxing converts to boxed types since this method returns a java Object

--- a/src/frontend/org/voltdb/ParameterConverter.java
+++ b/src/frontend/org/voltdb/ParameterConverter.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.util.Date;
-import java.util.regex.Pattern;
 import java.nio.ByteBuffer;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -121,8 +120,6 @@ public class ParameterConverter {
         return true;
     }
 
-    private static final Pattern thousandSeparator = Pattern.compile("\\,");
-
     /**
      * Given a string, covert it to a primitive type or boxed type of the primitive type or return null.
      *
@@ -143,7 +140,7 @@ public class ParameterConverter {
         // Remove commas.  Doing this seems kind of dubious since it lets strings like
         //    ,,,3.1,4,,e,+,,16
         // be parsed as a valid double value (for example).
-        String commaFreeValue = thousandSeparator.matcher(value).replaceAll("");
+        String commaFreeValue = value.contains(",") ? value.replaceAll(",", "") : value;
 
         try {
             // autoboxing converts to boxed types since this method returns a java Object

--- a/src/frontend/org/voltdb/parser/SQLParser.java
+++ b/src/frontend/org/voltdb/parser/SQLParser.java
@@ -1974,7 +1974,8 @@ public class SQLParser extends SQLPatternFactory
     public static TimestampType parseDate(String dateIn)
     {
         // Remove any quotes around the timestamp value.  ENG-2623
-        String dateRepled = dateIn.replaceAll("^\"|\"$", "").replaceAll("^'|'$", "");
+        boolean shouldTrim = (dateIn.startsWith("\"") && dateIn.endsWith("\"")) || (dateIn.startsWith("'") && dateIn.endsWith("'"));
+        String dateRepled = shouldTrim ? dateIn.substring(1, dateIn.length() - 1) : dateIn;
         return new TimestampType(dateRepled);
     }
 


### PR DESCRIPTION
During bulk loading, VoltDB translates any string values provided to the types of the underlying columns. This coercion sometimes utilizes regular expressions, which can be more costly than necessary.

These changes avoid regular expressions in those situations to make the bulk loading more efficient. When importing 28M row, 38 column, 5GB CSV file this overhead is quite noticeable for our application and these changes make a material difference.

I've built and packaged VoltDB and run TestParameterConverter and TestSQLParser locally to look for any breakages and don't see anything.

We'd appreciate if this can be backported to 8.x.