### PR TITLE
Fix 8 typos in ee/common

### DIFF
--- a/src/ee/common/NValue.hpp
+++ b/src/ee/common/NValue.hpp
@@ -298,7 +298,7 @@ class NValue {
        provided. This function will perform memory allocations for
        Object types as necessary using the provided data pool or the
        heap. This is used to deserialize tables. */
-    template <TupleSerializationFormat F, Endianess E>
+    template <TupleSerializationFormat F, Endianness E>
     static void deserializeFrom(SerializeInput<E>& input, Pool* tempPool, char* storage,
         const ValueType type, bool isInlined, int32_t maxLength, bool isInBytes);
     static void deserializeFrom(SerializeInputBE& input, Pool* tempPool, char* storage,
@@ -2918,7 +2918,7 @@ inline void NValue::deserializeFrom(SerializeInputBE& input, Pool* tempPool, cha
             type, isInlined, maxLength, isInBytes);
 }
 
-template <TupleSerializationFormat F, Endianess E> inline void NValue::deserializeFrom(
+template <TupleSerializationFormat F, Endianness E> inline void NValue::deserializeFrom(
         SerializeInput<E>& input, Pool* tempPool, char *storage,
         ValueType type, bool isInlined, int32_t maxLength, bool isInBytes) {
     switch (type) {

--- a/src/ee/common/serializeio.cpp
+++ b/src/ee/common/serializeio.cpp
@@ -41,7 +41,7 @@ void FallbackSerializeOutput::expand(size_t minimum_desired) {
     ExecutorContext::getPhysicalTopend()->fallbackToEEAllocatedBuffer(m_fallbackBuffer, maxAllocationSize);
 }
 
-template<voltdb::Endianess E>
+template<voltdb::Endianness E>
 std::string SerializeInput<E>::fullBufferStringRep() {
     std::stringstream message(std::stringstream::in | std::stringstream::out);
 

--- a/src/ee/common/serializeio.h
+++ b/src/ee/common/serializeio.h
@@ -100,7 +100,7 @@ namespace voltdb {
 
 
 /** Abstract class for reading from memory buffers. */
-template <Endianess E> class SerializeInput {
+template <Endianness E> class SerializeInput {
 protected:
     /** Does no initialization. Subclasses must call initialize. */
     SerializeInput() = default;
@@ -558,7 +558,7 @@ public:
 };
 
 /** Implementation of SerializeInput that references an existing buffer. */
-template <Endianess E>
+template <Endianness E>
 class ReferenceSerializeInput : public SerializeInput<E> {
 public:
     ReferenceSerializeInput(const void* data, size_t length) {
@@ -570,7 +570,7 @@ public:
 };
 
 /** Implementation of SerializeInput that makes a copy of the buffer. */
-template <Endianess E>
+template <Endianness E>
 class CopySerializeInput : public SerializeInput<E> {
 public:
     CopySerializeInput(const void* data, size_t length) :

--- a/src/ee/common/types.h
+++ b/src/ee/common/types.h
@@ -536,9 +536,9 @@ inline size_t rowCostForDRRecord(DRRecordType type) {
 enum TupleSerializationFormat { TUPLE_SERIALIZATION_NATIVE = 0, TUPLE_SERIALIZATION_DR = 1 };
 
 // ------------------------------------------------------------------
-// Endianess
+// Endianness
 // ------------------------------------------------------------------
-enum Endianess { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
+enum Endianness { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
 
 // ------------------------------------------------------------------
 // Types of DR conflict (keep sync with DRConflictType at PartitionDRGateway.java)


### PR DESCRIPTION
Fix same typo 8 times in all files but not `third_party` directory.